### PR TITLE
Improve historical item seeding and performance

### DIFF
--- a/DatabaseSeeder Unit Tests/CombatSeederSourceTests.cs
+++ b/DatabaseSeeder Unit Tests/CombatSeederSourceTests.cs
@@ -610,6 +610,20 @@ public class CombatSeederSourceTests
 	}
 
 	[TestMethod]
+	public void CombatSeederSource_EarlyFirearmRerunsUseTheCanonicalMusketCartridgeComponent()
+	{
+		string source = SeederSourceTestHelper.ReadPartialFamily("CombatSeeder");
+
+		StringAssert.Contains(source, "context.RangedWeaponTypes.Any(x => x.Name == \"Flintlock Musket\")");
+		StringAssert.Contains(source, "\"Musket\", \"Flintlock Musket\"");
+		StringAssert.Contains(source, "\"ArtilleryPiece\", \"Flintlock Musket\"");
+		StringAssert.Contains(source, "OrderByDescending(x => x.Id)");
+		Assert.IsFalse(source.Contains(
+			".Single(x => x.Name == $\"MusketCartridge_{boreName}\" && x.EditableItem.RevisionStatus == 4)",
+			StringComparison.Ordinal));
+	}
+
+	[TestMethod]
 	public void CombatSeederSource_SpearSuites_HaveShieldRequiredSwordAndBoardAttacks()
 	{
 		string source = GetCombatSeederSource();

--- a/DatabaseSeeder Unit Tests/ItemSeederAddCraftTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederAddCraftTests.cs
@@ -493,6 +493,48 @@ public class ItemSeederAddCraftTests
 	}
 
 	[TestMethod]
+	public void ItemSeeder_AddCraft_DeferredPersistenceRetainsInputReferences()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedPrerequisites(context);
+
+		var craft = new ItemSeeder().AddCraftWithDeferredPersistenceForTesting(context,
+			new ItemSeeder.CraftDefinitionSpec
+			{
+				Name = "test deferred craft",
+				Category = "Testing",
+				Blurb = "deferred test",
+				Action = "testing deferred persistence",
+				ActiveCraftItemSdesc = "a deferred craft event",
+				AppearProg = context.FutureProgs.Single(x => x.FunctionName == "AlwaysTrue"),
+				Trait = context.TraitDefinitions.Single(x => x.Name == "Crafting"),
+				FailPhase = 1,
+				Phases = [new ItemSeeder.CraftPhaseSpec { Seconds = 12, Echo = "$0 work|works." }],
+				Inputs =
+				[
+					new ItemSeeder.CraftInputSpec("Tag - 1x an item with the Ingredient tag", "Tag",
+						"1x an item with the Ingredient tag", [], 1.0)
+				],
+				Products =
+				[
+					new ItemSeeder.CraftProductSpec(
+						"UnusedInput - 25% of 1x an item with the Ingredient tag ($i1)",
+						"UnusedInput",
+						"25% of 1x an item with the Ingredient tag ($i1)",
+						[],
+						false,
+						null)
+				]
+			});
+
+		var input = craft.CraftInputs.Single();
+		var product = craft.CraftProducts.Single();
+		Assert.IsTrue(input.Id > 0);
+		Assert.AreEqual(input.Id,
+			long.Parse(XElement.Parse(product.Definition).Element("WhichInputId")!.Value));
+	}
+
+	[TestMethod]
 	public void ItemSeeder_AddCraft_NormalisesActiveSdescAndPhaseToolAndFailureEchoes()
 	{
 		using FuturemudDatabaseContext context = BuildContext();
@@ -585,6 +627,54 @@ public class ItemSeederAddCraftTests
 		var appear = context.FutureProgs.Single(x => x.FunctionName == "CrApTWoo940");
 		Assert.IsTrue(appear.FunctionText.Contains(@"ToTrait(""9"")"));
 		Assert.IsTrue(appear.FunctionText.StartsWith("// Trait 9 = \"Woodcraft\"", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	public void ItemSeeder_AddCraft_TraitGateResolvesNoGerundParchmentmakingSkillPackageName()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedPrerequisites(context);
+		AddSkillTrait(context, 9, "Parchmenter");
+
+		var craft = new ItemSeeder().AddTraitGatedCraftFromImportsForTesting(
+			context,
+			"test parchmentmaking alias craft",
+			"Testing",
+			"Parchmentmaking",
+			40,
+			BasicPhases(),
+			BasicInputs(),
+			BasicTools(),
+			BasicProducts(),
+			[]
+		);
+
+		Assert.AreEqual(9, craft.CheckTraitId);
+		Assert.AreEqual("Parchmenter", craft.CheckTrait.Name);
+	}
+
+	[TestMethod]
+	public void ItemSeeder_AddCraft_TraitGateResolvesApothecaryToComplexSkillPackagePharmacology()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedPrerequisites(context);
+		AddSkillTrait(context, 9, "Pharmacology");
+
+		var craft = new ItemSeeder().AddTraitGatedCraftFromImportsForTesting(
+			context,
+			"test apothecary alias craft",
+			"Testing",
+			"Apothecary",
+			40,
+			BasicPhases(),
+			BasicInputs(),
+			BasicTools(),
+			BasicProducts(),
+			[]
+		);
+
+		Assert.AreEqual(9, craft.CheckTraitId);
+		Assert.AreEqual("Pharmacology", craft.CheckTrait.Name);
 	}
 
 	[TestMethod]

--- a/DatabaseSeeder Unit Tests/ItemSeederRenaissanceCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederRenaissanceCraftingTests.cs
@@ -25,6 +25,9 @@ public class ItemSeederRenaissanceCraftingTests
 		StringAssert.Contains(source, "an in-progress {StripLeadingArticle(displayName)} craft");
 		StringAssert.Contains(source, "Commodity - {materialAmount} grams of {material}");
 		StringAssert.Contains(source, "SimpleProduct - 1x {displayName} (#{item.Value.Id})");
+		StringAssert.Contains(source, "\"Labouring\", 15");
+		Assert.IsFalse(source.Contains("\"Crafting\", 15", StringComparison.Ordinal),
+			"The generic Renaissance craft path must use a concrete stock skill, not the Crafting category.");
 		Assert.IsTrue(ItemSeeder.ShouldSeedRenaissanceFinishedItemCraftsForTesting("renaissance"));
 		Assert.IsFalse(ItemSeeder.ShouldSeedRenaissanceFinishedItemCraftsForTesting("medieval"));
 	}

--- a/DatabaseSeeder Unit Tests/PreIndustrialFoodCatalogueTests.cs
+++ b/DatabaseSeeder Unit Tests/PreIndustrialFoodCatalogueTests.cs
@@ -210,6 +210,17 @@ public class PreIndustrialFoodCatalogueTests
 	}
 
 	[TestMethod]
+	public void ExistingStockFoodLiquids_AreReusedWithoutTakingOwnership()
+	{
+		var source = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.PreIndustrialFoodCatalogue.cs");
+		StringAssert.Contains(source, "var hasExistingLiquid = _liquids.TryGetValue(entry.Name, out var existingLiquid);");
+		StringAssert.Contains(source, "if (hasExistingLiquid)");
+		StringAssert.Contains(source,
+			"FindManagedRecord(manifestEntry.EntityType, manifestEntry.StableKey) is null");
+		StringAssert.Contains(source, "Core and Kickstart seeders own their stock liquids.");
+	}
+
+	[TestMethod]
 	public void MaintainedExports_CoverPreparedComponentsLiquidsAndTags()
 	{
 		var items = ItemSeeder.PreIndustrialFoodItemsForTesting;

--- a/DatabaseSeeder Unit Tests/RenaissanceEarlyModernMedicalFoundationTests.cs
+++ b/DatabaseSeeder Unit Tests/RenaissanceEarlyModernMedicalFoundationTests.cs
@@ -25,6 +25,16 @@ public class RenaissanceEarlyModernMedicalFoundationTests
 	}
 
 	[TestMethod]
+	public void ItemSeeder_PreflightsHistoricalMedicalHealthComponents()
+	{
+		var dispatcher = Read("DatabaseSeeder", "Seeders", "ItemSeeder.cs");
+		var support = Read("DatabaseSeeder", "Seeders", "ItemSeeder.EraCatalogueSupport.cs");
+		StringAssert.Contains(dispatcher, "Validating historical medical prerequisites");
+		StringAssert.Contains(support, "ValidateHistoricalMedicalPrerequisites");
+		StringAssert.Contains(support, "Run the Health Seeder with the {requiredHealthTier} option before Items.");
+	}
+
+	[TestMethod]
 	public void MaintainedExports_ContainMedicalFoundationsWithoutDuplicates()
 	{
 		AssertJsonNames("Seeded_Materials.json", "Material Name", "benzoin resin", "camphor", "cinchona bark", "myrrh resin", "opium gum", "Peruvian balsam", "Epsom salts", "calomel", "tartar emetic", "bezoar", "ergot", "green vitriol");

--- a/DatabaseSeeder Unit Tests/RenaissanceMilitarySeederTests.cs
+++ b/DatabaseSeeder Unit Tests/RenaissanceMilitarySeederTests.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using DatabaseSeeder;
 using DatabaseSeeder.Seeders;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -242,6 +243,17 @@ public class RenaissanceMilitarySeederTests
 		Assert.IsTrue(gate >= 0, "Renaissance prerequisite gate was not registered in SeedData.");
 		Assert.IsTrue(rework >= 0 && gate < rework,
 			"Renaissance prerequisite gate must run before any rework item stage can write.");
+	}
+
+	[TestMethod]
+	public void ItemSeederMetadata_RequiresAnimalMountedWearComponents()
+	{
+		var metadata = SeederMetadataRegistry.GetMetadata(new ItemSeeder());
+		var dependencyTypes = (metadata.DependencySeederTypes ?? []).ToArray();
+
+		CollectionAssert.Contains(dependencyTypes, typeof(AnimalSeeder));
+		Assert.IsTrue(metadata.Prerequisites.Any(x =>
+			x.Description == "Animal-mounted gear wear-profile components must already exist."));
 	}
 
 	private static FuturemudDatabaseContext BuildContext()

--- a/DatabaseSeeder Unit Tests/SeederRepeatabilityMetadataTests.cs
+++ b/DatabaseSeeder Unit Tests/SeederRepeatabilityMetadataTests.cs
@@ -79,4 +79,42 @@ public class SeederRepeatabilityMetadataTests
 		Assert.AreEqual("simple", SeederAnswerMemory.GetLatestSeederAnswer(context, "Attributes", "choice"));
 		Assert.AreEqual("simple", SeederAnswerMemory.GetLatestSeederAnswers(context, "Attributes")["choice"]);
 	}
+
+	[TestMethod]
+	public void CoreSeeder_PasswordAnswerIsNotPersistedAndRemovesLegacyPlaintextAnswer()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		context.SeederChoices.Add(new SeederChoice
+		{
+			Id = 1,
+			Seeder = "Core",
+			Choice = "password",
+			Answer = "legacy plaintext password",
+			Version = "test",
+			DateTime = DateTime.UtcNow
+		});
+		context.SaveChanges();
+
+		IDatabaseSeeder seeder = new CoreDataSeeder();
+		SeederAnswerMemory.PersistAnswers(
+			context,
+			seeder,
+			seeder.Questions,
+			new Dictionary<string, string>
+			{
+				["gamename"] = "DemoMUD",
+				["password"] = "new plaintext password"
+			},
+			"test",
+			DateTime.UtcNow);
+		context.SaveChanges();
+
+		SeederQuestion passwordQuestion = seeder.Questions.Single(x => x.Id == "password");
+		Assert.IsFalse(passwordQuestion.PersistAnswer);
+		Assert.IsNull(SeederAnswerMemory.GetRememberedAnswer(context, seeder, passwordQuestion,
+			new Dictionary<string, string>()));
+
+		Assert.IsFalse(context.SeederChoices.Any(x => x.Seeder == "Core" && x.Choice == "password"));
+		Assert.IsTrue(context.SeederChoices.Any(x => x.Seeder == "Core" && x.Choice == "gamename"));
+	}
 }

--- a/DatabaseSeeder Unit Tests/TimeSeederTests.cs
+++ b/DatabaseSeeder Unit Tests/TimeSeederTests.cs
@@ -184,6 +184,24 @@ public class TimeSeederTests
     }
 
     [DataTestMethod]
+    [DataRow("gregorian-us", "Gregorian Calendar (EN-US)", "American", "january/01/1200")]
+    [DataRow("gregorian-uk", "Gregorian Calendar (EN-UK)", "British", "01/january/1200")]
+    public void SeedData_GregorianModes_DescribeTheirSelectedDateConvention(string mode, string shortName,
+        string convention, string date)
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+        TimeSeeder seeder = new();
+
+        seeder.SeedData(context, Answers(mode));
+
+        Calendar calendar = context.Calendars.Single();
+        XElement definition = XElement.Parse(calendar.Definition);
+        Assert.AreEqual(shortName, definition.Element("shortname")?.Value);
+        StringAssert.Contains(definition.Element("fullname")?.Value ?? string.Empty, convention);
+        Assert.AreEqual(date, calendar.Date);
+    }
+
+    [DataTestMethod]
     [DataRow("islamic-hijri")]
     [DataRow("hebrew")]
     [DataRow("old-persian")]

--- a/DatabaseSeeder Unit Tests/UsefulSeederItemPackageTests.cs
+++ b/DatabaseSeeder Unit Tests/UsefulSeederItemPackageTests.cs
@@ -1307,6 +1307,24 @@ public class UsefulSeederItemPackageTests
 		usefulSeeder.SeedAntiquityComponentGapCoverageForTesting(context);
 		usefulSeeder.SeedEraDependencyComponentsForTesting(context);
 		usefulSeeder.SeedGeneralCoverageForTesting(context);
+		var earthenware = context.Materials.SingleOrDefault(x => x.Name == "earthenware");
+		if (earthenware is null)
+		{
+			earthenware = new Material
+			{
+				Id = context.Materials.Any() ? context.Materials.Max(x => x.Id) + 1 : 1,
+				Name = "earthenware",
+				MaterialDescription = "earthenware",
+				BehaviourType = (int)MaterialBehaviourType.Ceramic,
+				ResidueColour = "white"
+			};
+			context.Materials.Add(earthenware);
+		}
+		else
+		{
+			earthenware.ResidueColour = "white";
+		}
+		context.SaveChanges();
 		EnsureComponentMarkers(context,
 			"Destroyable_Misc",
 			"Destroyable_Furniture",

--- a/DatabaseSeeder/ItemSeederManifest.cs
+++ b/DatabaseSeeder/ItemSeederManifest.cs
@@ -266,7 +266,19 @@ internal static class ItemSeederManifestCatalogue
 			var relativePath = Path.GetRelativePath(repositoryRoot, path).Replace('\\', '/');
 			hash.AppendData(Encoding.UTF8.GetBytes(relativePath));
 			hash.AppendData([0]);
-			hash.AppendData(File.ReadAllBytes(path));
+			var bytes = File.ReadAllBytes(path);
+			var hasUtf8Bom = bytes.Length >= 3 &&
+			                 bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF;
+			// Hash a platform-independent text representation while retaining an intentional UTF-8 BOM.
+			var source = File.ReadAllText(path)
+				.Replace("\r\n", "\n", StringComparison.Ordinal)
+				.Replace("\r", "\n", StringComparison.Ordinal);
+			if (hasUtf8Bom)
+			{
+				hash.AppendData(Encoding.UTF8.GetPreamble());
+			}
+
+			hash.AppendData(Encoding.UTF8.GetBytes(source));
 			hash.AppendData([0]);
 		}
 

--- a/DatabaseSeeder/Program.cs
+++ b/DatabaseSeeder/Program.cs
@@ -67,7 +67,7 @@ internal class Program
 			return;
 		}
 
-        string password = "", user = "", database = "";
+        string user = "", database = "";
 
         Console.ForegroundColor = ConsoleColor.Magenta;
 
@@ -150,13 +150,10 @@ Please press enter to begin.".WriteLineConsole();
                         case "uid":
                             user = match.Groups["value"].Value;
                             break;
-                        case "password":
-                            password = match.Groups["value"].Value;
-                            break;
                     }
                 }
 
-                if (!string.IsNullOrEmpty(password) && !string.IsNullOrEmpty(user) && !string.IsNullOrEmpty(database))
+                if (!string.IsNullOrEmpty(user) && !string.IsNullOrEmpty(database))
                 {
                     FileStream bfs = new(Path.Combine(installationDirectory, "Backup-MUD.bat"), FileMode.OpenOrCreate, FileAccess.ReadWrite);
                     using StreamReader breader = new(bfs);
@@ -177,10 +174,9 @@ set CUR_MS=%time:~9,2%
 
 SET backupdir={Path.Combine(installationDirectory, "Backups")}
 SET mysqluername={user}
-SET mysqlpassword={password}
 SET database={database}
 
-""C:\Program Files\MySQL\MySQL Workbench 8.0\mysqldump.exe"" -u%mysqluername% -p%mysqlpassword% %database% > %backupdir%\%database%_%CUR_YYYY%%CUR_MM%%CUR_DD%-%CUR_HH%%CUR_NN%%CUR_SS%.sql");
+""C:\Program Files\MySQL\MySQL Workbench 8.0\mysqldump.exe"" -u%mysqluername% -p %database% > %backupdir%\%database%_%CUR_YYYY%%CUR_MM%%CUR_DD%-%CUR_HH%%CUR_NN%%CUR_SS%.sql");
                     }
                 #endregion
                 }
@@ -574,7 +570,12 @@ The exception details were as follows:
 
             Console.WriteLine();
             Console.Write("Your choice: ");
-            string choice = Console.ReadLine() ?? string.Empty;
+            string? choice = Console.ReadLine();
+            if (choice is null)
+            {
+                return;
+            }
+
             if (choice.EqualToAny("quit", "q", "exit", "stop"))
             {
                 return;
@@ -695,6 +696,11 @@ The exception details were as follows:
             "Please type #3yes#F or #3no#F: ".WriteLineConsole();
             Console.WriteLine();
             string? answer = Console.ReadLine();
+            if (answer is null)
+            {
+                return;
+            }
+
             if (answer.EqualToAny("yes", "y"))
             {
                 DoSeederQuestions(context, seeder);
@@ -798,7 +804,12 @@ The exception details were as follows:
 
                 Console.WriteLine();
                 Console.Write("> ");
-                string answer = Console.ReadLine() ?? string.Empty;
+                string? answer = Console.ReadLine();
+                if (answer is null)
+                {
+                    return;
+                }
+
                 if (answer.EqualToAny("quit", "back", "exit"))
                 {
                     return;
@@ -820,12 +831,23 @@ The exception details were as follows:
 
         SafeClear();
         $"Applying the data from the #2{seeder.Name}#F seeder...".WriteLineConsole();
-        string result = seeder.SeedData(context, answers);
-        Console.WriteLine(result);
-        string version = (Assembly.GetCallingAssembly().GetName().Version ?? new Version(1, 0, 0)).ToString();
-        DateTime now = DateTime.UtcNow;
-        SeederAnswerMemory.PersistAnswers(context, seeder, questions, answers, version, now);
-        context.SaveChanges();
+        try
+        {
+            string result = seeder.SeedData(context, answers);
+            Console.WriteLine(result);
+            string version = (Assembly.GetCallingAssembly().GetName().Version ?? new Version(1, 0, 0)).ToString();
+            DateTime now = DateTime.UtcNow;
+            SeederAnswerMemory.PersistAnswers(context, seeder, questions, answers, version, now);
+            context.SaveChanges();
+        }
+        catch (Exception exception)
+        {
+            context.Database.CurrentTransaction?.Rollback();
+            context.ChangeTracker.Clear();
+            Console.ForegroundColor = ConsoleColor.Red;
+            ConsoleLayoutHelper.WriteWrapped($"The {seeder.Name} seeder failed: {exception.Message}");
+            Console.ForegroundColor = ConsoleColor.White;
+        }
     }
 
     internal static string ResolveQuestionAnswer(string answer, string? defaultAnswer)

--- a/DatabaseSeeder/SeederAnswerMemory.cs
+++ b/DatabaseSeeder/SeederAnswerMemory.cs
@@ -18,6 +18,11 @@ public static class SeederAnswerMemory
         SeederQuestion question,
         IReadOnlyDictionary<string, string> currentAnswers)
     {
+        if (!question.PersistAnswer)
+        {
+            return question.DefaultAnswerResolver?.Invoke(context, currentAnswers);
+        }
+
         if (!string.IsNullOrWhiteSpace(question.SharedAnswerKey))
         {
             string? sharedAnswer = GetLatestSharedAnswer(context, question.SharedAnswerKey);
@@ -47,8 +52,20 @@ public static class SeederAnswerMemory
         Dictionary<string, SeederQuestion> questionLookup = questions.ToDictionary(x => x.Id, StringComparer.OrdinalIgnoreCase);
         HashSet<string> persistedSharedKeys = new(StringComparer.OrdinalIgnoreCase);
 
+        foreach (SeederQuestion question in questionLookup.Values.Where(x => !x.PersistAnswer))
+        {
+            context.SeederChoices.RemoveRange(context.SeederChoices.Where(x =>
+                x.Seeder == seeder.Name &&
+                x.Choice == question.Id));
+        }
+
         foreach (KeyValuePair<string, string> answer in answers)
         {
+            if (questionLookup.TryGetValue(answer.Key, out SeederQuestion? question) && !question.PersistAnswer)
+            {
+                continue;
+            }
+
             context.SeederChoices.Add(new SeederChoice
             {
                 Version = version,
@@ -58,7 +75,7 @@ public static class SeederAnswerMemory
                 DateTime = timestamp
             });
 
-            if (!questionLookup.TryGetValue(answer.Key, out SeederQuestion? question) ||
+            if (!questionLookup.TryGetValue(answer.Key, out question) ||
                 string.IsNullOrWhiteSpace(question.SharedAnswerKey) ||
                 !persistedSharedKeys.Add(question.SharedAnswerKey))
             {

--- a/DatabaseSeeder/SeederMetadataRegistry.cs
+++ b/DatabaseSeeder/SeederMetadataRegistry.cs
@@ -406,12 +406,18 @@ public static class SeederMetadataRegistry
                         context.GameItemComponentProtos.Any(x => x.Name == "Insulation_Minor") &&
                         context.GameItemComponentProtos.Any(x => x.Name == "Destroyable_Misc") &&
                         context.GameItemComponentProtos.Any(x => x.Name == "Torch_Infinite") &&
-                        context.Tags.Any(x => x.Name == "Functions"))
+						context.Tags.Any(x => x.Name == "Functions")),
+					Requirement("Animal-mounted gear wear-profile components must already exist.", context =>
+						new[]
+						{
+							"Wear_Saddle", "Wear_Bridle", "Wear_Chanfron", "Wear_Criniere", "Wear_Croupiere",
+							"Wear_Flanchards", "Wear_Peytral", "Wear_Caparison"
+						}.All(name => context.GameItemComponentProtos.Any(x => x.Name == name)))
 				],
 				RerunSummary: "Reruns reconcile the installed ItemSeeder eras and can add newly selected implemented eras without removing prior content.",
 				UpdateSummary: "Manifest-owned stock aggregates are repaired when untouched; builder-customized aggregates are preserved and reported.",
 				OwnershipSummary: "Durable SeederManagedRecords provenance owns stock aggregate definitions and required stock links. Builder additions and customized aggregate graphs are retained; ambiguous untracked identities block before mutation.",
-                DependencySeederTypes: [typeof(UsefulSeeder)]
+                DependencySeederTypes: [typeof(UsefulSeeder), typeof(AnimalSeeder)]
             ),
             nameof(AnimalButcherySeeder) => new SeederMetadata(
                 SeederRepeatabilityMode.Idempotent,

--- a/DatabaseSeeder/SeederQuestion.cs
+++ b/DatabaseSeeder/SeederQuestion.cs
@@ -14,7 +14,8 @@ public sealed record SeederQuestion(
     string? SharedAnswerKey = null,
     Func<FuturemudDatabaseContext, IReadOnlyDictionary<string, string>, string?>? DefaultAnswerResolver = null,
     Func<FuturemudDatabaseContext, IReadOnlyDictionary<string, string>, ConsoleQuestionDisplay>? DisplayResolver = null,
-    bool AutoReuseLastAnswer = false)
+    bool AutoReuseLastAnswer = false,
+    bool PersistAnswer = true)
 {
     public ConsoleQuestionDisplay ResolveDisplay(FuturemudDatabaseContext context,
         IReadOnlyDictionary<string, string> currentAnswers)

--- a/DatabaseSeeder/SeederQuestionRegistry.cs
+++ b/DatabaseSeeder/SeederQuestionRegistry.cs
@@ -12,7 +12,8 @@ internal sealed record SeederQuestionEnhancement(
     string? SharedAnswerKey = null,
     Func<FuturemudDatabaseContext, IReadOnlyDictionary<string, string>, string?>? DefaultAnswerResolver = null,
     Func<FuturemudDatabaseContext, IReadOnlyDictionary<string, string>, ConsoleQuestionDisplay>? DisplayResolver = null,
-    bool AutoReuseLastAnswer = false);
+    bool AutoReuseLastAnswer = false,
+    bool? PersistAnswer = null);
 
 public static class SeederQuestionRegistry
 {
@@ -75,6 +76,9 @@ public static class SeederQuestionRegistry
             [BuildKey(nameof(HumanSeeder), "model")] = new(
                 SharedAnswerKey: "human-health-model",
                 AutoReuseLastAnswer: true
+            ),
+            [BuildKey(nameof(CoreDataSeeder), "password")] = new(
+                PersistAnswer: false
             ),
             [BuildKey(nameof(EconomySeeder), "era")] = new(
                 SharedAnswerKey: "economy-era",
@@ -157,7 +161,8 @@ public static class SeederQuestionRegistry
             SharedAnswerKey = enhancement.SharedAnswerKey,
             DefaultAnswerResolver = enhancement.DefaultAnswerResolver,
             DisplayResolver = enhancement.DisplayResolver,
-            AutoReuseLastAnswer = enhancement.AutoReuseLastAnswer
+            AutoReuseLastAnswer = enhancement.AutoReuseLastAnswer,
+            PersistAnswer = enhancement.PersistAnswer ?? question.PersistAnswer
         };
     }
 

--- a/DatabaseSeeder/Seeders/CombatSeeder.EraDependencies.cs
+++ b/DatabaseSeeder/Seeders/CombatSeeder.EraDependencies.cs
@@ -569,7 +569,12 @@ public partial class CombatSeeder
 			foreach (var boreName in new[] { "0.45 Bore", "0.55 Bore", "0.6 Bore", "0.65 Bore", "0.7 Bore", "0.75 Bore", "0.8 Bore" })
 			{
 				var baseComponent = context.GameItemComponentProtos
-					.Single(x => x.Name == $"MusketCartridge_{boreName}" && x.EditableItem.RevisionStatus == 4);
+					.Where(x => x.Name == $"MusketCartridge_{boreName}" && x.EditableItem.RevisionStatus == 4)
+					.OrderByDescending(x => x.Id)
+					.FirstOrDefault() ??
+					throw new InvalidOperationException(
+						$"Cannot seed MusketPaperCartridge_{boreName}: the base musket cartridge component is missing. " +
+						"Run Combat with installmuskets enabled first.");
 				var baseDefinition = XElement.Parse(baseComponent.Definition);
 				var bore = double.Parse(
 					baseDefinition.Element("BulletBore")?.Value ??
@@ -623,7 +628,7 @@ public partial class CombatSeeder
 		// on brittle database IDs from a development database.
 		if (context.GameItemComponentProtos.Any(x => x.Type == "Ammunition" && x.EditableItem.RevisionStatus == 4) &&
 			context.GameItemComponentProtos.Any(x => x.Type == "Musket" && x.EditableItem.RevisionStatus == 4) &&
-			context.RangedWeaponTypes.Any(x => x.Name == "Musket"))
+			context.RangedWeaponTypes.Any(x => x.Name == "Flintlock Musket"))
 		{
 		XElement CloneDefinition(GameItemComponentProto component) => XElement.Parse(component.Definition);
 		void SetElement(XElement definition, string name, object value) => definition.SetElementValue(name, value);
@@ -723,7 +728,7 @@ public partial class CombatSeeder
 		};
 		foreach (var profile in musketProfiles)
 		{
-			var ranged = EnsureRanged(profile.Name.Replace('_', ' '), profile.Name, "Musket", "Musket", x =>
+			var ranged = EnsureRanged(profile.Name.Replace('_', ' '), profile.Name, "Musket", "Flintlock Musket", x =>
 			{
 				if (profile.Rifled)
 				{
@@ -772,7 +777,7 @@ public partial class CombatSeeder
 		{
 			var gunnery = context.TraitDefinitions.FirstOrDefault(x => x.Name == "Gunnery") ??
 				throw new InvalidOperationException("Cannot seed artillery profiles because the Gunnery trait is missing.");
-			var ranged = EnsureRanged(name.Replace('_', ' '), name, "ArtilleryPiece", "Musket", x =>
+			var ranged = EnsureRanged(name.Replace('_', ' '), name, "ArtilleryPiece", "Flintlock Musket", x =>
 			{
 				x.RangedWeaponType = (int)RangedWeaponType.Artillery;
 				x.FireTraitId = gunnery.Id;

--- a/DatabaseSeeder/Seeders/CombatSeeder.cs
+++ b/DatabaseSeeder/Seeders/CombatSeeder.cs
@@ -317,7 +317,7 @@ You can choose #3Compact#f, #3Sentences#f or #3Sparse#f",
 	private static bool HasCombatFoundation(FuturemudDatabaseContext context) => context.WeaponAttacks.Any();
 
 	private static bool HasEarlyFirearms(FuturemudDatabaseContext context) =>
-		context.WeaponTypes.Any(x => x.Name.Contains("Flintlock"));
+		context.RangedWeaponTypes.Any(x => x.Name == "Flintlock Musket");
 
 	private static bool HasModernFirearms(FuturemudDatabaseContext context) =>
 		context.RangedWeaponTypes.Any(x => x.Name.Contains("Shotgun") || x.Name.Contains("Rifle"));

--- a/DatabaseSeeder/Seeders/ItemSeeder.AntiquityComponentGaps.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.AntiquityComponentGaps.cs
@@ -138,6 +138,11 @@ public partial class ItemSeeder
 		var manifestEntry = RegisterManifestAggregate("material", name, definition);
 		if (_materials.TryGetValue(name, out var existing))
 		{
+			if (FindManagedRecord(manifestEntry.EntityType, manifestEntry.StableKey) is null)
+			{
+				return existing;
+			}
+
 			var liveDefinition = new MaterialManifestDefinition(
 				existing.Name,
 				existing.MaterialDescription,
@@ -165,6 +170,11 @@ public partial class ItemSeeder
 		if (existing is not null)
 		{
 			_materials[name] = existing;
+			if (FindManagedRecord(manifestEntry.EntityType, manifestEntry.StableKey) is null)
+			{
+				return existing;
+			}
+
 			var liveDefinition = new MaterialManifestDefinition(
 				existing.Name,
 				existing.MaterialDescription,

--- a/DatabaseSeeder/Seeders/ItemSeeder.Crafting.Renaissance.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Crafting.Renaissance.cs
@@ -249,7 +249,7 @@ public partial class ItemSeeder
 				"This knowledge covers Renaissance carpentry and joinery from forestry and primary-production timber commodities.");
 		}
 
-		return Path("General craftwork", "make", "making a finished item", "Crafting", 15,
+		return Path("General craftwork", "make", "making a finished item", "Labouring", 15,
 			Difficulty.Normal, 0.75, 10.0, "general",
 			["TagTool - Held - an item with the Hammer tag"],
 			"This knowledge covers Renaissance finished goods whose configured material is supplied as a primary commodity or earlier craft stock.");

--- a/DatabaseSeeder/Seeders/ItemSeeder.Crafting.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Crafting.cs
@@ -91,6 +91,7 @@ public partial class ItemSeeder
 		["Weaponcrafting", "Weaponsmith", "Weapon Crafting", "Weapon Craft", "Weaponcraft", "Weaponsmithing"],
 		["Blacksmithing", "Metalcraft", "Metalworking", "Metal Work", "Metalwork", "Smithing"],
 		["Silversmithing", "Silversmith", "Silver Smithing", "Silver Smith"],
+		["Goldsmithing", "Goldsmith", "Gold Smithing", "Gold Smith"],
 		["Bowmaking", "Bowyer", "Bow Making", "Bowyer Craft"],
 		["Fletching", "Fletcher"],
 		["Pottery", "Potter"],
@@ -102,15 +103,18 @@ public partial class ItemSeeder
 		["Baking", "Baker"],
 		["Dyeing", "Dyecraft", "Dye Craft", "Dyer"],
 		["Glassworking", "Glasswork", "Glass Work", "Glassworker"],
-		["Gemcraft", "Gem Craft", "Gemcutting", "Gem Cutting"],
+		["Glassblowing", "Glassblower", "Glass Blowing"],
+		["Gemcraft", "Gem Craft"],
+		["Lapidary", "Gemcutting", "Gem Cutting"],
 		["Perfumery", "Perfumer"],
 		["Brewing", "Brewer"],
 		["Distilling", "Distiller"],
 		["Cooking", "Cookery", "Cook"],
-		["Carpentry", "Woodcraft", "Woodworking", "Wood Work", "Woodwork", "Carpenter", "Joinery", "Constructing", "Construction"],
+		["Carpentry", "Woodcraft", "Woodworking", "Wood Work", "Woodwork", "Carpenter", "Joinery"],
 		["Basketry", "Basketmaker", "Basket Making"],
 		["Coopering", "Cooper"],
 		["Ropemaking", "Ropemaker", "Rope Making"],
+		["Fulling", "Fuller"],
 		["Lacquerwork", "Lacquerer", "Lacquer Work"],
 		["Lumberjacking", "Lumberjack"],
 		["Masonry", "Stonecraft", "Stoneworking", "Stone Work", "Stonework", "Mason"],
@@ -122,6 +126,23 @@ public partial class ItemSeeder
 		["Wheelmaking", "Wheelwright", "Wheel Making"],
 		["Candlemaking", "Candlery", "Candle Making"],
 		["Leathermaking", "Hideworking", "Leatherworking", "Leather Work", "Leatherwork", "Leather Making", "Hide Work"],
+		["Parchmentmaking", "Parchmenter", "Parchment Making"],
+		["Papermaking", "Papermaker", "Paper Making"],
+		["Bookbinding", "Bookbinder", "Book Binding"],
+		["Calligraphy", "Calligrapher"],
+		["Scribing", "Scribe"],
+		["Woodblock Printing", "Block Printer", "WoodblockPrinting"],
+		["Movable Type Printing", "Printer", "MovableTypePrinting"],
+		["Gunsmithing", "Gunsmith", "Gun Smithing"],
+		["Powdermaking", "Powdermaker", "Powder Making"],
+		["Lensmaking", "Lensmaker", "Lens Making"],
+		["Clockmaking", "Clockmaker", "Clock Making"],
+		["Instrument Making", "Instrument Maker", "InstrumentMaking"],
+		["Navigation", "Navigator"],
+		["Cartography", "Cartographer"],
+		["Surveying", "Surveyor"],
+		["Engraving", "Engraver"],
+		["Chemistry", "Chemist"],
 		["Winemaking", "Winemaker", "Wine Making"],
 		["Foraging", "Forage"],
 		["Skinning", "Skin"],
@@ -130,12 +151,14 @@ public partial class ItemSeeder
 		["Surviving", "Survival"],
 		["Animal Breeding", "Husbandry"],
 		["Beekeeping", "Beekeeper"],
+		["Apothecary", "Pharmacology"],
 		["Medicine", "First Aid", "Healing", "Patient Care", "Diagnosis", "Surgery", "Pharmacology", "Herbalism"],
 		["Law", "Lawyer"],
 		["Labouring", "Labourer", "Laboring", "Laborer"],
 		["Supervising", "Supervisor"],
 		["Painting", "Paint"],
 		["Civil Engineering", "Civil Engineer"],
+		["Constructing", "Construction"],
 		["Administration", "Administrator"],
 		["Performance", "Performer"],
 		["Investigation", "Investigator"],
@@ -986,6 +1009,11 @@ return GetTrait(@ch, ToTrait(""{trait.Id.ToString(System.Globalization.CultureIn
     {
         if (HasValue(match.Groups["craftid"]) && long.TryParse(match.Groups["craftid"].Value, out long id))
         {
+			if (_itemsById.TryGetValue(id, out GameItemProto? cachedItem))
+			{
+				return cachedItem;
+			}
+
             return _context!.GameItemProtos.FirstOrDefault(x => x.Id == id);
         }
 
@@ -997,6 +1025,11 @@ return GetTrait(@ch, ToTrait(""{trait.Id.ToString(System.Globalization.CultureIn
         Match match = RequireMatch(ItemReferenceRegex, text, $"Invalid item reference {text}");
         if (HasValue(match.Groups["craftid"]) && long.TryParse(match.Groups["craftid"].Value, out long id))
         {
+			if (_itemsById.TryGetValue(id, out GameItemProto? cachedItem))
+			{
+				return cachedItem;
+			}
+
             GameItemProto? itemById = _context!.GameItemProtos.FirstOrDefault(x => x.Id == id);
             if (itemById is not null)
             {
@@ -1373,6 +1406,7 @@ return GetTrait(@ch, ToTrait(""{trait.Id.ToString(System.Globalization.CultureIn
         (string typename, string definition) = BuildInputDefinition(spec);
         CraftInput input = new()
         {
+			Id = _deferCraftProductSave ? _nextCraftInputId++ : 0,
             Craft = craft,
             InputQualityWeight = spec.QualityWeight,
             OriginalAdditionTime = DateTime.UtcNow,
@@ -2166,6 +2200,7 @@ return GetTrait(@ch, ToTrait(""{trait.Id.ToString(System.Globalization.CultureIn
 					var repairedFingerprint = ItemSeederManifestCatalogue.Fingerprint(BuildLiveCraftManifestDefinition(existing));
 					RecordAppliedManifestEntry(manifestEntry, existing.Id, existing.RevisionNumber, repairedFingerprint);
 					IncrementManifestResult(manifestEntry.Module, x => x with { Updated = x.Updated + 1 });
+					QueueDeferredCraftPersistence();
 					return existing;
 				}
 
@@ -2206,6 +2241,7 @@ return GetTrait(@ch, ToTrait(""{trait.Id.ToString(System.Globalization.CultureIn
 			var rebuiltFingerprint = ItemSeederManifestCatalogue.Fingerprint(BuildLiveCraftManifestDefinition(existing));
 			RecordAppliedManifestEntry(manifestEntry, existing.Id, existing.RevisionNumber, rebuiltFingerprint);
 			IncrementManifestResult(manifestEntry.Module, x => x with { Updated = x.Updated + 1 });
+			QueueDeferredCraftPersistence();
 			return existing;
 		}
 
@@ -2231,21 +2267,17 @@ return GetTrait(@ch, ToTrait(""{trait.Id.ToString(System.Globalization.CultureIn
 		var appliedFingerprint = ItemSeederManifestCatalogue.Fingerprint(BuildLiveCraftManifestDefinition(dbitem));
 		RecordAppliedManifestEntry(manifestEntry, dbitem.Id, dbitem.RevisionNumber, appliedFingerprint);
 		IncrementManifestResult(manifestEntry.Module, x => x with { Inserted = x.Inserted + 1 });
+		QueueDeferredCraftPersistence();
 		return dbitem;
 	}
 
 	private IEnumerable<string> GetCraftProductManifestDependencies(CraftDefinitionSpec spec)
 	{
-		var stableReferencesById = _items
-			.Where(x => !string.IsNullOrWhiteSpace(x.Value.UniqueName) && x.Value.Id > 0)
-			.GroupBy(x => x.Value.Id)
-			.ToDictionary(x => x.Key, x => x.First().Value.UniqueName);
-
 		foreach (var product in spec.Products)
 		{
 			var match = Regex.Match(product.Details, @"\(#(?<id>\d+)\)");
 			if (!match.Success || !long.TryParse(match.Groups["id"].Value, out var itemId) ||
-			    !stableReferencesById.TryGetValue(itemId, out var stableReference))
+			    !_itemStableReferencesById.TryGetValue(itemId, out var stableReference))
 			{
 				continue;
 			}
@@ -2460,22 +2492,70 @@ return GetTrait(@ch, ToTrait(""{trait.Id.ToString(System.Globalization.CultureIn
 			craft.CraftTools.Add(ConvertToTool(craft, tool));
 		}
 
-		_context!.SaveChanges();
+		if (!_deferCraftProductSave)
+		{
+			_context!.SaveChanges();
+		}
 		foreach (var product in spec.Products.Concat(spec.FailProducts))
 		{
 			craft.CraftProducts.Add(ConvertToProduct(craft, product));
 		}
 
-		_context.SaveChanges();
-		if (_deferCraftProductSave)
+		if (!_deferCraftProductSave)
 		{
-			DetachTrackedEntities(entity => entity is Craft or
-				CraftPhase or
-				CraftInput or
-				CraftTool or
-				CraftProduct or
-				EditableItem);
+			_context!.SaveChanges();
 		}
+	}
+
+	private void BeginDeferredCraftPersistence()
+	{
+		_nextCraftInputId = _context!.CraftInputs
+			.OrderByDescending(x => x.Id)
+			.Select(x => x.Id)
+			.FirstOrDefault() + 1;
+		_deferredCraftPersistenceCount = 0;
+	}
+
+	private void QueueDeferredCraftPersistence()
+	{
+		if (!_deferCraftProductSave)
+		{
+			return;
+		}
+
+		_deferredCraftPersistenceCount++;
+		if (_deferredCraftPersistenceCount >= 128)
+		{
+			FlushDeferredCraftPersistence();
+		}
+	}
+
+	private void FlushDeferredCraftPersistence()
+	{
+		if (!_deferCraftProductSave || _deferredCraftPersistenceCount == 0)
+		{
+			return;
+		}
+
+		SaveCraftChanges();
+		DetachTrackedEntities(entity => entity is Craft or
+			CraftPhase or
+			CraftInput or
+			CraftTool or
+			CraftProduct or
+			SeederManagedRecord or
+			EditableItem);
+		_deferredCraftPersistenceCount = 0;
+	}
+
+	private void SaveCraftChanges()
+	{
+		if (!_context!.ChangeTracker.AutoDetectChangesEnabled)
+		{
+			_context.ChangeTracker.DetectChanges();
+		}
+
+		_context.SaveChanges();
 	}
 
     private static int? GetMaterialDefiningInputIndex(List<(int Product, int Input)>? indexes, int productNumber)
@@ -2737,12 +2817,20 @@ return GetTrait(@ch, ToTrait(""{trait.Id.ToString(System.Globalization.CultureIn
 		if (!_manifestCaptureOnly &&
 		    progs.Any(prog => _context!.Entry(prog).State is EntityState.Added or EntityState.Modified))
 		{
-			_context!.SaveChanges();
+			SaveCraftChanges();
 		}
 	}
 
 	private FutureProg EnsureAlwaysTrueProg()
 	{
+		// AlwaysTrue is core infrastructure, not ItemSeeder-owned content. Reuse it
+		// verbatim so its independently maintained signature is never claimed or
+		// treated as an unsafe ItemSeeder conflict.
+		if (_progs.TryGetValue("AlwaysTrue", out var existingProg))
+		{
+			return existingProg;
+		}
+
 		return EnsureFutureProg("AlwaysTrue", "Utility", "General", ProgVariableTypes.Boolean, "",
 			[], "return true");
 	}
@@ -2835,7 +2923,7 @@ return GetTrait(@ch, ToTrait(""{trait.Id.ToString(System.Globalization.CultureIn
 			CompleteManifestAggregate(manifestEntry, null, manifestDefinition, ManifestAggregateDisposition.Insert);
 			if (!_manifestCaptureOnly)
 			{
-				_context.SaveChanges();
+				SaveCraftChanges();
 			}
 		}
 		else
@@ -2942,6 +3030,35 @@ return ""You need at least {minimumTraitValue.Value.ToString(System.Globalizatio
 		return AddCraft(spec);
 	}
 
+	internal MudSharp.Models.Craft AddCraftWithDeferredPersistenceForTesting(
+		FuturemudDatabaseContext context,
+		CraftDefinitionSpec spec)
+	{
+		InitialiseCraftAuthoringForTesting(context);
+		var previousDeferCraftProductSave = _deferCraftProductSave;
+		var previousAutoDetectChanges = _context!.ChangeTracker.AutoDetectChangesEnabled;
+		_deferCraftProductSave = true;
+		_context.ChangeTracker.AutoDetectChangesEnabled = false;
+		BeginDeferredCraftPersistence();
+		try
+		{
+			var craft = AddCraft(spec);
+			FlushDeferredCraftPersistence();
+			return context.Crafts
+				.Include(x => x.CraftPhases)
+				.Include(x => x.CraftInputs)
+				.Include(x => x.CraftTools)
+				.Include(x => x.CraftProducts)
+				.Single(x => x.Id == craft.Id && x.RevisionNumber == craft.RevisionNumber);
+		}
+		finally
+		{
+			_deferCraftProductSave = previousDeferCraftProductSave;
+			_context.ChangeTracker.AutoDetectChangesEnabled = previousAutoDetectChanges;
+			_deferredCraftPersistenceCount = 0;
+		}
+	}
+
 	internal MudSharp.Models.Craft AddCraftFromImportsForTesting(FuturemudDatabaseContext context, string name, string category,
 		IEnumerable<(int Seconds, string Echo, string FailEcho)> phases, IEnumerable<string> inputs, IEnumerable<string> tools,
 		IEnumerable<string> products, IEnumerable<string> failProducts, List<(int Product, int Input)>? productMaterialInputIndexes = null,
@@ -2995,7 +3112,10 @@ return ""You need at least {minimumTraitValue.Value.ToString(System.Globalizatio
 		_nextCraftId = _context!.Crafts.Select(x => x.Id).ToList().DefaultIfEmpty(0).Max(x => x) + 1;
 
 		var previousDeferCraftProductSave = _deferCraftProductSave;
+		var previousAutoDetectChanges = _context!.ChangeTracker.AutoDetectChangesEnabled;
 		_deferCraftProductSave = true;
+		_context.ChangeTracker.AutoDetectChangesEnabled = false;
+		BeginDeferredCraftPersistence();
 		try
 		{
 			RunSeedStage("Creating historic and primary-production crafts", () =>
@@ -3070,10 +3190,13 @@ return ""You need at least {minimumTraitValue.Value.ToString(System.Globalizatio
 					SeedRenaissanceFinishedItemCrafts();
 				});
 			}
+			FlushDeferredCraftPersistence();
 		}
 		finally
 		{
 			_deferCraftProductSave = previousDeferCraftProductSave;
+			_context!.ChangeTracker.AutoDetectChangesEnabled = previousAutoDetectChanges;
+			_deferredCraftPersistenceCount = 0;
 		}
 	}
 

--- a/DatabaseSeeder/Seeders/ItemSeeder.EraCatalogueSupport.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.EraCatalogueSupport.cs
@@ -3,12 +3,44 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using MudSharp.Framework;
 using MudSharp.GameItems;
 
 namespace DatabaseSeeder.Seeders;
 
 public partial class ItemSeeder
 {
+	private void ValidateHistoricalMedicalPrerequisites(string eras)
+	{
+		var specifications = Enumerable.Empty<EraCatalogueItemSpec>();
+		if (HasAnyEra(eras, "renaissance"))
+		{
+			specifications = specifications.Concat(EraMedicalRepairCatalogue.Renaissance.Select(x => x.ToItemSpec()));
+		}
+
+		if (HasAnyEra(eras, "earlymodern"))
+		{
+			specifications = specifications.Concat(EraMedicalRepairCatalogue.EarlyModern.Select(x => x.ToItemSpec()));
+		}
+
+		var missingComponents = specifications
+			.SelectMany(x => x.Components)
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.Where(component => !_components.ContainsKey(component))
+			.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+			.ToArray();
+		if (missingComponents.Length == 0)
+		{
+			return;
+		}
+
+		var requiredHealthTier = HasAnyEra(eras, "earlymodern") ? "earlymodern" : "renaissance";
+		throw new InvalidOperationException(
+			$"The selected historical medical catalogue requires Health Seeder at the {requiredHealthTier} tier. " +
+			$"Run the Health Seeder with the {requiredHealthTier} option before Items. Missing components: " +
+			missingComponents.ListToString() + ".");
+	}
+
 	internal sealed record EraCatalogueItemSpec(
 		string StableReference,
 		string Noun,

--- a/DatabaseSeeder/Seeders/ItemSeeder.Manifest.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Manifest.cs
@@ -832,11 +832,28 @@ public partial class ItemSeeder
 			return null;
 		}
 
-		var localRecord = _context!.SeederManagedRecords.Local.FirstOrDefault(x =>
-			x.Seeder == Name && x.EntityType == entityType && x.StableKey == stableKey &&
-			_context.Entry(x).State != EntityState.Deleted);
-		return localRecord ?? _context.SeederManagedRecords.FirstOrDefault(x =>
-			       x.Seeder == Name && x.EntityType == entityType && x.StableKey == stableKey);
+		var identity = ManagedRecordIdentity(entityType, stableKey);
+		if (_managedRecordsByIdentity.TryGetValue(identity, out var cachedRecord))
+		{
+			var entry = _context!.Entry(cachedRecord);
+			if (entry.State == EntityState.Detached)
+			{
+				_context.Attach(cachedRecord);
+				entry = _context.Entry(cachedRecord);
+			}
+
+			if (entry.State != EntityState.Deleted)
+			{
+				return cachedRecord;
+			}
+
+			_managedRecordsByIdentity.Remove(identity);
+		}
+
+		// InitialiseDependencies indexed every existing record for this seeder. A miss is
+		// therefore a genuinely new aggregate; querying it again once per new item or
+		// craft turns a fresh installation into thousands of database round-trips.
+		return null;
 	}
 
 	private void RecordAppliedManifestEntry(
@@ -860,6 +877,7 @@ public partial class ItemSeeder
 				StableKey = entry.StableKey
 			};
 			_context!.SeederManagedRecords.Add(record);
+			_managedRecordsByIdentity[ManagedRecordIdentity(entry.EntityType, entry.StableKey)] = record;
 		}
 
 		record.Module = entry.Module;

--- a/DatabaseSeeder/Seeders/ItemSeeder.PreIndustrialFoodCatalogue.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.PreIndustrialFoodCatalogue.cs
@@ -637,7 +637,13 @@ public partial class ItemSeeder
 			1.0, 0, 0.01, 1.0, false, string.Empty, tagPaths);
 		var manifestEntry = RegisterManifestAggregate("liquid", entry.Name, manifestDefinition);
 		var disposition = ManifestAggregateDisposition.Insert;
-		if (!_liquids.TryGetValue(entry.Name, out var liquid))
+		var hasExistingLiquid = _liquids.TryGetValue(entry.Name, out var existingLiquid);
+		Liquid liquid;
+		if (hasExistingLiquid)
+		{
+			liquid = existingLiquid!;
+		}
+		else
 		{
 			liquid = new Liquid
 			{
@@ -651,8 +657,15 @@ public partial class ItemSeeder
 		{
 			return;
 		}
-		else
+		if (hasExistingLiquid)
 		{
+			if (FindManagedRecord(manifestEntry.EntityType, manifestEntry.StableKey) is null)
+			{
+				// Core and Kickstart seeders own their stock liquids. Reuse an existing liquid without
+				// claiming it or overwriting its tailored properties.
+				return;
+			}
+
 			disposition = InspectManifestAggregate(manifestEntry, liquid.Id, BuildLiveLiquidManifestDefinition(liquid));
 			if (disposition is ManifestAggregateDisposition.Customized or ManifestAggregateDisposition.Unchanged)
 			{

--- a/DatabaseSeeder/Seeders/ItemSeeder.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.cs
@@ -75,10 +75,19 @@ What is your choice? ", (context, answers) => true,
     private Dictionary<string, FutureProg> _progs = new(StringComparer.InvariantCultureIgnoreCase);
     private DictionaryWithDefault<string, TraitDefinition> _traits = new(StringComparer.OrdinalIgnoreCase);
     private Dictionary<string, GameItemProto> _items = new(StringComparer.InvariantCultureIgnoreCase);
+	private Dictionary<string, GameItemProto> _itemsByStableReference = new(StringComparer.OrdinalIgnoreCase);
+	private Dictionary<long, GameItemProto> _itemsById = [];
+	private Dictionary<long, string> _itemStableReferencesById = [];
+	private Dictionary<string, IReadOnlyList<GameItemProto>> _legacyItemsByShortDescription =
+		new(StringComparer.OrdinalIgnoreCase);
+	private Dictionary<string, SeederManagedRecord> _managedRecordsByIdentity =
+		new(StringComparer.OrdinalIgnoreCase);
 	private Dictionary<string, Craft> _craftsByNameAndCategory = new(StringComparer.OrdinalIgnoreCase);
 	private long _nextItemId = 1;
 	private long _nextCraftId = 1;
+	private long _nextCraftInputId = 1;
 	private bool _deferCraftProductSave;
+	private int _deferredCraftPersistenceCount;
 	private Stopwatch? _progressStopwatch;
 	private int _progressStage;
 	private int _progressStageCount;
@@ -91,10 +100,19 @@ What is your choice? ", (context, answers) => true,
 
     private void InitialiseDependencies()
     {
-        if (_context is null)
-        {
-            throw new ApplicationException("Context cannot be null at this point.");
-        }
+		if (_context is null)
+		{
+			throw new ApplicationException("Context cannot be null at this point.");
+		}
+
+		_managedRecordsByIdentity = _manifestCaptureOnly
+			? new Dictionary<string, SeederManagedRecord>(StringComparer.OrdinalIgnoreCase)
+			: _context.SeederManagedRecords
+				.Where(x => x.Seeder == Name)
+				.AsEnumerable()
+				.GroupBy(x => ManagedRecordIdentity(x.EntityType, x.StableKey), StringComparer.OrdinalIgnoreCase)
+				.ToDictionary(x => x.Key, x => x.OrderByDescending(record => record.AppliedAt).First(),
+					StringComparer.OrdinalIgnoreCase);
 
 		_components = _context.GameItemComponentProtos.Local
 			.AsEnumerable()
@@ -195,14 +213,24 @@ What is your choice? ", (context, answers) => true,
 		}
 
 		_items = new Dictionary<string, GameItemProto>(StringComparer.InvariantCultureIgnoreCase);
+		_itemsByStableReference = new(StringComparer.OrdinalIgnoreCase);
+		_itemsById = [];
+		_itemStableReferencesById = [];
+		_legacyItemsByShortDescription = itemPrototypes
+			.Where(x => string.IsNullOrWhiteSpace(x.UniqueName))
+			.GroupBy(x => x.ShortDescription, StringComparer.OrdinalIgnoreCase)
+			.ToDictionary(x => x.Key, x => (IReadOnlyList<GameItemProto>)x.ToArray(), StringComparer.OrdinalIgnoreCase);
 		foreach (var group in itemPrototypes.GroupBy(x => x.Id))
 		{
 			var item = group.FirstOrDefault(x => x.EditableItem?.RevisionStatus == 4) ??
 			           group.FirstOrDefault(x => x.EditableItem?.RevisionStatus is 1 or 2) ??
 			           group.OrderByDescending(x => x.RevisionNumber).First();
+			_itemsById[item.Id] = item;
 			if (!string.IsNullOrWhiteSpace(item.UniqueName))
 			{
 				_items[item.UniqueName] = item;
+				_itemsByStableReference[item.UniqueName] = item;
+				_itemStableReferencesById[item.Id] = item.UniqueName;
 			}
 		}
 
@@ -256,6 +284,8 @@ What is your choice? ", (context, answers) => true,
 		{
 			RunSeedStage("Validating Renaissance and Early Modern jewellery and door prerequisites",
 				ValidateRenaissanceEarlyModernJewelleryDoorsPrerequisites);
+			RunSeedStage("Validating historical medical prerequisites",
+				() => ValidateHistoricalMedicalPrerequisites(requestedEras));
 		}
 
         SeedReworkItems();
@@ -409,6 +439,7 @@ What is your choice? ", (context, answers) => true,
 			GameItemProtosOnLoadProgs or
 			GameItemProtosTags or
 			GameItemProtoExtraDescription or
+			SeederManagedRecord or
 			EditableItem);
 	}
 
@@ -450,6 +481,11 @@ What is your choice? ", (context, answers) => true,
             context.GameItemComponentProtos.All(x => x.Name != "Insulation_Minor") ||
             context.GameItemComponentProtos.All(x => x.Name != "Destroyable_Misc") ||
             context.GameItemComponentProtos.All(x => x.Name != "Torch_Infinite") ||
+			new[]
+			{
+				"Wear_Saddle", "Wear_Bridle", "Wear_Chanfron", "Wear_Criniere", "Wear_Croupiere",
+				"Wear_Flanchards", "Wear_Peytral", "Wear_Caparison"
+			}.Any(name => context.GameItemComponentProtos.All(x => x.Name != name)) ||
             context.Tags.All(x => x.Name != "Functions"))
         {
             return ShouldSeedResult.PrerequisitesNotMet;
@@ -760,33 +796,7 @@ What is your choice? ", (context, answers) => true,
 
 	private GameItemProto? FindItemByStableReference(string stableReference)
 	{
-		var matches = _context!.GameItemProtos.Local
-			.AsEnumerable()
-			.Concat(_context.GameItemProtos
-				.Include(x => x.EditableItem)
-				.Include(x => x.GameItemProtosTags)
-				.Include(x => x.GameItemProtosGameItemComponentProtos)
-				.AsEnumerable())
-			.Where(x => x.UniqueName?.Equals(stableReference, StringComparison.OrdinalIgnoreCase) == true)
-			.GroupBy(x => (x.Id, x.RevisionNumber))
-			.Select(x => x.First())
-			.ToArray();
-		var activeLogicalIds = matches
-			.Where(x => x.EditableItem?.RevisionStatus is 1 or 2 or 4)
-			.Select(x => x.Id)
-			.Distinct()
-			.ToArray();
-		if (activeLogicalIds.Length > 1)
-		{
-			throw new InvalidOperationException(
-				$"Stable item reference '{stableReference}' is active on multiple logical prototype IDs: {string.Join(", ", activeLogicalIds.OrderBy(x => x))}.");
-		}
-
-		var logicalId = activeLogicalIds.SingleOrDefault();
-		var candidates = logicalId == 0 ? matches : matches.Where(x => x.Id == logicalId).ToArray();
-		return candidates.FirstOrDefault(x => x.EditableItem?.RevisionStatus == 4) ??
-		       candidates.FirstOrDefault(x => x.EditableItem?.RevisionStatus is 1 or 2) ??
-		       candidates.OrderByDescending(x => x.RevisionNumber).FirstOrDefault();
+		return _itemsByStableReference.GetValueOrDefault(stableReference);
 	}
 
 	private GameItemProto? FindExactLegacyItemMatch(
@@ -794,13 +804,9 @@ What is your choice? ", (context, answers) => true,
 		string shortDescription,
 		ItemManifestDefinition definition)
 	{
-		var candidates = _context!.GameItemProtos
-			.Include(x => x.EditableItem)
-			.Include(x => x.GameItemProtosTags)
-			.Include(x => x.GameItemProtosGameItemComponentProtos)
-			.AsEnumerable()
-			.Where(x => string.IsNullOrWhiteSpace(x.UniqueName) &&
-			            x.ShortDescription.Equals(shortDescription, StringComparison.OrdinalIgnoreCase))
+		var candidates = _legacyItemsByShortDescription
+			.GetValueOrDefault(shortDescription, [])
+			.Where(x => x.ShortDescription.Equals(shortDescription, StringComparison.OrdinalIgnoreCase))
 			.ToArray();
 		var expectedFingerprint = ItemSeederManifestCatalogue.Fingerprint(definition);
 		var exactMatches = candidates
@@ -873,10 +879,13 @@ What is your choice? ", (context, answers) => true,
 	private void CacheReworkItem(string stableReference, GameItemProto item)
 	{
 		_items[stableReference] = item;
+		_itemsByStableReference[stableReference] = item;
+		_itemsById[item.Id] = item;
 		_items[item.ShortDescription] = item;
 		if (!string.IsNullOrWhiteSpace(item.UniqueName))
 		{
 			_items[item.UniqueName] = item;
+			_itemStableReferencesById[item.Id] = item.UniqueName;
 		}
 	}
 

--- a/DatabaseSeeder/Seeders/TimeSeeder.Calendars.cs
+++ b/DatabaseSeeder/Seeders/TimeSeeder.Calendars.cs
@@ -3439,7 +3439,7 @@ The Tranquility Calendar originally appeared in the July 1989 (Mendel 19 A.T.) i
             Definition = @$"<calendar>
   <alias>gregorian</alias>
   <shortname>Gregorian Calendar (EN-{(useImperial ? "US" : "UK")})</shortname>
-  <fullname>The Gregorian Calendar, in English with {(useImperial ? "British" : "American")} Date Display</fullname>
+  <fullname>The Gregorian Calendar, in English with {(useImperial ? "American" : "British")} Date Display</fullname>
   <description><![CDATA[The calendar created by pope Gregory to replace the Julian calendar. English edition.]]></description>
   <shortstring>{(useImperial ? "$mo/$dd/$yy" : "$dd/$mo/$yy")}</shortstring>
   <longstring>$nz$ww {(useImperial ? "$mf $dt" : "the $dt of $mf")}, $yy {(useCE ? "C.E" : "A.D")}</longstring>

--- a/Design Documents/Seeding/Seeded_Item_Manifest.json
+++ b/Design Documents/Seeding/Seeded_Item_Manifest.json
@@ -1,6 +1,6 @@
 {
   "manifestVersion": "1",
-  "sourceFingerprint": "367d990593b2cd7fa71d009bced305a31adb1304d239cf0c11656504ada06bfc",
+  "sourceFingerprint": "d375e8d2e2de917c368763177e447bd99cf1ddb6d8c2b70c32fcb3077f08c6dd",
   "generatedAtUtc": "2026-08-05T04:56:12.20763Z",
   "entries": [
     {

--- a/Design Documents/Seeding/Seeded_Item_Manifest.json
+++ b/Design Documents/Seeding/Seeded_Item_Manifest.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": "1",
-  "sourceFingerprint": "feae031d613a6a0d3881a2e73f6d0a269ae19e3f760884b1e9eb298669d7dbc1",
-  "generatedAtUtc": "2026-08-04T23:10:08.8758217Z",
+  "sourceFingerprint": "367d990593b2cd7fa71d009bced305a31adb1304d239cf0c11656504ada06bfc",
+  "generatedAtUtc": "2026-08-05T04:56:12.20763Z",
   "entries": [
     {
       "entityType": "commodity-spoilage",
@@ -49401,7 +49401,7 @@
         "item:renaissance_western_gable_hood"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a5e46106023705c87cfb1b97ac4fbcda1c2c7dab706252f9e18f05f2719a9d52"
+      "fingerprint": "f5c5993ea86a1f92b8f9bfb3eef569b0ade326b7d21890a90512818f4f69a507"
     },
     {
       "entityType": "craft",
@@ -49414,7 +49414,7 @@
         "item:renaissance_western_back_laced_bodice"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "12946c4bc0ea5220e45c38290413bd05a316d96a99604cfde423d97d1331678f"
+      "fingerprint": "14c8b173542675435505d9c5019aeffbc1b71937e4a1860b4ccb99206e4b1603"
     },
     {
       "entityType": "craft",
@@ -49427,7 +49427,7 @@
         "item:renaissance_andean_braided_fibresandals"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3a8e51a568472f4b63a0f6605553e7fd67085fb83638a5b86e98fd8a41f4da73"
+      "fingerprint": "17a737ec561317b339ab6aa6915ec994446cbfd4f10988256283676686fee3d4"
     },
     {
       "entityType": "craft",
@@ -49440,7 +49440,7 @@
         "item:renaissance_andean_feathered_headband"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7d1e95d5346ab4e410d9728450761e9f36b3525e7adffc387753ef72428a15a2"
+      "fingerprint": "e21ab169624c38ba5037caadd872b8c0847c047c2b161d68dbe807ba26a9ff44"
     },
     {
       "entityType": "craft",
@@ -49453,7 +49453,7 @@
         "item:renaissance_mesoamerican_broad_featherheadband"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "4cdf45e384cd39f612702e1bf65f92db3b657c2bb5c795a080d864cb600230d1"
+      "fingerprint": "66bc778d73fbb181a5daf1f61fa90bcc3bcffbe1436bc008fe8184e774b1471e"
     },
     {
       "entityType": "craft",
@@ -49466,7 +49466,7 @@
         "item:renaissance_japanese_broad_sedge_travelhat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "f2d077103968163e5581985cf72599026988e2ab03073d70f30cfade167c8381"
+      "fingerprint": "2d76733b2fb410b8c812ce69bbc1b1affc7e52c4fa5e8da786bf813d6dd7920a"
     },
     {
       "entityType": "craft",
@@ -49479,7 +49479,7 @@
         "item:renaissance_contact_broadbrim_sunhood"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "28f27e7232675db18c2e3ec450724fa26628302281aedc52e377fe96639e6d29"
+      "fingerprint": "2afcdaa724fdced90c53df39b708ea82bf334c61317d7ee7bfd04f40d0daddc3"
     },
     {
       "entityType": "craft",
@@ -49492,7 +49492,7 @@
         "item:renaissance_ottoman_broad_sleeve_ceremonial_kaftan"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1cb838476878b54dec7999cb07d6d2ec197c119a65db3dffa54bd69089ada78b"
+      "fingerprint": "7c9fbeb5ae29207d87930dcfdebc9d6646b3309bf390a7b984df58463fe8914f"
     },
     {
       "entityType": "craft",
@@ -49505,7 +49505,7 @@
         "item:renaissance_shared_clothing_tarred_canvas_deckcap"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "5aebbaa0d66a1a7fec9fd797d81a60f053b309258d7f3eb4ac7f34a5fe490f3e"
+      "fingerprint": "2f1cd2f1fb62c9d5b423760f6ce70ed7864f8c062ecb806678081d1bf2a96fd7"
     },
     {
       "entityType": "craft",
@@ -49518,7 +49518,7 @@
         "item:renaissance_western_fitted_kirtle"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "78a8ca22d11fae4b71cef78f97669230966b8910d119f5e9c14dd70b710c1037"
+      "fingerprint": "ef4f0ae349adad4658dd26b6f45f7d7979d35b328ed7b1f16933f92401900630"
     },
     {
       "entityType": "craft",
@@ -49531,7 +49531,7 @@
         "item:renaissance_western_spanish_farthingale"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c8c07ef45fa32f9558437b3e855f7fd4863fec8c81135a60f606a2d4c0c14cff"
+      "fingerprint": "a76c8a44bf49a008532b58f96e37011a1e95a223edd1fb2125c9e693db3acc1a"
     },
     {
       "entityType": "craft",
@@ -49544,7 +49544,7 @@
         "item:renaissance_western_french_hood"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "9f93ba8132e1ef3a67edb2639e0201b9d1cac8072bfb7ab778169909e4e0bb5e"
+      "fingerprint": "e4d727a00366c5cd898288eae1871a19dd338c93d7bda29cac204230c4141aeb"
     },
     {
       "entityType": "craft",
@@ -49557,7 +49557,7 @@
         "item:renaissance_africancourt_beadwork_ceremonialapron"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "253f8253925829c74c313bcb566b06fe120d3700782516204630446fdbf83df1"
+      "fingerprint": "9dfdd019f8e11e5b3e7b3c49a3aac29340f3db348b5409e8266cd82ffd817cb5"
     },
     {
       "entityType": "craft",
@@ -49570,7 +49570,7 @@
         "item:renaissance_persianate_domed_courtcap"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "eb05a3e27c9007c2bf2a56810ec12638d42bb06d7fc70bc5098a38c78e7d0f4f"
+      "fingerprint": "413bbed8686c74f03db2ffb0c24261b42263b00edd438986a20d9bedca26e7fc"
     },
     {
       "entityType": "craft",
@@ -49583,7 +49583,7 @@
         "item:renaissance_western_pluderhosen"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "930339dcdf6408b3ae915731d18170f9b89741bcf44b3dc279244764f66d6141"
+      "fingerprint": "c3ece84230cdb8fe738ceec1864777f02c7ec1a36dbe035dacbaecc951f5d21b"
     },
     {
       "entityType": "craft",
@@ -49596,7 +49596,7 @@
         "item:renaissance_western_false_sleeve_overgown"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a0b51eb908deb2deec7747e6b3ae07c726c136677652f5dd97704a93b7514d9b"
+      "fingerprint": "a664d9edbc92fcd5d2da81457b043093af350400fa359ed4e0ee2003b742ce6f"
     },
     {
       "entityType": "craft",
@@ -49609,7 +49609,7 @@
         "item:renaissance_mesoamerican_featheredge_crown"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b52bee1551cd8876c989d809adbc7b5f70ca22c80c3a2471dd4dd24b09803bbc"
+      "fingerprint": "125c15bd0c3706e3c2fb86be70d16eb3379f8b4e64b4eb70a5c2e49676145283"
     },
     {
       "entityType": "craft",
@@ -49622,7 +49622,7 @@
         "item:renaissance_andean_featherwork_tunic"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c6e40f4d4fcda5cf72318db2ea1dfe334fa83fff6a606bcc62953493aceb801b"
+      "fingerprint": "0332e566bf6f2a5dea1b74e8c2832dfe340b136193e0c273560e90b9b3349bdc"
     },
     {
       "entityType": "craft",
@@ -49635,7 +49635,7 @@
         "item:renaissance_western_feathered_velvet_bonnet"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "dd20d8358a178cd96d88c4227ed20fa43c28af70933bfcf8d9bfb8467ee033bf"
+      "fingerprint": "7e34ffc3bfc23482c24b1d9b76c84c01dcf27987c4ecedccf9776085774c6d93"
     },
     {
       "entityType": "craft",
@@ -49648,7 +49648,7 @@
         "item:renaissance_andean_fine_tapestrytunic"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "50e5c1643d5231a928790a41622bfcecea57929fa56e53608c1bdb826af2f07f"
+      "fingerprint": "e8811609cfa0a512e2881af68e333d2022e056093af0731a3b024b098776835e"
     },
     {
       "entityType": "craft",
@@ -49661,7 +49661,7 @@
         "item:renaissance_shared_clothing_fine_velvet_slippers"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "03ea68e729bf6a1b7d7eb05324ae2275875d5d2e594b4965cf79520ff9de45c6"
+      "fingerprint": "1a3b57ec89daf1ef1b1b1aee98a61a39863980d9bed44a60ba6b35db9e9ead83"
     },
     {
       "entityType": "craft",
@@ -49674,7 +49674,7 @@
         "item:renaissance_western_cloth_jerkin"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "dfca80855ded07fae9e81fd6a487dd04887c101004620597b08af6341eb82009"
+      "fingerprint": "6d4a0c382677b7d0427fca98a8b3d074575c59684340365356ad2d84f8234d28"
     },
     {
       "entityType": "craft",
@@ -49687,7 +49687,7 @@
         "item:renaissance_western_fitted_court_gown"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7a4c1163cf563997cef32dc00cf37d1e23e4c5345181c04a1cda5aa8cad28d3d"
+      "fingerprint": "e9988b242fd79045bcd06ffbb733c4fb75c69d69ebb72fa751e338a996558ff2"
     },
     {
       "entityType": "craft",
@@ -49700,7 +49700,7 @@
         "item:renaissance_western_sleeveless_doublet"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "0656ca8b64d69cca6f5643288a631316aaf13ac866a4f77be576a0afd6f116d8"
+      "fingerprint": "b433736bb59ced8cb99a3103b11b673d1e8bdaf3674c67468ed9459228f756e2"
     },
     {
       "entityType": "craft",
@@ -49713,7 +49713,7 @@
         "item:renaissance_andean_fourcorner_wovencap"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a8b3070b3af7dc2aa36f0085a8e2011c43006ac6f9877b764e0a3660135260c3"
+      "fingerprint": "ac650113c6d2867b00a488c510b0e4bb99a5d5ad7e0d82f44882491d5f6817c7"
     },
     {
       "entityType": "craft",
@@ -49726,7 +49726,7 @@
         "item:renaissance_andean_fringed_ceremonialapron"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "69861d4dcc1ba20271bf9c5b0f1221c3deb71b1f01bebbf7dffc830f074fa14b"
+      "fingerprint": "8df7f06ba6f3034ac835ecb0b8221c682713fb4100505960942209959f8a9605"
     },
     {
       "entityType": "craft",
@@ -49739,7 +49739,7 @@
         "item:renaissance_western_front_laced_bodice"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8b4c30e6d3f978aa43b8cb8d476645d5da215f75c6767bfd2614aa9d0b5d6112"
+      "fingerprint": "9fc026473081563a063b0ca15b336f017050a0d78a8b4e6068f8868a27c9e94f"
     },
     {
       "entityType": "craft",
@@ -49752,7 +49752,7 @@
         "item:renaissance_western_front_opening_kirtle"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "949e85ed7480dc1869b10eaeb72a2f45aa6b739040534107201dcd9e96ac553a"
+      "fingerprint": "4f4b7edc5f5b55b222ff4a546ca61c0fb37bae6cf892ab2b81c2bff59b876c63"
     },
     {
       "entityType": "craft",
@@ -49765,7 +49765,7 @@
         "item:renaissance_western_front_opening_gown"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "fd97275df2a7aaedcfdd9489313fda47db0bb859b8343cd1df070e91414dcaff"
+      "fingerprint": "05f7eb7eea798310596fe080a70a3748d6bac872d168bf981376298a7963ebaa"
     },
     {
       "entityType": "craft",
@@ -49778,7 +49778,7 @@
         "item:renaissance_iberian_full_shipboard_breeches"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "9c56f0079569660b38748f7fa96bcf9f17ca2e051e545d1bbf0482d6c47894a8"
+      "fingerprint": "c9feb7bdb9b2895b53f885e4389a474cdbb5a6fc698eda01660bf1003a2df81b"
     },
     {
       "entityType": "craft",
@@ -49791,7 +49791,7 @@
         "item:renaissance_western_full_circle_cloak"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1550e858e535c27dc2cdde880873a48d47854b12a8a8aabdeb0b0e179921e15f"
+      "fingerprint": "f98b6846917ab7b691ce145a86fbd0fede8c414eb5d92e1dec0ff9a804cd203e"
     },
     {
       "entityType": "craft",
@@ -49804,7 +49804,7 @@
         "item:renaissance_western_round_gown"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e0370a59878565035ea053783c2df73a7f8c23ee1c049d850c2e4b283b597d57"
+      "fingerprint": "f3e68554093ef177033bd6ba04704eca0d4766f6741ae09349c9f9cd23503015"
     },
     {
       "entityType": "craft",
@@ -49817,7 +49817,7 @@
         "item:renaissance_institution_physicians_roundcap"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "f634b912ac01394ed6f97e6e5fac13830183a9cb1d8e7de3d6fa7040b99f50c7"
+      "fingerprint": "2e2ada858125351c60fa0a9bbad7b34e29b70d8f10b6b2cd05c7b5b6ed9d2678"
     },
     {
       "entityType": "craft",
@@ -49830,7 +49830,7 @@
         "item:renaissance_persianate_furedge_domedcap"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "62118a375a10a4063cf8173ee029331bcebe5a16d136f484770effd9564ff5bc"
+      "fingerprint": "63e6819cf9ad1b9ca5e3c7f3c46f2c5e8fe26b272535afa6ef1eb60478c13cef"
     },
     {
       "entityType": "craft",
@@ -49843,7 +49843,7 @@
         "item:renaissance_persianate_fur_edged_longcoat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3e634ce4ff673d5171b5b46e0cef3331668e5bdb93d8cc6823c36e037966e951"
+      "fingerprint": "84429557e3df5d2d9f7c291a34b3b8b00675e069d08f8c50963215175a294cb8"
     },
     {
       "entityType": "craft",
@@ -49856,7 +49856,7 @@
         "item:renaissance_western_furred_gown"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "cf6d1f24cb576526a1547507c9e4fda01f6ebd1b0b0fd6b3b887fb4610af7aca"
+      "fingerprint": "07d863e20777b8823012a42ebee0903b0cd00b323cde96cf1bb04ed15616eb00"
     },
     {
       "entityType": "craft",
@@ -49869,7 +49869,7 @@
         "item:renaissance_northamerican_furlined_moccasins"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "92c957479d2bf107f33bbf1c1441d0c0e18dd20b5b9c54b704ece82bdf7fab46"
+      "fingerprint": "4e8250ef7f927beaf7558f01fe58e2ca38a93f6468bbe681a4b047ae43ccd127"
     },
     {
       "entityType": "craft",
@@ -49882,7 +49882,7 @@
         "item:renaissance_ottoman_fur_lined_winter_kaftan"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a5fe980eb26616db676b3d7947668429b97ed6f12db4229ace2e5ec0b3c99dff"
+      "fingerprint": "e51db517fa946c7edb167ac5028df95f08ae745e61ee4d4d790d8cb5b8fd3d3f"
     },
     {
       "entityType": "craft",
@@ -49895,7 +49895,7 @@
         "item:renaissance_western_hanging_sleeve_overgown"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "948cd35efa0813e35451c76801bb7c432fd7d2e27a6f0089ef457cbde4605fa0"
+      "fingerprint": "6a78c54eabd294db3c0d5f37074056636ac324549ccf3f243151daf379368e7b"
     },
     {
       "entityType": "craft",
@@ -49908,7 +49908,7 @@
         "item:renaissance_western_high_neck_bodice"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3fb52d8a9b2adca0a08dd8b7db4a972e06cab21c83351fc94ded608bfee94a1e"
+      "fingerprint": "424a243922eda59f60eed2d47614bf6a6a44b9f5d4ca6cdb9d1fabae51e8058e"
     },
     {
       "entityType": "craft",
@@ -49921,7 +49921,7 @@
         "item:renaissance_western_high_waisted_gown"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c111e70806226c5c30dcd783fb79b6286da3a8367dffdf5a675316529b9c70ea"
+      "fingerprint": "5dac8ed13ec2c221594e3a7517ad448ed86930a7a31dd76cfbefb267c77b0151"
     },
     {
       "entityType": "craft",
@@ -49934,7 +49934,7 @@
         "item:renaissance_africancourt_beaded_chestmantle"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "cb02bb36d48ad2de2f487c0af33ab8b6990b8aea0f0c23455dc4c9a28b171bcc"
+      "fingerprint": "f6365f0c52a5cb7a359bd55d1dd65f2f8a4defcfbe07f337f1ad1419b2a4dd33"
     },
     {
       "entityType": "craft",
@@ -49947,7 +49947,7 @@
         "item:renaissance_northamerican_feathered_mantle"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "cef463c4f70a9824e013241c8e60779806d5b79bbf85bc8d6a35e92e39f5f863"
+      "fingerprint": "beeb9803faee146f78c7fc42976b8dc171a770da32abb1aa0e8b2254371781c5"
     },
     {
       "entityType": "craft",
@@ -49960,7 +49960,7 @@
         "item:renaissance_africancourt_featherwork_shouldermantle"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3171c7a4da359dd21bcae9fc5e5833ab451f7f86e0e8e8e3cfc9eac6c2651813"
+      "fingerprint": "7d3da65a71d9955610bcd43c9ccab2314fe8f5c8acf411598f1107744b451614"
     },
     {
       "entityType": "craft",
@@ -49973,7 +49973,7 @@
         "item:renaissance_japanese_straw_raincape"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "9747f9a8f35df698c595f59b121168f13b1f953fea3af372b6802bc61c5f7172"
+      "fingerprint": "22ae74a3038b90d4b8fad91497040556b6020f729a0ca20f09d0407b062739c8"
     },
     {
       "entityType": "craft",
@@ -49986,7 +49986,7 @@
         "item:renaissance_andean_ceremonial_broadmantle"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ac315c633d886a0cca93217e5c839722b2c13d4541952d8e3f1319a4203ef227"
+      "fingerprint": "722e0915c57eb6143443b3807683f8b9e92d27e4991500e4ce404411b08c9887"
     },
     {
       "entityType": "craft",
@@ -49999,7 +49999,7 @@
         "item:renaissance_shared_clothing_ceremonial_mantle"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ab33a129c3e20eaecf390ef3754158bee0cdf4339ad6762741a925ea519351a5"
+      "fingerprint": "73268770c06bdb7337eda4e2ea8f918acabb886658e573665c4a3148368861f1"
     },
     {
       "entityType": "craft",
@@ -50012,7 +50012,7 @@
         "item:renaissance_frontier_long_furred_overcoat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "875707063b6270b9be5460dc925411fa8d78666ab281420bfa7421872297d7cc"
+      "fingerprint": "7fe45a709b17e9a1821eb67818fc7f5ef6d2eb0787c66a7a18a707f06cc2b608"
     },
     {
       "entityType": "craft",
@@ -50025,7 +50025,7 @@
         "item:renaissance_maritime_canvas_watchcoat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "602fb10a393c9375b9889448e28d66b4b51960f0079af20b962b86ff7ea8d735"
+      "fingerprint": "b5f9ceff5075cd9d65b2f25fe407be0fb3d58275e0ad3c4a26d1bb75dbf05470"
     },
     {
       "entityType": "craft",
@@ -50038,7 +50038,7 @@
         "item:renaissance_western_robe_style_gown"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "71fc925a1c75559e72e26f6287f4228d80e125e1b3d85dcecbf13c39bd1d7376"
+      "fingerprint": "5d0f228dba67ed106324501e994fe503bac514e19f3997b75b8b268b60ef3dc6"
     },
     {
       "entityType": "craft",
@@ -50051,7 +50051,7 @@
         "item:renaissance_japanese_woven_strawcoat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a84e484ffc5dac9d299946daf7fb08fbe8a2909009190cfc8ed78690f08ddd68"
+      "fingerprint": "a103e8311b777033804ca14de976c4d3680713a1b3e41df474db03ce00296b91"
     },
     {
       "entityType": "craft",
@@ -50064,7 +50064,7 @@
         "item:renaissance_western_long_skirted_doublet"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2726adb994bf44ef39abb7a412a036dc59bc39b3d4b9bd90ed5dabad39be2944"
+      "fingerprint": "4eaef5b1978413be6359830dcbebec08135f8185058591bfbc0c50ac24662e37"
     },
     {
       "entityType": "craft",
@@ -50077,7 +50077,7 @@
         "item:renaissance_western_trained_gown"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b437b1e91cf85b227e0ec871ed1dcf17504711119677be1dcea82597e3012cdc"
+      "fingerprint": "abb6ebd3ec9a5058cc38bdd7498acb702ae0a1084742dd2b657912e00c3171ca"
     },
     {
       "entityType": "craft",
@@ -50090,7 +50090,7 @@
         "item:renaissance_maritime_loose_decktrousers"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "f373d4c3fab458ad6022bd9bbbf0d9885ccbbca0e0171f8ea4379a3e4a54dd53"
+      "fingerprint": "b5439b496ad088f40c7e92912b90ee6cd01c188171d9d260fcbd42d4a601187e"
     },
     {
       "entityType": "craft",
@@ -50103,7 +50103,7 @@
         "item:renaissance_western_venetian_breeches"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "796b4c581c83ae67a5d1fa63d037b182b019d9a65b4cda437d88a7187fe5de22"
+      "fingerprint": "0dcd084942c759975dc99ee2a84135d1d462cc3261f3313e8e26cdefc011c8f6"
     },
     {
       "entityType": "craft",
@@ -50116,7 +50116,7 @@
         "item:renaissance_mesoamerican_featherwork_mantle"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d9a67f85c83d5ec817a5df6329976b8aab57a5e295f1cf338177485e3000265b"
+      "fingerprint": "04fa5c9c05dcd7312250c6ac3c11a50ea7ecd827b585c6f90ecefb5ebbe83215"
     },
     {
       "entityType": "craft",
@@ -50129,7 +50129,7 @@
         "item:renaissance_caribbean_feathered_headband"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "96728381822917a5da2f338931283a3e3fd542f6079c77a3afe44ed97a57ad28"
+      "fingerprint": "b366920ec016a979005d0dabf13d562644f96ccdd7bd3fd622585beb7ba06744"
     },
     {
       "entityType": "craft",
@@ -50142,7 +50142,7 @@
         "item:renaissance_joseon_narrowbrim_horsehairhat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "49b167e35f413e9ecc1d2da02634d2e1f9e7551fe023d80e24c5982d0ccfdf71"
+      "fingerprint": "55786173a8b200bc2d64181e3bd5f1b5dcf2114eff4aabd198728c64766ff8d9"
     },
     {
       "entityType": "craft",
@@ -50155,7 +50155,7 @@
         "item:renaissance_western_paned_trunk_hose"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c6b785300e83b5ad8c53ed6c3e9cc0793aa7933e2fb56ab748df6358535213bf"
+      "fingerprint": "95f22eda08de3b3c31f0c0fe49766782da5110c38392b5f201aad8a926c1154a"
     },
     {
       "entityType": "craft",
@@ -50168,7 +50168,7 @@
         "item:renaissance_mesoamerican_featherwork_tunic"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "68c91e06544ffe85988a0c39abef41fd9b09ace842f850e5fb7b8967460bdce8"
+      "fingerprint": "dca39c3c0b5f26131b7a7bd37b0ba9e48e01902831317abee8590e2d3b62af0f"
     },
     {
       "entityType": "craft",
@@ -50181,7 +50181,7 @@
         "item:renaissance_western_pointed_attifet_hood"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2aaf3ebe29640fd1d8968874ef588379208b84d6b9c0896d4d9adb324e7baec7"
+      "fingerprint": "4a9ebfa9e7667d4301961976793feece0726ef579cc025ace4c7a1dac9b23fd0"
     },
     {
       "entityType": "craft",
@@ -50194,7 +50194,7 @@
         "item:renaissance_western_peascod_doublet"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a2c3efffae2dd3e5b3d653ead7e1a78a30dc33151270eb50da4b2adc302b7ff3"
+      "fingerprint": "678b9ce67984a3f6de370e4e2d45eed265e4009157fded0a197c11dfc22006f5"
     },
     {
       "entityType": "craft",
@@ -50207,7 +50207,7 @@
         "item:renaissance_redsea_rawhide_sandals"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "0af588fc713d25b0b36101ac04b42a1aedae3c2d60c722dbeb00a0f2dd2132ed"
+      "fingerprint": "cce2b795f6e5d961183d3bc05ce02e8974c5e44ed4c9392ad7adb30112cb5973"
     },
     {
       "entityType": "craft",
@@ -50220,7 +50220,7 @@
         "item:renaissance_andean_rawhide_roadsandals"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "cb2791f3ed485a3cc047efa235078e1ba8c46c6eafd1a51c923bbc23dd28700e"
+      "fingerprint": "6171d16b3d8d27d11104203dc58685df0092ec297e5764ae326b9081dcd37803"
     },
     {
       "entityType": "craft",
@@ -50233,7 +50233,7 @@
         "item:renaissance_western_rolled_velvet_balzo"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8594eb3462e491370992531f451b572e221fc6ef3bee56f0f91e3d198150bb7e"
+      "fingerprint": "d564570ab1cbb22453b55586a4bd85de424f053592385e9749b37d90b5669dcc"
     },
     {
       "entityType": "craft",
@@ -50246,7 +50246,7 @@
         "item:renaissance_shared_clothing_ropesole_deckshoes"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7a2b0cf65fb9d9da0bf73f4af54d57bb34b016de557e6baf026cbcd296b9873f"
+      "fingerprint": "2d927bf8e45c93ee2fa6d39d4b5839a4020d6e6389ef53cea96f045545fcb8c6"
     },
     {
       "entityType": "craft",
@@ -50259,7 +50259,7 @@
         "item:renaissance_western_trunk_hose"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7a0f0c61829578d3f56b642d3a7b85e050591d56ab38f371bfeb06ba67666017"
+      "fingerprint": "a5e77fd2bb000e87819d51b59e91a6d9c95db23c22fe11c51ca60a9641836505"
     },
     {
       "entityType": "craft",
@@ -50272,7 +50272,7 @@
         "item:renaissance_mesoamerican_shellbead_apron"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "030319032ca5af47411b9ed232f1da073ea5c325181200f976b97db541933d1a"
+      "fingerprint": "37ef568e8f1da82b705120a3f7dc3e679cec4650be7af0e6e8fff3dbbf4794d5"
     },
     {
       "entityType": "craft",
@@ -50285,7 +50285,7 @@
         "item:renaissance_iberian_canvas_deck_smock"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1dbf2aa60e6276aca294df2ca46fff460b8377cfe10028e6a47e2660e30d7b49"
+      "fingerprint": "7cbcf4da92f9c7a23b8d4c66397facf5e2ab10fa8f8dd179db4531cd65af4593"
     },
     {
       "entityType": "craft",
@@ -50298,7 +50298,7 @@
         "item:renaissance_iberian_hooded_weather_cape"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3e1134dabe49cfcff171bb341abf6cbe01f23a14661d5e2b4f05e618e5516562"
+      "fingerprint": "0e8704984eb49c83d87ede5d9c5be8b82d9b8c224ff702689f7d65ccf66abb40"
     },
     {
       "entityType": "craft",
@@ -50311,7 +50311,7 @@
         "item:renaissance_maritime_treated_canvas_cape"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b4ba9b2d9b7c54994d25f6a667d256e717c85a677018fb037de14f7b5fcb52b4"
+      "fingerprint": "fb3a23c8de0b2825ae18b1f58e02b5adcf57d1dcdbbe71cce6e0e12b915d8359"
     },
     {
       "entityType": "craft",
@@ -50324,7 +50324,7 @@
         "item:renaissance_western_short_skirted_doublet"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e81684cabc8f226729d53e5d93818bfecced4ea606b5817b1c1f19b4309c776e"
+      "fingerprint": "c192a124425051ee16bd2a10e1b2229774490a922cf3e9d5e05dee992e796624"
     },
     {
       "entityType": "craft",
@@ -50337,7 +50337,7 @@
         "item:renaissance_western_side_laced_bodice"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "14532b750bb07125ef45ce0c91ef53816c0e7d68b28134a738de18ef65eb7a9a"
+      "fingerprint": "14d92d61432a597ee54a58f0c0ae9512e1ef1295b45835c99e52e1949151cb29"
     },
     {
       "entityType": "craft",
@@ -50350,7 +50350,7 @@
         "item:renaissance_caribbean_gathered_rawhide_shoes"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "431490270acb45a0361ccaef571a20d8b980c1f1f1190fbd5c9913d1bce4e1cc"
+      "fingerprint": "857556275410f1611c0e598d74d0f871e0c2ad86548e384b1324daf127901ef6"
     },
     {
       "entityType": "craft",
@@ -50363,7 +50363,7 @@
         "item:renaissance_western_slashed_puffed_cap"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "efc3b7addbdc031420428fceb379fe86f11d3a81dfdd46f4a5b33c67b546c237"
+      "fingerprint": "57b46eae0d803f971f8972c1078a042c5b01f3f5c914e9323eafd9ec9f9102d5"
     },
     {
       "entityType": "craft",
@@ -50376,7 +50376,7 @@
         "item:renaissance_western_slashed_doublet"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "5188173c03ffdce71a23d9b185d584b0c1a4ce6142ef4e1c31ae6fd25a233783"
+      "fingerprint": "b75e28e24c0a56111c95180bdeaf26c17924dfae34f506669fb702b23970702d"
     },
     {
       "entityType": "craft",
@@ -50389,7 +50389,7 @@
         "item:renaissance_maritime_sleeveless_decksmock"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3d80779f1eb66c99af4eae53d029f85e93f99dca157723ba491aed865b25736b"
+      "fingerprint": "6db1189096ff73869a57efd18dead0b8d7fae36691adbf3579c14c54668ad1b4"
     },
     {
       "entityType": "craft",
@@ -50402,7 +50402,7 @@
         "item:renaissance_western_sleeveless_kirtle"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "5edf893c8123eb4acafb1da1ee076b00a1d2b0b55c8e7d14a6b0f41862ae9e8c"
+      "fingerprint": "9908fdf794b14d7eee10b593e95e87a0115137eefa744f2bb61f763618015553"
     },
     {
       "entityType": "craft",
@@ -50415,7 +50415,7 @@
         "item:renaissance_western_sleeveless_overbodice"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "6ba4c60b61bbebaa308351ca99948f5e79ff2124891038a344a25fea79397bbd"
+      "fingerprint": "44e0583bffc16144d8672280a91c4505300eb7c383c8fde39573377f0e587141"
     },
     {
       "entityType": "craft",
@@ -50428,7 +50428,7 @@
         "item:renaissance_western_sleeveless_jerkin"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "cee9d6005aabe271f4c0ad63b1f3739fe8e55f22e0e7e4a2e5f0b1959f6f3e82"
+      "fingerprint": "91906c0154a05c003174ead2f946d217c1bb1276c30f0e0f60089a042238df38"
     },
     {
       "entityType": "craft",
@@ -50441,7 +50441,7 @@
         "item:renaissance_northamerican_soft_hide_winterhood"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "fce0040bfb76a19299bb4824611c8964981fa24ad2f9a63a81840ff90343b603"
+      "fingerprint": "f52df1c5e1ad880e0e9b27018a3bbef7846ec86240362f62072bdf38949dad0f"
     },
     {
       "entityType": "craft",
@@ -50454,7 +50454,7 @@
         "item:renaissance_frontier_split_sleeve_noblecoat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ed461c9168fa7e6c184e1c2764d17e2e0fb48a8bee1702dc408ccc84c2c7698e"
+      "fingerprint": "36a108544019fa0ba85fb6cdcb2b4f6fa118168478e116e3778e418afc49e875"
     },
     {
       "entityType": "craft",
@@ -50467,7 +50467,7 @@
         "item:renaissance_western_square_neck_bodice"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "91a872403bdaa5f2f351e155b7bed665c4d91bbe60a1871e33d2684d8820b508"
+      "fingerprint": "ce4b29e596f3f238a4a1793f98b4078111a5c77c9950a4916442da1383a50abb"
     },
     {
       "entityType": "craft",
@@ -50480,7 +50480,7 @@
         "item:renaissance_western_square_neck_gown"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b196f9f38dfacde641224ababac41c60160d728e87d2a6e3d1b58f0faf8c4035"
+      "fingerprint": "b66303646fbd1ab86238246e0f6ebe8c993d5ba0540e292566f22da6118b8c6f"
     },
     {
       "entityType": "craft",
@@ -50493,7 +50493,7 @@
         "item:renaissance_japanese_shoulderwing_vest"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "396c625b4e288d187d91564bcd1cc47be0e57c5670b9342ffdc926f7585b82b9"
+      "fingerprint": "389b3fdc0ef63e157d5a01ff14c33bfa05214fa021d7754e9559459926bdaf25"
     },
     {
       "entityType": "craft",
@@ -50506,7 +50506,7 @@
         "item:renaissance_western_stiffened_pair_of_bodies"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "22ea43661aecdf36a16c9afaafdcda75c9ccfdc6b94a180d0dc5096d060996bc"
+      "fingerprint": "3bd1c801b5d97d0f34ed4506bd77c6a76b0070475de8450862c572fd484ad094"
     },
     {
       "entityType": "craft",
@@ -50519,7 +50519,7 @@
         "item:renaissance_western_stomachered_bodice"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "81c2179b1aca1aa9493bb654353097949cefd2c70252b0a9cf1479881580b1db"
+      "fingerprint": "3a70d9e29ef0555487e2f750a0495a09362bcbe6b45053f580e8d0b5aaa83d3a"
     },
     {
       "entityType": "craft",
@@ -50532,7 +50532,7 @@
         "item:renaissance_institution_academic_squarecap"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1d435ce362dccf74d87d3176a5cc9990a97a480441434a874bb07d09fdd79e74"
+      "fingerprint": "045472cb252dad1bef5c15aecfb00170c57e3fd33dd5ae69f05962f0b48deaee"
     },
     {
       "entityType": "craft",
@@ -50545,7 +50545,7 @@
         "item:renaissance_ming_gauze_officialhat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a242ba1cffced7edbd1d05997f69e7e057e259f9580f5bc7c92349851c890d09"
+      "fingerprint": "54827e4c13df5a154acefc8598aed44ed70014d6223bb74acb1800a681da5619"
     },
     {
       "entityType": "craft",
@@ -50558,7 +50558,7 @@
         "item:renaissance_frontier_tall_fur_hat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "075715789c314eb0af774d62d2c85ac51b4a94ef54211a00c16ab596055dfbb8"
+      "fingerprint": "5f99812f0709af130e689cbe0e1b76d50159cf3a4d0bfdb22a84978bbb50e89f"
     },
     {
       "entityType": "craft",
@@ -50571,7 +50571,7 @@
         "item:renaissance_mesoamerican_tall_feathercrown"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d16ea9236019c2cef0e40b50a6917f63e2ae47a502535d45086ef30db1222149"
+      "fingerprint": "1f4159427735f0c61dbc05982643c2713b3659be971487923505b494e3571e1a"
     },
     {
       "entityType": "craft",
@@ -50584,7 +50584,7 @@
         "item:renaissance_maritime_tarred_brimhat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "87ded3abdd75741662bc7155178c66a9949418f06f3469f54184a79b88bf9aea"
+      "fingerprint": "e44e83948f45dba4ec809dfb839a0d1c6640de733b0987bba1e2b2ee56ab4382"
     },
     {
       "entityType": "craft",
@@ -50597,7 +50597,7 @@
         "item:renaissance_japanese_tied_straw_travelsandals"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "49c058a4f8630670ecd79cbebdcbf3de6463cc6226a381e0472e31f7711d3d7e"
+      "fingerprint": "f30c8b00eb640ca908d7d4462c9fd0916754e353623fc4967747e0707d6ea342"
     },
     {
       "entityType": "craft",
@@ -50610,7 +50610,7 @@
         "item:renaissance_western_wheel_farthingale"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "f1e18c27e01c35f884f2e53f8800c4857f39ccf9e3ebab7708d7781c83ebd6a4"
+      "fingerprint": "3eb87ebd6f1fb5114febc5a6775578430b4945cdb8a463d9134ce9e2c7d60e20"
     },
     {
       "entityType": "craft",
@@ -50623,7 +50623,7 @@
         "item:renaissance_caribbean_woven_fibresandals"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "944bce04f464db88884735dfe1875b36cf484b5a7f9ebf0b5f4454b9040d5159"
+      "fingerprint": "3c2a9c3ca135e3950dcc3264db8fb55b7843d13b6cca548f0f33f055e9b12c5c"
     },
     {
       "entityType": "craft",
@@ -50636,7 +50636,7 @@
         "item:renaissance_mesoamerican_woven_fibresandals"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "186d622e1d7364eed28480d824ff1a606889203c43793936d456380bee592469"
+      "fingerprint": "a52dbf9c80b5b8655b505a219fff10318e4bebcd97f6417a507977b4c543ac56"
     },
     {
       "entityType": "craft",
@@ -50649,7 +50649,7 @@
         "item:renaissance_shared_clothing_textile_sandals"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "42f42653c5e0f0caa2a9d627898b41c57bbf1aab3bdab034bee0c61810923fb0"
+      "fingerprint": "b164d4d05da58fbcfd2f143e04c96e4d2c385b009a3c8f16ddbfee807d93b51f"
     },
     {
       "entityType": "craft",
@@ -50662,7 +50662,7 @@
         "item:renaissance_joseon_straw_everydayshoes"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7f8b3605b50707db2d094093972871a1d5c50611ab7fbb88b3efd08b5349c782"
+      "fingerprint": "29514c4e9a53122ab23cbfe71347dfe1fd731eac2c0b73c52d0da66d2a039f02"
     },
     {
       "entityType": "craft",
@@ -50675,7 +50675,7 @@
         "item:renaissance_shared_clothing_straw_brimmed_hat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "aff33bf30cac74e63c91d102f3eda475dffe973bf051370b5d84c2fbdb4f88b6"
+      "fingerprint": "b044ee205fae8c940ae516bfefcd8be0ae45969e4f9bfa6e0b05df58c4e41a92"
     },
     {
       "entityType": "craft",
@@ -50688,7 +50688,7 @@
         "item:renaissance_ming_woven_straw_rainovershoes"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7c7ef711fa4f36c3682dc8c08d5e493c59218caac326293a39b89e5a4898b41b"
+      "fingerprint": "629c994b1b319ff7a0505dae21c056eda8f9448a2b2d96633caeef206d8a41fa"
     },
     {
       "entityType": "craft",
@@ -50701,7 +50701,7 @@
         "item:renaissance_military_cuirass_andean_rawhide"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b0e0504d67e23e57349ab3fcaf15131e60bf2e0c031f1747376f5026b0f69d99"
+      "fingerprint": "989bba0104a28303cd65d6734c26c96d3d73cb3c09626f00a546bbe9f001b6b8"
     },
     {
       "entityType": "craft",
@@ -50714,7 +50714,7 @@
         "item:renaissance_military_cuirass_burmese_rattan"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c0c16db3bddd43c15de84dc9742e705cf62772f1c26fce2fc2da75171b99a2ca"
+      "fingerprint": "20609b2b8074a0b96442ed6c4c4ec50e09d4cca0953425b76dc393fc28a6cc5c"
     },
     {
       "entityType": "craft",
@@ -50727,7 +50727,7 @@
         "item:renaissance_military_armet_italian"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "097671c245ca69fe733e3cc80a379aa7a3d09a7b968e013e5be33c408044aa66"
+      "fingerprint": "57a6ae3099d6182e6da7aeebf3897a6bd31028ad0ac3ca7347c2cd51c419746c"
     },
     {
       "entityType": "craft",
@@ -50740,7 +50740,7 @@
         "item:renaissance_military_caparison_japanese"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "302dbf58b1a748a1e739d87ecf0adc0f12f1b557ef515e100ec79b6799747376"
+      "fingerprint": "470dbd1e251cd09b4eb0e845e3e1794432062a27824d7087df738608bf9b7e8a"
     },
     {
       "entityType": "craft",
@@ -50753,7 +50753,7 @@
         "item:renaissance_military_backplate_milanese"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "009dca184b5971bb5bf254dcd88b2ea35f75e903cce67f2cdbb5c8d97e1cf594"
+      "fingerprint": "382cfa42063d4478732133402d35abf7d73d42349ead49ec2241d60277786acb"
     },
     {
       "entityType": "craft",
@@ -50766,7 +50766,7 @@
         "item:renaissance_military_breastplate_milanese"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "14723fbf937f89b483534df5fecd0c9e550f94512285a96de923e318cc7fc2a8"
+      "fingerprint": "975f29dccc03eb34db03b490ceff71bb39e39de3c07c2d80559ecd53980e0130"
     },
     {
       "entityType": "craft",
@@ -50779,7 +50779,7 @@
         "item:renaissance_military_sallet_milanese"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "9043d740583d8acd480889c488215c558c24f62ca392e6d9122aa2f76d3dfae5"
+      "fingerprint": "2e92ba070fa780ded756a6e461ecde68e3d48270588ac9705efab60a152e0d6c"
     },
     {
       "entityType": "craft",
@@ -50792,7 +50792,7 @@
         "item:renaissance_military_dastana_mughal"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7ef558df30c5ebe1a0f5f78361b0df3606f711cb4b6a330801d27074c66d6230"
+      "fingerprint": "045f7046488bf3dec983430e67ba6588f85d4bc7cb8d3b09ab3bb759a59f0c63"
     },
     {
       "entityType": "craft",
@@ -50805,7 +50805,7 @@
         "item:renaissance_military_char_aina_mughal"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "915c973e36d6087dd3868ee59c09f7cc17f9407cddf9312a2ccb14f7b1b0dd0b"
+      "fingerprint": "4a7bbc832349734e6ed21fcffdc2d94f2215354e65ebb230742fc49f9a4ebdb7"
     },
     {
       "entityType": "craft",
@@ -50818,7 +50818,7 @@
         "item:renaissance_military_khula_khud_mughal"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d409e26af3b5ddb76f69d117d7da892fba1e2dfa863a2f5d02e157c9d18834a6"
+      "fingerprint": "ba9a88f3b13ebc9b9d31730a7bc376be9fbd2a307ddf0047aa926292bfcdfb34"
     },
     {
       "entityType": "craft",
@@ -50831,7 +50831,7 @@
         "item:renaissance_military_muscovite_caparison"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a41ec5599ce2c43b8955b55c692759e7a366b65cfbda09acc0d9f4e7b249f7db"
+      "fingerprint": "42117bcce0e29ee9cb4005f6efca577b2da07d88e7ba4da59bf994c232873d17"
     },
     {
       "entityType": "craft",
@@ -50844,7 +50844,7 @@
         "item:renaissance_military_shishak_muscovite"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "451eb7e2d806fbfa304d3bb01bfd0cdbef3d69583ef4d668b65751bd677d2474"
+      "fingerprint": "117863be547e5a8755dd0d9c1acb1eea82f5d8a1395871b48898e57a0c838248"
     },
     {
       "entityType": "craft",
@@ -50857,7 +50857,7 @@
         "item:renaissance_military_bazubands_ottoman"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a5e2f1fba7a5d64741f01fff758fa10e937d2568ef5347f342935e40e40d5dff"
+      "fingerprint": "a01df9e7c92381b6ba9d0ba218498a45f6013782c09e090a4d81ea543edfdd43"
     },
     {
       "entityType": "craft",
@@ -50870,7 +50870,7 @@
         "item:renaissance_military_ottoman_caparison"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "05a914563976235ee9f2974d0b2113c40a46ff2148cd7788d51e308084a36e1c"
+      "fingerprint": "27782c89e38672d89d1a347c642f847b0135e336d1659dab65c2fe4a35c985c0"
     },
     {
       "entityType": "craft",
@@ -50883,7 +50883,7 @@
         "item:renaissance_military_bazubands_safavid"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "23339086f8667a2b20a2f2bc880b6dad8b5bbf5e6c54c258a6da9ac88d3b0de5"
+      "fingerprint": "22bd2d09c168a6e175845b45b809a18305ff577a6f4ded2b2528c84bf27ef4dd"
     },
     {
       "entityType": "craft",
@@ -50896,7 +50896,7 @@
         "item:renaissance_military_char_aina_safavid"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "117e621b947ba65e5ad193403eb76553d01c048829c42980e298a2c7a9833def"
+      "fingerprint": "ef28834fc866962b2951396bd05d72028a7b27cde90edc0240231507cf47c60b"
     },
     {
       "entityType": "craft",
@@ -50909,7 +50909,7 @@
         "item:renaissance_military_safavid_helmet_turban"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "45d6a9dc779dc594cdf9f6bdd6963287354475af823f750a62a29db40c3b2821"
+      "fingerprint": "fc5d5a7248a0f440f872589ab5108d5d714468696198f4cbd9b4697c7ed1c970"
     },
     {
       "entityType": "craft",
@@ -50922,7 +50922,7 @@
         "item:renaissance_furniture_ott_lock_fitted_display_cabinet_05"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "83a4e2d0bada035295b3d5c5458acd91e54b762ee3330e9f6c5a17998c66fa87"
+      "fingerprint": "1de4bdd2e807e0412b519f9c323951ae8eb71d7031884bef445da34ac3b8edd8"
     },
     {
       "entityType": "craft",
@@ -50935,7 +50935,7 @@
         "item:renaissance_furniture_wer_campaign_armour_tree_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "273bb22fe5eed7a299d3db4a6beb98db03d207450d740f19115adc1677f7985f"
+      "fingerprint": "4ab0a3f072858f726954537d6e3c2690ac87f2b4ff54e50362b4bbf866c851e9"
     },
     {
       "entityType": "craft",
@@ -50948,7 +50948,7 @@
         "item:renaissance_furniture_eon_many_drawer_cabinet_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8d3756a449c17946450abae6a2ef7a43bba48416d84447bd8a0fd5d4b7b47456"
+      "fingerprint": "df7c328989e0871648755840d630172631d0211b75b921867ba32943a941b4f7"
     },
     {
       "entityType": "craft",
@@ -50961,7 +50961,7 @@
         "item:renaissance_furniture_col_vessel_display_stand_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "aa60ba5494a86aa598c1358aed32d8f7f98535599456f772a568afdb2ebb8162"
+      "fingerprint": "8d64d0913535479d4401119f377ae4e73384f8c5aa14eb600e21d57fbb3eeec5"
     },
     {
       "entityType": "craft",
@@ -50974,7 +50974,7 @@
         "item:renaissance_furniture_msea_drawer_nightstand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "36a17968ca6b2a92cb5036a591f80a4d863d29d16919b4f45f09aec505e5cddd"
+      "fingerprint": "1c2313cb61087a7d9ef889c4b777fa3aacd9eb03215082858e53d824c7f9104c"
     },
     {
       "entityType": "craft",
@@ -50987,7 +50987,7 @@
         "item:renaissance_furniture_sas_campaign_weapon_rack_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "85c839fc849c7f99980ad23694b59e4ef3c4798b688b3c2cbcbf3dba2b44cf64"
+      "fingerprint": "8691b8973933521969676d81cc6261a9e7501c85e2e7f0281a446b31555a3134"
     },
     {
       "entityType": "craft",
@@ -51000,7 +51000,7 @@
         "item:renaissance_furniture_stp_lock_fitted_weapon_cabinet_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "032ec037d700172e5ccc5a1e2f67d22acdab21e65193b39bf1ee30a4119eb2b2"
+      "fingerprint": "fa190b5039f0d35c588c7c63b94d2fd47c64a8bc1d5e701e04ca47ce729a5c4c"
     },
     {
       "entityType": "craft",
@@ -51013,7 +51013,7 @@
         "item:renaissance_furniture_and_harness_stand_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "52abd4589c396e268ca0d4dab4b15806e63c75540fece5874a81cbe4d9e9a205"
+      "fingerprint": "aa400bc0a87e7d8bde5ffa6407be44b318407a2af4fa82e7977af58c4d79f15a"
     },
     {
       "entityType": "craft",
@@ -51026,7 +51026,7 @@
         "item:renaissance_furniture_nba_bow_rack_04"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "9e64601193b997e7dbdff6c63d397ba4b0d8c1933e6b287feb3a97ff6583e5fe"
+      "fingerprint": "f380ad6d8e0ba1f5da28f687cee57dadcf295504a186c9a0a1fe8d28758f2b88"
     },
     {
       "entityType": "craft",
@@ -51039,7 +51039,7 @@
         "item:renaissance_furniture_mar_cloak_cupboard_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "289c4cc68fa73fcc35cd369105e0eae08bf9f1e117ee7ed562101a2f4f540451"
+      "fingerprint": "a78dc04ef3e1a6ef995c26f515edd040d488d04d3d40b06aa3abded5d6995ad1"
     },
     {
       "entityType": "craft",
@@ -51052,7 +51052,7 @@
         "item:renaissance_furniture_mes_wall_weapon_rack_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "631b09c550c45e2b5cdde9acd2d4dff52db6ddfded1733592b90db1cd8281065"
+      "fingerprint": "6b9ff144338fff49046589aeb183e7c354ca177527182e287cd26e5cb05785c2"
     },
     {
       "entityType": "craft",
@@ -51065,7 +51065,7 @@
         "item:renaissance_furniture_aca_counting_desk_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7261c3bfac2a4559a7e210828297159fa10008c403c8f8a83bc9e57e8781e722"
+      "fingerprint": "45d4a1cbaa32a269b6f64779ee67e9effea66cf17a8de3fd974866ca10aafbc2"
     },
     {
       "entityType": "craft",
@@ -51078,7 +51078,7 @@
         "item:renaissance_military_cuisses_articulated"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "bc1b94036d95c8bfbcdd5c5db8de5badbcbefd2dc7692d4485294162d3bd92fb"
+      "fingerprint": "3dee546588ca9257e2b89dca7dceefe66d505b5d80267840f10669461603bde6"
     },
     {
       "entityType": "craft",
@@ -51091,7 +51091,7 @@
         "item:renaissance_military_articulated_gauntlets"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "00e660bf86202598f51bc7f0b99c7c6d948da1ef6572d48ccbcfe3d95a379049"
+      "fingerprint": "429aed77981e1aea671f0c3fe9507a82e72db88d53c939c128c2ec8b9e4fd64c"
     },
     {
       "entityType": "craft",
@@ -51104,7 +51104,7 @@
         "item:renaissance_furniture_eal_statue_pedestal_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3ccf48d49687fa14c6defe3152140f71913680ac474cf6b86a9b8fc791be815c"
+      "fingerprint": "d2146488f8ac0243ce7731282d3643081fb779c5348714a285e4712d34fe2701"
     },
     {
       "entityType": "craft",
@@ -51117,7 +51117,7 @@
         "item:renaissance_furniture_eal_side_table_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "31828fbd92f614ddea246fed11af3d86545a8495bb83ff088ccad5388c1c1e40"
+      "fingerprint": "3a988877cc5430b93bcd940c4d3d1498ce10e6456c669977544add520d3a670f"
     },
     {
       "entityType": "craft",
@@ -51130,7 +51130,7 @@
         "item:renaissance_furniture_jpn_stepped_plinth_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "319c762038349a79c65ab0e430e259690f8e5c902097f3767717e35300cfd5ef"
+      "fingerprint": "d2d843c3b8e768c83365c48aceab8d28b58ec6a1e71beda325e1309dd41fc151"
     },
     {
       "entityType": "craft",
@@ -51143,7 +51143,7 @@
         "item:renaissance_furniture_nac_wall_cupboard_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2c9873c2f99d78d1cbf889b92be51ad6a8c4de9d18f117347ce451d773cae066"
+      "fingerprint": "c17d0004f87fe1640bd01746c88994b8c0be62f8afd89d92c21199ac6cb44c56"
     },
     {
       "entityType": "craft",
@@ -51156,7 +51156,7 @@
         "item:renaissance_military_artillery_stone_shot_light"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "160fc8b5222f51d0768fb413bccde37949f5082a0de93eb41a54b8725b3a5d39"
+      "fingerprint": "fce73dcf13926e84e1f1d1051d9addd0a5bbc1a01b7cedfd889b30bf06323471"
     },
     {
       "entityType": "craft",
@@ -51169,7 +51169,7 @@
         "item:renaissance_container_stp_trade_locking_trade_coffer_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "9057dbea2b12348be24914ac916caa5558f52e17f47cfaff442535e7ab5f92cb"
+      "fingerprint": "0f1f4450ecfad3cda78d3d7ba71572d7be097de9eb4b7034f4aca6d4dc5508e4"
     },
     {
       "entityType": "craft",
@@ -51182,7 +51182,7 @@
         "item:renaissance_container_nac_trade_fitted_sample_case_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d0d24f923d7ff4508e5f59f1e61b6e205c470c25a7668cd6afb027aeea8f1582"
+      "fingerprint": "d02b1e99ceb0daa8d9d1dc69649c0f1605e1c67662c82f1c64f04074bf2b686f"
     },
     {
       "entityType": "craft",
@@ -51195,7 +51195,7 @@
         "item:renaissance_furniture_eon_counting_desk_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "6358645beee51b8c67bc3d5ea5b04b5ec854110a16505d4cdb7dea5f55bd6c65"
+      "fingerprint": "6f61808516bca2aae0296be02d625ffdabc2ff4d8c384ed285fb95d279524523"
     },
     {
       "entityType": "craft",
@@ -51208,7 +51208,7 @@
         "item:renaissance_domestic_east_asian_literati_serving_tray"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "627cd7209ac8f5f87369bab6c02ba6181b03b680ce49c858f07e084f0f2a8a4b"
+      "fingerprint": "b4f0e5297c1c36b8c3809b2c28977611cab2b079567cd7053907ef2d3def8ee5"
     },
     {
       "entityType": "craft",
@@ -51221,7 +51221,7 @@
         "item:renaissance_military_jousting_grandguard"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "f71aa66d5c7fd838f189bc3c718b364b68b183c400d955309b7844a42a2e5190"
+      "fingerprint": "a90413dccf6b3012ea53dad2aa6b1ca4226c76eccf2bc0360f5037b20b6063c0"
     },
     {
       "entityType": "craft",
@@ -51234,7 +51234,7 @@
         "item:renaissance_art_pattern_book"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7b31863150a02522e76c2840c023564a86222a47da030c674c55b3ff6833576e"
+      "fingerprint": "5ba0fcb97b33da09fa5cb3ab7cdb5dc502bbd48a3838795bd5296fc5e7774c22"
     },
     {
       "entityType": "craft",
@@ -51247,7 +51247,7 @@
         "item:renaissance_container_msea_domestic_condiment_box_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "423ca2434d5349efd0b7ad25e212d3852d39cc7ca5aaee0b518d0163a0007985"
+      "fingerprint": "406d156e70e06f2a19f6df0c7cf16e57709b010fa50d9f843f7743d40712d80c"
     },
     {
       "entityType": "craft",
@@ -51260,7 +51260,7 @@
         "item:renaissance_container_stp_liquid_large_storage_jar_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b2d5bfc6b051d66d3acd184c89752746e975f6bf0da4be3404d1a59b6d742ca5"
+      "fingerprint": "cf28b5b9d896892754d5e38d5a69b0f1fe00adf7b2079803bc74e7d7e697ad52"
     },
     {
       "entityType": "craft",
@@ -51273,7 +51273,7 @@
         "item:renaissance_container_sas_liquid_small_drinking_cup_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "060fd4edaf721190391497e8b687bf1871ac8629e6ed21ade44315ca3813438f"
+      "fingerprint": "49634a0c689920e7bef84fa8996216767bf23d5d622e4c1ed54cef966a687c4e"
     },
     {
       "entityType": "craft",
@@ -51286,7 +51286,7 @@
         "item:renaissance_science_horizontal_sundial"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "517e316ed3fb8274df9cca365121086d020b1e1bea62a8feca1e9321825b2439"
+      "fingerprint": "9686e121d78eeaeddfb7367df2f1bdbcd7eae15ed9598b022a1551e32f00b1e1"
     },
     {
       "entityType": "craft",
@@ -51299,7 +51299,7 @@
         "item:renaissance_container_cen_trade_strong_trade_chest_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "11690045a0d357a98968691c63d2201e7c8168f4b70f99f04ac75e1fda987921"
+      "fingerprint": "c0c1d98f0405ce62285f2f7baca0d7c0b328cc0092d0f53e4435b2acffff6945"
     },
     {
       "entityType": "craft",
@@ -51312,7 +51312,7 @@
         "item:renaissance_container_rse_personal_sample_roll_case_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "4fe5474873520461d19bffc8fdb23fd608d22699af36c2289160b18653a799ce"
+      "fingerprint": "4943458b172922b96afbb6495d9ecff0650485eb82aae410a7eda60ea4836a03"
     },
     {
       "entityType": "craft",
@@ -51325,7 +51325,7 @@
         "item:renaissance_container_mar_trade_sealed_transport_jar_08"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8d2513cf21e6d7cb2b665232dc912aaf99fa8be382fa0bb3e08be33bf244ebfd"
+      "fingerprint": "b3dd94cb4c899a07e4a939042f9e9869913f4df9a7e2a811464c729d6049b0e1"
     },
     {
       "entityType": "craft",
@@ -51338,7 +51338,7 @@
         "item:renaissance_domestic_shipboard_purser_cabin_salt_casket"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3971525d89a92b319d172d68ae4cfee6edf2ac9d0fef098b9cd98e0404c8f81c"
+      "fingerprint": "748fbf3b558160fa151b5df30ef90754ab5e3b3ab9adf6eb88ba32c380c9c51a"
     },
     {
       "entityType": "craft",
@@ -51351,7 +51351,7 @@
         "item:renaissance_furniture_sai_corner_table_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "9d360ee54cb0c4131e1cdb052f60b01cbd58e9ffa9021814b2a9bac30708149c"
+      "fingerprint": "0a316b4fca0f961a7c2340c5ce312073e9a2d9be130f3e50478fe0ff64b9de60"
     },
     {
       "entityType": "craft",
@@ -51364,7 +51364,7 @@
         "item:renaissance_trade_western_counting_house_coin_weight_casket"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2e30369bd2070303858fb2aeccbe174311202bd91eeeb2a7751f5aae9b8f0113"
+      "fingerprint": "2f8c601b33479231a0855c5f986964910e2068032b837a0385f58771140aa9f9"
     },
     {
       "entityType": "craft",
@@ -51377,7 +51377,7 @@
         "item:renaissance_furniture_ott_nightstand_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a180a6fe4508a56f179357d8432b4e5a4f9337e2a4e8d6c9b5e6d127f505373e"
+      "fingerprint": "738d9202b551a291328d9d4ef7615ea185e5d649329a670d6fdc67b00478f038"
     },
     {
       "entityType": "craft",
@@ -51390,7 +51390,7 @@
         "item:renaissance_furniture_pip_curiosity_case_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "938c5dd957d20275dcb7cd234faa49e2f9ef37076c2672740b2a3baa2f2cf313"
+      "fingerprint": "7a4184423645fee4285c0d627fbadb3070a8f848f6848991e61e8cf476f3222c"
     },
     {
       "entityType": "craft",
@@ -51403,7 +51403,7 @@
         "item:renaissance_military_corselet_breast_and_back"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "29d0982a4f56110e3d02ab910d5457993889766b0e60987233d3657fe39e29a9"
+      "fingerprint": "e6a65a85b73168583a2199e8a616bbc80c41adca847c2175cb3031d34a67b90d"
     },
     {
       "entityType": "craft",
@@ -51416,7 +51416,7 @@
         "item:renaissance_military_barding_caparison_brigandine"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c8a9e5a9a1573cd349dde837610ff86aefcae018c7d19459336eeb7036fb6c11"
+      "fingerprint": "58170591ff70500afbf64a3d2c353306709dd0925cdef184392790c301003546"
     },
     {
       "entityType": "craft",
@@ -51429,7 +51429,7 @@
         "item:renaissance_personal_andean_storehouse_carrying_bag"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "875185409ab8bc94a41de41d433fa8f0c8faf3daba688bb02e46a50dd89b4de2"
+      "fingerprint": "386e14ab2a2ed74d16e3b6b9e55ab3c929eaea2c154a48835d2265b7f7781b14"
     },
     {
       "entityType": "craft",
@@ -51442,7 +51442,7 @@
         "item:renaissance_domestic_south_asian_merchant_dining_tray"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "35c151afe77d2cf3de5bddb8be6a8322eb019bb114d292830ce07762f3673428"
+      "fingerprint": "03ffc246058ca2e2082f1821f7c842519fc07ae865f079914f0b43c2f74191bf"
     },
     {
       "entityType": "craft",
@@ -51455,7 +51455,7 @@
         "item:renaissance_domestic_persianate_court_washing_basin"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "898fd60180ca4466e2a0ace7655575eafc1eb5df80ebb4b987d6f35d1b7e7b38"
+      "fingerprint": "ad3db5a766e5f14b67e6fbec82a59c4c63a85e6c5db856365a83d35b18f64680"
     },
     {
       "entityType": "craft",
@@ -51468,7 +51468,7 @@
         "item:renaissance_domestic_urban_kitchen_wash_basin"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e7570ad81815a13582b8f92466f4a6625b1403b77b2b27ccf4f221da4b026f3b"
+      "fingerprint": "6bace93e4c3fbe0c600fd76da4fa8854b438c1e450b989067d08384745157f89"
     },
     {
       "entityType": "craft",
@@ -51481,7 +51481,7 @@
         "item:renaissance_domestic_ottoman_bazaar_brass_tray"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c0ce9f5d2769efd679c4e4b167b9093bb676294f679f0ee373c12e453a9d8404"
+      "fingerprint": "fc6e8a0c8fe8decb35931d9f62a8d12d8c0776c4f8f6e94bb5f915cd7495ab94"
     },
     {
       "entityType": "craft",
@@ -51494,7 +51494,7 @@
         "item:renaissance_northamerican_fur_robe"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8652096c05aea70c0e5735fab7abc361f6546c2bfaa22fd74cf391a634c1a708"
+      "fingerprint": "b60a85242189e7fe90ddda539133b65ef7e86afdbad33cb5944fb15e5d183297"
     },
     {
       "entityType": "craft",
@@ -51507,7 +51507,7 @@
         "item:renaissance_domestic_japanese_ryukyuan_freshwater_jar"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "13dd2cbe0735f46cf2452e3257c525ae81b7722749c32f20686734eeaf9959c2"
+      "fingerprint": "fc2946a1d535ac0f6ac351c37ea86d97b28b006f2415d37cb23b483a309fa01e"
     },
     {
       "entityType": "craft",
@@ -51520,7 +51520,7 @@
         "item:renaissance_domestic_east_asian_literati_storage_jar"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8c6cf45a4fc31600464cadb31352e3901e93094c36cda9fce698fc7ddafc6ee7"
+      "fingerprint": "4c31eab35b9f7b72c5c4be98b0e7d510d8702c9d5c4376355c03c80d7507f206"
     },
     {
       "entityType": "craft",
@@ -51533,7 +51533,7 @@
         "item:renaissance_furniture_ott_helmet_cuirass_stand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "bbca67966290c4c9f9769fa0dd0553881c5e595ad844d5be096b86bb2d1609b9"
+      "fingerprint": "fc271a6e662b090d95ec88e3548e9651c03eece7084ab1059b37c32633b46a3f"
     },
     {
       "entityType": "craft",
@@ -51546,7 +51546,7 @@
         "item:renaissance_domestic_western_counting_house_pewter_plate"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "0f4fc504501249587c1efcf9b6fcff45cfced4698abd4077fa105319183ed6ee"
+      "fingerprint": "bc94a73618de29dbf48b7464307a2cb7f04bbfc4b8dd9e9f4f8a20719180ccc4"
     },
     {
       "entityType": "craft",
@@ -51559,7 +51559,7 @@
         "item:renaissance_domestic_civic_guild_tankard"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1d6618ced8fc279a38fe8aaa04852b7958b0e61a8cfa4a858f4847b4b04b8159"
+      "fingerprint": "b2c089540760b29a795f7bbc07fbcd7b5a0d470c772f2b5a4c8acb5ef558e6eb"
     },
     {
       "entityType": "craft",
@@ -51572,7 +51572,7 @@
         "item:renaissance_domestic_warehouse_dock_ration_tray"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a13d869627f91991cafce1f04a3ad6ca832957ee9eaf35ad50dede10b1c75552"
+      "fingerprint": "b06960a784eb7109dccdea250555b55425da534c4d1e62d467bb5d28ee9d72b8"
     },
     {
       "entityType": "craft",
@@ -51585,7 +51585,7 @@
         "item:renaissance_andean_paired_shouldermantle"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "bd5048336455fa51e7f51619af22e34a46ae1b4e0331ba6b830fc3cb7ce69472"
+      "fingerprint": "b2a7d4fcce0cfb86ae7e379457fa91107dfed965af95a1c771f82d15bae3896e"
     },
     {
       "entityType": "craft",
@@ -51598,7 +51598,7 @@
         "item:renaissance_furniture_stp_apothecary_drawers_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "13fc80103561d0d7d8ec1f7fae91244cbbca3e4acc870dda64cce8d4f03c213c"
+      "fingerprint": "effdf65df9a03785bdf67f6e241a6282c6cff2242190957d02349e353436b5a9"
     },
     {
       "entityType": "craft",
@@ -51611,7 +51611,7 @@
         "item:renaissance_furniture_southeast_asian_port_rattan_shelves"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ab001f37dadc08c13cbc485ccaf46be5852303abb5821f0aebfbe07fd40b2ef6"
+      "fingerprint": "41dd0c10601ad10ec8eed9c4d862cf8ac21204f3d32ad8137ac13dbb38640870"
     },
     {
       "entityType": "craft",
@@ -51624,7 +51624,7 @@
         "item:renaissance_furniture_ott_low_drawer_chest_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e4f6e224d704ef9da3dc1674500aef4bf33388df61f7f4ef4646282991c37e43"
+      "fingerprint": "e9f32b5a71bfdf63072ee862249b7baf3349f0e1b5f41f7988226e105c593a28"
     },
     {
       "entityType": "craft",
@@ -51637,7 +51637,7 @@
         "item:renaissance_personal_tavern_inn_servers_tote"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "cec49c80b8ff36536e2ad0fa9d0fb426bf73fc2d327442532de158d568a2fe16"
+      "fingerprint": "6fa7bb16a6fb38127bba2d5b6606cf01bb4b30ec1f147c386e0f3036f5c2be31"
     },
     {
       "entityType": "craft",
@@ -51650,7 +51650,7 @@
         "item:renaissance_military_rotella_steel"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "909e2171fea5a4d75281e03e3990e0ffe42edfd9a8161e60943c53a2fe0fd416"
+      "fingerprint": "6195476a3cd023ed3a40dcaffd382cbe173dc723992b4337fe675f0460ef0872"
     },
     {
       "entityType": "craft",
@@ -51663,7 +51663,7 @@
         "item:renaissance_furniture_eal_clerks_desk_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "941179482ec27c26b199a0356149766724f22066ffed08a476f5ae5aa9514636"
+      "fingerprint": "808f41cf8a416840609948d50075a4dce5cce275ccea14141551cb562af0b6bb"
     },
     {
       "entityType": "craft",
@@ -51676,7 +51676,7 @@
         "item:renaissance_furniture_western_counting_house_counting_table"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "fbdcad12d95d9c2a45d261fb32dd4ab279b2b0dec653974fe32670a138272f28"
+      "fingerprint": "80aec14a7297523d26fca1e1c452c57df11a224747e912285f39970eb9dcb9fc"
     },
     {
       "entityType": "craft",
@@ -51689,7 +51689,7 @@
         "item:renaissance_domestic_atlantic_contact_cassava_tray"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d2dcaa4a68431401c5fd9a1d15cb146649339b4253a61d40c62bc926d3195f39"
+      "fingerprint": "cdf521a0d0f92dacbae3601371abae5dc5516ca183ef1a7492d38142eecec082"
     },
     {
       "entityType": "craft",
@@ -51702,7 +51702,7 @@
         "item:renaissance_military_halberd_axe_spike"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e4bc0755f9f64b3a3f1721effd558dc498a7fafb5c6aac2df96ab5585a71ef8b"
+      "fingerprint": "2afe2621d66a44743ee7780b82a760a96dbe0dd24971f6ff007a8b5c19880387"
     },
     {
       "entityType": "craft",
@@ -51715,7 +51715,7 @@
         "item:renaissance_military_falconet_bronze"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "0c7f6219a9ff202495f2303533e1ca8f3866cc68c38e06c84b4a518cabfa6e25"
+      "fingerprint": "bea4eb785b5f82149f417c4dce94c27f59f159a3c4583c05d90134d040e338dd"
     },
     {
       "entityType": "craft",
@@ -51728,7 +51728,7 @@
         "item:renaissance_military_paper_cartridge_060"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2b28e3af942e66a98923b7207d7e57f50e44d39d4dc26a30ae74ed63d87a420d"
+      "fingerprint": "54080b233cce41903c93251d2f98357ba282d4cbfc254f13a0abf76a7cd1338f"
     },
     {
       "entityType": "craft",
@@ -51741,7 +51741,7 @@
         "item:renaissance_military_paper_cartridge_075"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "cdb3d545468b0465b7c204ad33450489c619f195c2e0a2e4533ce58aaca1a188"
+      "fingerprint": "60a16c4aaf4a0b8da7fe94a6b58f4972fa83a05b04caad4761d39cbca91e2331"
     },
     {
       "entityType": "craft",
@@ -51754,7 +51754,7 @@
         "item:renaissance_military_paper_cartridge_055"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "dd54769e1a962636bc562a1374b999b99f4909d6fd9f9a7ce5c23178f82bfbee"
+      "fingerprint": "59e17b420ad8368d9622d141ce66576e1504e4f89a831738172806bfac3470c4"
     },
     {
       "entityType": "craft",
@@ -51767,7 +51767,7 @@
         "item:renaissance_container_car_liquid_large_pitcher_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "790a13bd49cea6aa73c279d66429a63fe11b6ff3a9d8b6414d7085c6fb6d41d0"
+      "fingerprint": "e1427cbada1b95b4a1b5012ea327fcbedc6bab4cdd7fea455a122b7ba68d501f"
     },
     {
       "entityType": "craft",
@@ -51780,7 +51780,7 @@
         "item:renaissance_container_rse_liquid_stoppered_flask_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b68adca9e85d785b6fcd92474bd975a837c6979569a77ed90f413ba732cc5a77"
+      "fingerprint": "4551751cc63beab5d5797af1e559e70fd114823098db9f1be76526e6a271cf70"
     },
     {
       "entityType": "craft",
@@ -51793,7 +51793,7 @@
         "item:renaissance_container_car_trade_deep_trade_hamper_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "6f8fac472cfb139d575fa0decd33b2e251f111a1d568ed572d912b077cc31a8a"
+      "fingerprint": "672c8675def599618cc1d6f668053e45b408748086e5a0fa6b2d07ec9f8aacc0"
     },
     {
       "entityType": "craft",
@@ -51806,7 +51806,7 @@
         "item:renaissance_military_artillery_grapeshot_light"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1472bb7ba7af108e5b8a25237b09b0054a51a566eaf6d8de020b858d45f2358d"
+      "fingerprint": "67ae7f612aa0327537c7a44b7ba8a5948b631e90954d98b72d5d877e38c19a5b"
     },
     {
       "entityType": "craft",
@@ -51819,7 +51819,7 @@
         "item:renaissance_furniture_eon_lock_fitted_wardrobe_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "aa2f29b44bea8014067d26a54199642a6bcffa8ffa742bed74232374bc8fc80b"
+      "fingerprint": "391477ca47dd34af00d46d37fec93ecffafebccc6ca9c3587edc79c75717d900"
     },
     {
       "entityType": "craft",
@@ -51832,7 +51832,7 @@
         "item:renaissance_container_eal_domestic_serving_tray_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8651edc39ec219b5df4e4dfd81ba1cf2133ecb773a09cea2e0279ee45522340a"
+      "fingerprint": "2a7605a673269dc34a5fa2467537b53c379fe526dfb21fc950cc8ab57472dcad"
     },
     {
       "entityType": "craft",
@@ -51845,7 +51845,7 @@
         "item:renaissance_furniture_nba_bookcase_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3d237f1afdd7277c6d95da894a105dcc415f8ea4d3f4815827713a2dcb78578d"
+      "fingerprint": "a998f061da677fa35a6715277c30518822c1196ba54a2dafbab3f49148b6a69e"
     },
     {
       "entityType": "craft",
@@ -51858,7 +51858,7 @@
         "item:renaissance_furniture_col_end_table_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "30a1d8e3ffaa70a07a24313d49f73bdeb6599e624e4c4953c06ca38414e35ecf"
+      "fingerprint": "d3a2d1fb8cfc12048705bbfc8bd43ec7c609f9c0a64a0d706e74b32a68f5c0dd"
     },
     {
       "entityType": "craft",
@@ -51871,7 +51871,7 @@
         "item:renaissance_furniture_elite_household_display_credenza"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "35bd4b1f971e014bce6a598ec98dfe67bc824834be05c8233103a24b8591c1cf"
+      "fingerprint": "7cd725c533b666a832dcbeb273ddf0e7539580ba00342c9de363793386c38e71"
     },
     {
       "entityType": "craft",
@@ -51884,7 +51884,7 @@
         "item:renaissance_furniture_wer_end_table_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3758be2bfa85caaf566a5f080cae211d4914256a0a574b9155436e9626f81978"
+      "fingerprint": "3588cef7b9156f296dd425036f53baf057cdbf7982f795b1627cebe1f6cf247e"
     },
     {
       "entityType": "craft",
@@ -51897,7 +51897,7 @@
         "item:renaissance_furniture_wer_lock_fitted_wardrobe_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b0fe3a6173ef148a5d07f05c95aa0f7eb25e6aa9d839788795c4302d43bd1777"
+      "fingerprint": "639b6720b506d86adede9088acb55dbf5fcb77afe06e96885ba7dcaa96a0a668"
     },
     {
       "entityType": "craft",
@@ -51910,7 +51910,7 @@
         "item:renaissance_domestic_west_african_court_brass_bowl"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "18c77912509351c58ef9d18c3de8f80b7639477944fb4c95191e4c3e6db7aee1"
+      "fingerprint": "1e9885e892ce05b025c5add3a123e6136877cee1a068732c91c4eefb0f2db50a"
     },
     {
       "entityType": "craft",
@@ -51923,7 +51923,7 @@
         "item:renaissance_container_iba_liquid_washing_basin_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "52c7acd2ae6fbfe595eed9cbec7ccb2ccb05e27b2509ff22fa2bbf6b9e4563d7"
+      "fingerprint": "2fd1ec0570f634ddee05fe624aff28972c9ab455313513ac39e7adabe55bfe63"
     },
     {
       "entityType": "craft",
@@ -51936,7 +51936,7 @@
         "item:renaissance_military_falcon_cast_iron"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e828619590b782b918637d2fdd800473a4ae1d656ad183c29a251a9b6b88c299"
+      "fingerprint": "639b9d708c56f58bfb9895d03deb1cce826eca3ed623b0f0f511fcdf266cec99"
     },
     {
       "entityType": "craft",
@@ -51949,7 +51949,7 @@
         "item:renaissance_military_burgonet_cheekpieces"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "aff7711b3642bcc078226f41511085424e4aa428dcbb1b475f21204b5b5d03db"
+      "fingerprint": "629ea04a62e9df4d8649c055aa4f57229684fb95e06ec5dc28de6e8b1c661813"
     },
     {
       "entityType": "craft",
@@ -51962,7 +51962,7 @@
         "item:renaissance_container_car_domestic_nested_service_tray_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8e39d8f573124946870356083553fb3baaacc175c2c808da4a7a7abfea8a47e0"
+      "fingerprint": "41a07d4a22449f665886d541de057ac50963e846292c237684c230c00d8f7a3d"
     },
     {
       "entityType": "craft",
@@ -51975,7 +51975,7 @@
         "item:renaissance_container_mes_liquid_washing_basin_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ef6107012ae9dda92df25e3be2bc7df539a48455c03c15afd6d35e10430cfded"
+      "fingerprint": "840a4eeb25c26c24cacbe9154b9627453eaf565421971dbe3554a80afe8f9463"
     },
     {
       "entityType": "craft",
@@ -51988,7 +51988,7 @@
         "item:renaissance_container_and_trade_large_transport_jar_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "74c44814959f2d0b134dc2b7bfc83cc0b228da6f8b6da665cc0a313fe300c6a1"
+      "fingerprint": "b1fe699a3c621b8297eab6b5b84fd084328252ff874ce3a03c24d13546c75969"
     },
     {
       "entityType": "craft",
@@ -52001,7 +52001,7 @@
         "item:renaissance_domestic_elite_household_crystal_goblet"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8f9e4cecf1fe090441806ef9a4859f7d188c1b5fa6cf9fa85261f10e4e85cabb"
+      "fingerprint": "d427565b493ff3ebcb4797672585f51475b78a6f4b3be4f949998e781d20ff3c"
     },
     {
       "entityType": "craft",
@@ -52014,7 +52014,7 @@
         "item:renaissance_domestic_western_counting_house_venetian_beaker"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "48cc6afc9ea7ce26ebecc7adf882be77f3fd8915b2fd1dcc048288ff7ab730b4"
+      "fingerprint": "9481ad4723929e8d4581ed5d486e31b1d945e0342d36f40ed408a87df1f8f492"
     },
     {
       "entityType": "craft",
@@ -52027,7 +52027,7 @@
         "item:renaissance_domestic_andean_storehouse_woven_basket"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "98aaafcd00efcf50b4a9d38f8cd9368e04383b24094f76c499836be56dfe19df"
+      "fingerprint": "750c9f1ec5e9049e7d5834e3e9e0efbb377544a0fbd0c799c32f64081311b813"
     },
     {
       "entityType": "craft",
@@ -52040,7 +52040,7 @@
         "item:renaissance_trade_mesoamerican_market_cacao_market_basket"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7b7d88d04d250053282448578c1bf1442fdf679420cf5b119e6017097b71c11c"
+      "fingerprint": "20dbfed39203f487e7b1cee36ed97d18aad1006839e6353440b638afcc9460b4"
     },
     {
       "entityType": "craft",
@@ -52053,7 +52053,7 @@
         "item:renaissance_domestic_west_african_court_woven_basket"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "f8d6a43891eafb87b65e45b7aa0b735f4395ff278ed8dbb3a8bcd59f684f98f7"
+      "fingerprint": "7b84feab8b7ef5cc98a77278f36f410a8bfb690cf2cc34eef7fd736837cab4a0"
     },
     {
       "entityType": "craft",
@@ -52066,7 +52066,7 @@
         "item:renaissance_container_mar_trade_lidded_trade_basket_04"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d5e733be4c8c1a4f41755d80bd7233c8094c67d20fbcee7fc21709f70a637293"
+      "fingerprint": "52e976dae292595eb477cdfcaf06f68a02cd65f396b98e181754417e1c4d880f"
     },
     {
       "entityType": "craft",
@@ -52079,7 +52079,7 @@
         "item:renaissance_container_iba_personal_shoulder_basket_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d80301b3d8d92f5fec51ac0c0e2bc14a137cc820550bc8aa393a43e34a2aa2bc"
+      "fingerprint": "536a93d83beb770932381a8b5e7641bf9b9a732b9f8a89b263b5d8193a9d813a"
     },
     {
       "entityType": "craft",
@@ -52092,7 +52092,7 @@
         "item:renaissance_furniture_iba_specimen_cabinet_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "60b8691a3bd8eedc32bef7fbf064136e8c345a87e1808eb05858a0911be3a910"
+      "fingerprint": "cfd34810fa7e804fec1b60b5728446460970f3f80342522f54b0982ff46d2765"
     },
     {
       "entityType": "craft",
@@ -52105,7 +52105,7 @@
         "item:renaissance_furniture_wer_coin_drawer_cabinet_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ddfdb028d8f71140aa4dbc4184c01c776d7e067d192c6769fee584aa6c68963f"
+      "fingerprint": "1d65a319e3d20255dc4e981fd039cfcff81e1004935c7d000a990e21d57865ea"
     },
     {
       "entityType": "craft",
@@ -52118,7 +52118,7 @@
         "item:renaissance_navigation_sounding_line"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "af5d71f0007fab0e73c021ebdc6adfd0d2e6c340047cac653676273fe965c6a1"
+      "fingerprint": "bba813c225de59e59386c73b502dc00f9a1edcad6f8c6df314f79ecb17189bf6"
     },
     {
       "entityType": "craft",
@@ -52131,7 +52131,7 @@
         "item:renaissance_military_morion_combed"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "57246395096ef2b6ad188ebfa5455e6aacdd35cc5392addfcb97a989a0fe6b22"
+      "fingerprint": "d1dea32084ebb384b1e99ef142f28036b8c62e7d65f732ce5cdfa65e3b0a35f0"
     },
     {
       "entityType": "craft",
@@ -52144,7 +52144,7 @@
         "item:renaissance_furniture_rse_travelling_wardrobe_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "6f3ce3e58571f53456fadec6951e0d86b643705b2094e7ee66509b7a77cfe822"
+      "fingerprint": "029bebd5c9933dee9ab357951fa28458239c9a00fecff47e0ede967473b9b25c"
     },
     {
       "entityType": "craft",
@@ -52157,7 +52157,7 @@
         "item:renaissance_furniture_sas_travelling_wardrobe_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "627dc74af54952e7040238edb8911302c16a4d97f68decddb6f0f6fe60d85ed8"
+      "fingerprint": "59a752c917b8655d4448004ce61e6ca0d274797b2883825bfe43a31e58f098d8"
     },
     {
       "entityType": "craft",
@@ -52170,7 +52170,7 @@
         "item:renaissance_trade_apothecary_perfumer_dispensary_till_chest"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1a689d19ea4be7715bac8b6ed44101528c09e136b4960c03a0c30313afc899e6"
+      "fingerprint": "00585e427fcdaea9191aeb15aa2e0a0e8be23afcb176691d18cc07ec868bb5c7"
     },
     {
       "entityType": "craft",
@@ -52183,7 +52183,7 @@
         "item:renaissance_furniture_iba_tall_wardrobe_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "bf083977f55a7e138e10c7ba79a50c2017901ce606b9ebc43827c8e5bd79f839"
+      "fingerprint": "ceac55aa268013d88bdfa015521a7cdf0464f9007e6b42527dafb6af71812b6f"
     },
     {
       "entityType": "craft",
@@ -52196,7 +52196,7 @@
         "item:renaissance_furniture_msea_folding_display_stand_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "65d8ebcb61caa1b18a48c05b2cd3de02cd8a904df7bf67e46f1190ee25980000"
+      "fingerprint": "3bfaf6662236dbde6c935bf3f738c5afbd739bdf32976a297b16fc8c51cb1e37"
     },
     {
       "entityType": "craft",
@@ -52209,7 +52209,7 @@
         "item:renaissance_furniture_mea_folding_display_stand_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3a3e06be86f71d58574c52331180b5461907737a69d1016fc742b8cd032cb3ab"
+      "fingerprint": "ff2d76fecb6e79c9ae1e84f044efba2f59e5ad3a615e6bb0ff41fe94da042972"
     },
     {
       "entityType": "craft",
@@ -52222,7 +52222,7 @@
         "item:renaissance_furniture_nac_lamp_table_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8e8fe30a810563948715dbd17973d042d44da39288769b30e04060ee1755e643"
+      "fingerprint": "9f645366b4a06c06571f000d34f9443c9211b2008e478fd83fed17b7f1a2a968"
     },
     {
       "entityType": "craft",
@@ -52235,7 +52235,7 @@
         "item:renaissance_furniture_rse_campaign_desk_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8aa05064757b82bfb4edbe174737d2fa8c8af8103e19bdaae231ae6764085586"
+      "fingerprint": "0c829fb3f8f0ebed4acce6666aa70d35d2736706371a7cda61a90ce210dd2e59"
     },
     {
       "entityType": "craft",
@@ -52248,7 +52248,7 @@
         "item:renaissance_furniture_ott_coin_drawer_cabinet_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "bdc14a9adb453c3ec720c1235125f2896aa6dd0e4d1f39a09118a21d3e241000"
+      "fingerprint": "e8cc3822d40aa31d7ec03aa64f05e2c7bc93a6e7e0ac0a9b10ebd55e88d26740"
     },
     {
       "entityType": "craft",
@@ -52261,7 +52261,7 @@
         "item:renaissance_furniture_sem_statue_pedestal_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "5f48aab3968cb198c1dba94e2f4eb431bcef7f033d0ccdb0e7b5f5a787d48e02"
+      "fingerprint": "c873611b92d483d56d282b5cc2b7cdfbe7f815a61cdd318de35ce0f7bcc5bd1f"
     },
     {
       "entityType": "craft",
@@ -52274,7 +52274,7 @@
         "item:renaissance_furniture_aca_lamp_table_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "942bbd3a845e19f82e9f70d6437d9cc70692a8a78f689ef4fe7cf1d452b775c4"
+      "fingerprint": "04cdd3eaed5ba3870fa336e743e965547491ab9bbf08806292f244433e6f7ac6"
     },
     {
       "entityType": "craft",
@@ -52287,7 +52287,7 @@
         "item:renaissance_furniture_ott_crossbow_rack_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "6b94cf563213aca7e6a83aa464a417362bdd9058aecbe3345372e77b0f4d3312"
+      "fingerprint": "1f97f4c0b9c6e0b0377477c8f83f7ccfedb581f322d5f473dc15758c27f49e1c"
     },
     {
       "entityType": "craft",
@@ -52300,7 +52300,7 @@
         "item:renaissance_furniture_ind_statue_pedestal_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "818d64cfc96ed7cb8bd7b2decba6643910ffbcc5e35c87b19bfac649498c9346"
+      "fingerprint": "813baba5708c2894c1a7be64027b921d832e48f688d5b18ab42b0435f0dc95bc"
     },
     {
       "entityType": "craft",
@@ -52313,7 +52313,7 @@
         "item:renaissance_furniture_ott_lock_fitted_weapon_cabinet_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "901768430ce94f9f51c7bf5307cdc2d24a36924f9610cc068a57a16757d4e417"
+      "fingerprint": "79c82942674a38cb76fe9c6e6b3eb2c9d5fc7b3e6956ac3319ff22b83b82eeb1"
     },
     {
       "entityType": "craft",
@@ -52326,7 +52326,7 @@
         "item:renaissance_furniture_ott_robe_cabinet_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "addc0c22de397423452342309b2f6acdf1203eee76fc6348f303c04f9863abcd"
+      "fingerprint": "91fa55146c1740a3b18bdeb5617b9a7e6333d54d0143f0ce64dfae76159c7945"
     },
     {
       "entityType": "craft",
@@ -52339,7 +52339,7 @@
         "item:renaissance_furniture_ind_mail_stand_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "aa1f1ed962bc983acf3e1c7297e16b5949502c95a15db38b08b2d130215370b0"
+      "fingerprint": "82b37201bd9ac30cff3078cb184108437c8acb4a27d69632077be3896e2542b4"
     },
     {
       "entityType": "craft",
@@ -52352,7 +52352,7 @@
         "item:renaissance_domestic_western_counting_house_merchant_salt_box"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "87469c067c6f3c4ad14c64767766df744ff34901a0ddead6fce9dd137f4f73bb"
+      "fingerprint": "17064195be0b71a29eaa571f9acb435883b427a029453bb7183cc85e0e06190a"
     },
     {
       "entityType": "craft",
@@ -52365,7 +52365,7 @@
         "item:renaissance_container_pip_trade_sealable_archive_coffer_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8e850647b4dcbd258be365f4260bf57477a0176f090946a14921bc2eda511a5f"
+      "fingerprint": "df689d6c9deea65f25cd9708947c3373a8aa45fc742bbb450b6d80eb6201502d"
     },
     {
       "entityType": "craft",
@@ -52378,7 +52378,7 @@
         "item:renaissance_container_pip_domestic_condiment_box_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d24181030f02b979156523e80b793e2effc0f2cc2359e82d5a386877740aa15f"
+      "fingerprint": "9375ba93875ee0168a8c0853485e46b8caa30f67065c9d17132d4e76cadbde6c"
     },
     {
       "entityType": "craft",
@@ -52391,7 +52391,7 @@
         "item:renaissance_container_stp_liquid_small_drinking_cup_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "5804dbfaac8571a29746113ed87e061811714c0f5b1d4f64483107ddb5d6092e"
+      "fingerprint": "52f0f2132ea018135a4f96d98f0f3de8902f8404c473672d9551d9171b823c00"
     },
     {
       "entityType": "craft",
@@ -52404,7 +52404,7 @@
         "item:renaissance_container_wer_personal_fitted_belt_case_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c7d96acea712834809fb2ca7192abbd903f086020eff0ceee6e0f9234b6ee895"
+      "fingerprint": "e4cfaa4e1ab5fa62237b0d74c17ad5bcc22b1bbc9f9b57df25ca76503be5903c"
     },
     {
       "entityType": "craft",
@@ -52417,7 +52417,7 @@
         "item:renaissance_container_ott_liquid_great_storage_vat_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3617d34df2ab42beb50a36257a2aa9678944506c446c38ddcfd5793fec813e37"
+      "fingerprint": "293a73de0de7b1bd6d1dd54bcd3d3dfbce46e62372293685f4ba298bcab977af"
     },
     {
       "entityType": "craft",
@@ -52430,7 +52430,7 @@
         "item:renaissance_container_nba_trade_strong_trade_chest_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "87918129873e85a833d6e697025f20a40591b6b12b0126f7c1a97392b1129a67"
+      "fingerprint": "37d1c94aa499931ba14710d881ea8be8242fd3662ab406220710f0b59717627e"
     },
     {
       "entityType": "craft",
@@ -52443,7 +52443,7 @@
         "item:renaissance_container_sem_trade_large_transport_jar_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "04e625ff0b38892ce8bf4fe0aa1ffa4c6cc388e19b434816de5c244e88ffbfc3"
+      "fingerprint": "5b3ef09f9295921e267638e8595135d09a443e58d3d9808895a7e8dfcf8ea145"
     },
     {
       "entityType": "craft",
@@ -52456,7 +52456,7 @@
         "item:renaissance_container_cef_trade_strong_trade_chest_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "4a7088955f2b2d8b2c0cc9be03232bb28e966b15bef0195e72ce3704c8ae8c9b"
+      "fingerprint": "7bb15d45379eef9c66e889bd7f39933b0e01768412062b1578b256af88045517"
     },
     {
       "entityType": "craft",
@@ -52469,7 +52469,7 @@
         "item:renaissance_container_col_liquid_large_storage_jar_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8597bc88ee1aaa8f9dad5969d733e47dd88eb66d233b61a281de09cf23f5a21f"
+      "fingerprint": "eb08f9ea787948d7e0ff41ad8fb45f0303963b97feb91cbcee2f072add933b76"
     },
     {
       "entityType": "craft",
@@ -52482,7 +52482,7 @@
         "item:renaissance_military_artillery_shot_one_pound"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8bd5f439bc44ea75402afd5ab654505a2215086a7e69350a8ec2738e4d23c76a"
+      "fingerprint": "03e0970c13b39f052742da91ef9d3033dd467c58b64a8a8e3f1e610f0361a706"
     },
     {
       "entityType": "craft",
@@ -52495,7 +52495,7 @@
         "item:renaissance_military_artillery_shot_six_pound"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "cc62d051033d2874ceca75b743d06799b78a4b212f18dde0d05ee64d4bbdc6f0"
+      "fingerprint": "d0256dc7e2bba377326a60cde1ab604dcfa67e1a093856ea52e11adea460f2ea"
     },
     {
       "entityType": "craft",
@@ -52508,7 +52508,7 @@
         "item:renaissance_military_artillery_shot_three_pound"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "58278a9a18448916b06e2478f03c3a26023ee0ccc3d24d8aaa38f1d71f82432b"
+      "fingerprint": "faae7a138cdfda83c5ff071ec3858a86587502091c87968e29e014a237b49021"
     },
     {
       "entityType": "craft",
@@ -52521,7 +52521,7 @@
         "item:renaissance_military_shishak_polish"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "5b5253caff381b8a6ffc21b226f0f7eb6cebc23a2727c3135bd4b7b0f7266966"
+      "fingerprint": "a867d3ecfc3682ee8caacd48af2b335c65bcdb4c6832a6d28b9b75365362f5a4"
     },
     {
       "entityType": "craft",
@@ -52534,7 +52534,7 @@
         "item:renaissance_container_ott_personal_fitted_belt_case_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "cf2866f2fd72cfbf9e15884ee458db18690f56490f3c84c0e92c5e665803fe53"
+      "fingerprint": "9ec74480bd8184cb942c411f9147c4765bc1373238e3528b9272455cd63e77f3"
     },
     {
       "entityType": "craft",
@@ -52547,7 +52547,7 @@
         "item:renaissance_container_mea_liquid_great_storage_vat_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8e3dfdd7e144fe06fd70e8aa4ace371e5e8a447e9da85c289c872ac9af1eae36"
+      "fingerprint": "0a416e9a581dbe56faf9761776a034f4079d3e3b9a15726fa1f77a8d66950944"
     },
     {
       "entityType": "craft",
@@ -52560,7 +52560,7 @@
         "item:renaissance_domestic_south_asian_merchant_rice_bowl"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "9717b594b6c268bdb183df907c52748d1d70fb94f0812887145744557c277086"
+      "fingerprint": "4aa777a4cf22897cd42a1bfbd206626a6b2e213f3c58073e877cf84cba9060c4"
     },
     {
       "entityType": "craft",
@@ -52573,7 +52573,7 @@
         "item:renaissance_furniture_col_chest_of_drawers_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "9da27f5d2347955ad44bd67aca0bf6236859e46b47e77b42b5cde3f3e621371f"
+      "fingerprint": "26d0936aba22f6f6503e25826bbdb2190dc33c072b754df9451d313661c99a32"
     },
     {
       "entityType": "craft",
@@ -52586,7 +52586,7 @@
         "item:renaissance_trade_andean_storehouse_maize_store_basket"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7df00affee40ab72992d9e0bbf23f583f283fab2ba68c138da0cc8a160b7fc5c"
+      "fingerprint": "9fcde7fccb7434b8bf14c7bb7706f83f970ecc4beab652f52824a1c2d88e9ab3"
     },
     {
       "entityType": "craft",
@@ -52599,7 +52599,7 @@
         "item:renaissance_furniture_msea_hanging_cabinet_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "65d9a3e4b2ba3bf389eda2fcb742421b5c7f5dbb15a0fbe85b76043b7e919715"
+      "fingerprint": "3981b9cbdb037fc45f61f902b74ac47b2183e272e84c8b8a8fa54877c8b788bf"
     },
     {
       "entityType": "craft",
@@ -52612,7 +52612,7 @@
         "item:renaissance_furniture_msea_folding_display_stand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "6be7d2e30ce583ce1b37f4172aeade812f6149778d9f70353570752a8fc03cde"
+      "fingerprint": "95ca4018db527cb2d5ebf7d28e0d921c7e9060139a9cf95b486bb4a7bcfd12c8"
     },
     {
       "entityType": "craft",
@@ -52625,7 +52625,7 @@
         "item:renaissance_furniture_cef_tall_wardrobe_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "890eca9281feb5ca265a8e3ad192e58bdd18ad3bff8c07d38641156d2ada94fe"
+      "fingerprint": "1f2d1205c0f6997c53de0deb026ec67c48d3e4e49008cbf8f22e31b8ed663544"
     },
     {
       "entityType": "craft",
@@ -52638,7 +52638,7 @@
         "item:renaissance_domestic_shipboard_purser_mess_bowl"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "86eac52b76ceb949bdc95e26009908125ef9fc17cd639a244be5774e869e150e"
+      "fingerprint": "b3191f637124c5c7257db7512a1e9a536d0dac1c908ff4af818a86be84ba0d4d"
     },
     {
       "entityType": "craft",
@@ -52651,7 +52651,7 @@
         "item:renaissance_furniture_car_vessel_display_stand_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "30e7735bed376c977f0193f7b100bd42b13266c3a953cf5012817c5b305c7c94"
+      "fingerprint": "abd5849985ed1e15406ac415a2cd1fe1570671c634bbcbb4749bd0d9d12c2f96"
     },
     {
       "entityType": "craft",
@@ -52664,7 +52664,7 @@
         "item:renaissance_domestic_southeast_asian_port_lacquer_bowl"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "f5865d3b054ce05402e1629b3ca7a76b6261c496066d9f0dc31badd699f40431"
+      "fingerprint": "aa013562110bdbdd0d7e8b988db647454d9d93881f16484d15fb51b74784b742"
     },
     {
       "entityType": "craft",
@@ -52677,7 +52677,7 @@
         "item:renaissance_domestic_japanese_ryukyuan_lacquer_bowl"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3413fadfd446e497401353f8bcf52374972f990b4c23d0cc1356863bad930aa2"
+      "fingerprint": "0a8096be42670988a561fb344ff90d0bfbce1ecd359c5218afa6c64a37dc8ee0"
     },
     {
       "entityType": "craft",
@@ -52690,7 +52690,7 @@
         "item:renaissance_furniture_mes_lamp_table_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a08b8d3cadcf509c042aaa6f43245707c59e1b272de13d8edb7e877138030dca"
+      "fingerprint": "34803e6d0849a2e4e48177c9cc12963ef00f2220dc00e15292c0b6865948c031"
     },
     {
       "entityType": "craft",
@@ -52703,7 +52703,7 @@
         "item:renaissance_furniture_mes_helmet_cuirass_stand_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7f13bd6bc5545ccbc82b86f95c22aeabf7c0312fc8108804e607bcad4c4fc74b"
+      "fingerprint": "d6f607b03a5d288d27fdc74682333bcfa1bbf4df7087b8d2b4f6594272c23b76"
     },
     {
       "entityType": "craft",
@@ -52716,7 +52716,7 @@
         "item:renaissance_domestic_civic_guild_communal_bowl"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "f12c7b55f115bb06cc092570de60d5052466bb3e8bd076e62a6468dfbd334002"
+      "fingerprint": "6d8c19ddcfe0a85294699280c1f10fe723f60f6c6c4447f92cdd25e2425ca7c3"
     },
     {
       "entityType": "craft",
@@ -52729,7 +52729,7 @@
         "item:renaissance_domestic_japanese_ryukyuan_tea_bowl"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "37ba371a5c30b2b118f601d84930c4ce8321935d8d2746d0027c1a23a6f09414"
+      "fingerprint": "58b792d17657fa4dd1eefa4f43894acf66c17d1184a94b5b97a4663f96866e8a"
     },
     {
       "entityType": "craft",
@@ -52742,7 +52742,7 @@
         "item:renaissance_personal_warehouse_dock_porter_back_basket"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "bbf8bdb5c96e7cb0085eaedb54a8d69dd5b883ea76b3ff73b0c803f9dd0cf3d6"
+      "fingerprint": "2c5c1dc35e503fc5bdbed70fb80860fffd082aa064a7d89dd96f96dcd7721c72"
     },
     {
       "entityType": "craft",
@@ -52755,7 +52755,7 @@
         "item:renaissance_furniture_car_archive_bookcase_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "14c5dcd805d370303e4dca2e80d4aa56049d351d3fc70c81edf697e5cee1cb22"
+      "fingerprint": "64e1f263b7a3ea287681772f82b70a8d4b27971e2b77798b90d2bbeec04cb434"
     },
     {
       "entityType": "craft",
@@ -52768,7 +52768,7 @@
         "item:renaissance_furniture_sem_display_plinth_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "6c0fb2b611a0533e4772f36be3ac00fae1842b8b55c7ecaa04d2a2de7a56b511"
+      "fingerprint": "eb3151a94e3707c23fea4c6d21f78affefd5672ae6bd6273395c175aedca6383"
     },
     {
       "entityType": "craft",
@@ -52781,7 +52781,7 @@
         "item:renaissance_furniture_aca_lock_fitted_desk_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8bc37b03f63a76e2ddd545575ab7024a4e16d0bdb9e7b9fc0ef61cbc6fb4f8ed"
+      "fingerprint": "657cf6efe5bf0c1382d18655469bc19dadd5131f712a5cfa06e138c159512e85"
     },
     {
       "entityType": "craft",
@@ -52794,7 +52794,7 @@
         "item:renaissance_furniture_and_lattice_display_cabinet_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "4b75d74c8c9dfb604c7a68347519315136a93e0ac8537cd9cc1d247a42bd996c"
+      "fingerprint": "dd7bd908f4f4061e4a1043d62986a2986748d382be4fc891d6c5dbe8a0726beb"
     },
     {
       "entityType": "craft",
@@ -52807,7 +52807,7 @@
         "item:renaissance_furniture_aca_lock_fitted_cupboard_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "4728d36c4ca0145815893d82787f03e1c4aa3cc858345e42580d309940ac2817"
+      "fingerprint": "311084b73f5d5e1b5c1e6256c4185d7f7c721afc08f5d2c2513d8c019ada1885"
     },
     {
       "entityType": "craft",
@@ -52820,7 +52820,7 @@
         "item:renaissance_military_talwar_disc_pommel"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "802c3a0d273ec7a972b606013ba0c9fe82014c8f6a676adede8f05e97e51a77e"
+      "fingerprint": "e403a9901e859bc187807167ba1801a8cef351b84f613d3513dc1331582df3c1"
     },
     {
       "entityType": "craft",
@@ -52833,7 +52833,7 @@
         "item:renaissance_trade_tavern_inn_gaming_stakes_box"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2a8f85340c7a94613254c8e2703a73e69d6c3c641d9fa5ace98ac746114aca96"
+      "fingerprint": "b67fbb3c8e8182de7df6cca3faf2bc38a6f7cc2aaf70c79c648e7586024b8d95"
     },
     {
       "entityType": "craft",
@@ -52846,7 +52846,7 @@
         "item:renaissance_trade_persianate_court_scent_sample_box"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "62ed578f95f8ac7c991d5eb7acef3fee1c0f89559a906ac4a3b0cf00b0f767a9"
+      "fingerprint": "dcf932722ac18abf469e85b36a9dd2df6a00b79351337dd5b4fb93ce7f967794"
     },
     {
       "entityType": "craft",
@@ -52859,7 +52859,7 @@
         "item:renaissance_trade_east_asian_literati_seal_chop_box"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a459f2d57601b59f25bc32c64d2aec270447bed648fbb6201879b9158abc6a22"
+      "fingerprint": "67d10c78b76859e09d781c6b02f3d9bf088dae66bf59d34e99eee079aaebb204"
     },
     {
       "entityType": "craft",
@@ -52872,7 +52872,7 @@
         "item:renaissance_furniture_elite_household_glass_display_cabinet"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d79b1e8e6c37190c1f1bcb91d537bc16fe11c66789134d0c2337dc5b1f6413af"
+      "fingerprint": "71f02c552a4c4a7f3b87074f75960d1fccf4fa040cc05b1b794773b22f818641"
     },
     {
       "entityType": "craft",
@@ -52885,7 +52885,7 @@
         "item:renaissance_container_aca_trade_locking_trade_coffer_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "cc836e8dbb8a4496265ab998344beb1c35bc62dbfd25d52a6e2069e97e413cc6"
+      "fingerprint": "0ab30ff12c3fbff5005e45568f3d5760e2fb5d4b1f945a8aa94ebb1786d4f801"
     },
     {
       "entityType": "craft",
@@ -52898,7 +52898,7 @@
         "item:renaissance_domestic_persianate_court_engraved_ewer"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3823fbb7446799f7fab0d6936f33d26fed581c81181198b14f438a1ed6422841"
+      "fingerprint": "576c5984943a186cab92bf7eab15e13b427aeb15278ea46345bc65667c6d8500"
     },
     {
       "entityType": "craft",
@@ -52911,7 +52911,7 @@
         "item:renaissance_military_faulded_cuirass_german"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "07eb967a260660ff9040196bdd5297c0547b7caebbd4e067ea0fac63d466dcc0"
+      "fingerprint": "4892713861488d432d61dd58980f5853b7b007d3f14faafdfaf542f6425e7085"
     },
     {
       "entityType": "craft",
@@ -52924,7 +52924,7 @@
         "item:renaissance_persianate_flared_skirt_coat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1d96fe70220800659c59e298d60dbf0db363fc11202b2db62e0b095607c72341"
+      "fingerprint": "515ded56feb52c445a8abb4b9bf0279fa492b04d27f9fe95833f63acd4ad6b77"
     },
     {
       "entityType": "craft",
@@ -52937,7 +52937,7 @@
         "item:renaissance_trade_south_asian_merchant_balance_weight_box"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "494a48990f270c491a53ea396b4f7aaa68f8d19e7ab556ccac92e931b8af883c"
+      "fingerprint": "4707f6eec52f21c922758a64304396cf1ba30415f8e5661b7b9b2ec520ed320a"
     },
     {
       "entityType": "craft",
@@ -52950,7 +52950,7 @@
         "item:renaissance_personal_ottoman_bazaar_scent_flask_case"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "858cae84dab9833096aed21da9d1dc6e4399a8e28548f6eb9c4d433ddcb23f13"
+      "fingerprint": "df15cd85c280a37618636a1ce99d0214f3c5acfb7c1d727490199d6f8d2ce54b"
     },
     {
       "entityType": "craft",
@@ -52963,7 +52963,7 @@
         "item:renaissance_trade_western_counting_house_cloth_sample_case"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "78eccfe13c8a5e855d51f2c490ae1cf60c29a32510b6e84cfc3e47f65dd93e99"
+      "fingerprint": "856e8291ee7f35124806edd619ad29b5d281a0bf1842cadda1384647e41c068f"
     },
     {
       "entityType": "craft",
@@ -52976,7 +52976,7 @@
         "item:renaissance_trade_urban_kitchen_spice_measure_box"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "59e65f46d0a219dd367a3f6cdffc9f7dfe5cf5fd4986977d3222b31878b2d0d6"
+      "fingerprint": "2111b4636b3bbb14a5b9fa52d7ce5c33fa68dce3fe1348cc20509a1cc4c38758"
     },
     {
       "entityType": "craft",
@@ -52989,7 +52989,7 @@
         "item:renaissance_personal_andean_storehouse_quipu_satchel"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3b509a4e518fc498a4693542891b4464bb70b868279141a0ab14a44d9687aa7f"
+      "fingerprint": "cce3b287350342968e5389b7362d8c5a59e369f2bb642561882fe0f4dec44ca3"
     },
     {
       "entityType": "craft",
@@ -53002,7 +53002,7 @@
         "item:renaissance_personal_persianate_court_perfume_case"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "4f83d36c6b5f340e1aa25c2354ad8f05bb0f106bd203ca0b270ef9064d76b69f"
+      "fingerprint": "b31d1701ffa9b218757685513e2b4401845a3a93bf864a281c1cd77bb522b7b1"
     },
     {
       "entityType": "craft",
@@ -53015,7 +53015,7 @@
         "item:renaissance_trade_elite_household_silver_service_coffer"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ac31e32d6bcd153f637eb8dff33033578f5d516f3d2a08357abb67bf5b788b33"
+      "fingerprint": "c11e74f8ee792f0d4df64254f61ed68b3737480ff2229cb948500eb7aaa4a2be"
     },
     {
       "entityType": "craft",
@@ -53028,7 +53028,7 @@
         "item:renaissance_trade_civic_guild_standard_weight_box"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "9bd715c1b5cc9ea95f662ec5583bad52483bad3c19a40d30fa08270fa10b17cb"
+      "fingerprint": "bdbc44e65d70cafd482b4e5354b3081037abfd22613de043e917167dc6ce52dc"
     },
     {
       "entityType": "craft",
@@ -53041,7 +53041,7 @@
         "item:renaissance_furniture_ottoman_bazaar_dye_mixing_vat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "f0004e5b851dc5b77abc425ecf70f365c8c321a480f779ae8b644981d78f9a75"
+      "fingerprint": "d97e8be088ee7bb94447bbfd8c14596faa05c2eaa8cd94d3d0719139a2d45e70"
     },
     {
       "entityType": "craft",
@@ -53054,7 +53054,7 @@
         "item:renaissance_furniture_apothecary_perfumer_maceration_vat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8e5adc043322609d023285b9f83f4f20f87c6e4b9f2566d927e72464194969c2"
+      "fingerprint": "8c6adfffa51c7b117a72030e13e78cc3faa33587d9dc40f075ceb259974b560e"
     },
     {
       "entityType": "craft",
@@ -53067,7 +53067,7 @@
         "item:renaissance_furniture_persianate_court_perfume_preparation_vat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2379745ab061900f5ed06d6528cd6f34d4a95525c0878960d65bc31c36d6d03a"
+      "fingerprint": "cd3aa887991166546d5bb326416f6ca471f6f2abcb785ebd7c45e9b9282b81e2"
     },
     {
       "entityType": "craft",
@@ -53080,7 +53080,7 @@
         "item:renaissance_furniture_urban_kitchen_flour_meal_bin"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c189a09cae98c838274192711c556db0af5c3658221287364ced9dec3e6e6bc5"
+      "fingerprint": "bca5a94f3a3858a59347dff63d5eaba7a097a951bc1915087bf29b51af14dc6c"
     },
     {
       "entityType": "craft",
@@ -53093,7 +53093,7 @@
         "item:renaissance_furniture_sahel_redsea_indianocean_water_storage_vat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2b083c6ee8d42df9321c78d7aeb2cbff4479a0d74b5bfc718666414b64ce7685"
+      "fingerprint": "963bc8721bc9e16019af605221810416d234cf01581c4546609e23785b17a443"
     },
     {
       "entityType": "craft",
@@ -53106,7 +53106,7 @@
         "item:renaissance_military_turban_helmet_ottoman"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ade632f05b4ae072892354dec95b2593a60f14d7f3169b93a39f334daf064ac5"
+      "fingerprint": "930e2b7ddd98e80c2230c23857c9498a32168ecf4b7c71a71058e0bbb3f2ebc5"
     },
     {
       "entityType": "craft",
@@ -53119,7 +53119,7 @@
         "item:renaissance_military_cuirass_fluted_parade"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7b68aa8171f10a098d0326bb9d111764b3ca3f654cb44b7d0e12b440f89cebe8"
+      "fingerprint": "1649137f48d30b4cdbb8824e8e85cd8c2d30ebe09faa636733a0a83d9ff50d5b"
     },
     {
       "entityType": "craft",
@@ -53132,7 +53132,7 @@
         "item:renaissance_military_vambraces_fluted"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "807b776feaf70103cd7c60e80cb9544c2fd3269bd5d02fda5f3df4cbe8cce300"
+      "fingerprint": "2a10c5eca66fdbcb88eb97d84ea3f824485e89c174582277c5f7bb58720b2e00"
     },
     {
       "entityType": "craft",
@@ -53145,7 +53145,7 @@
         "item:renaissance_personal_apothecary_perfumer_formula_wallet"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d2586ee9f791c96dcfcad91dfbd69a037a2f738011316eb6cc79719cb7be13fc"
+      "fingerprint": "b7efe76e8e4f77be9778f51b5e2a9e1b5c4c0b91f482927a18db53e612bedea7"
     },
     {
       "entityType": "craft",
@@ -53158,7 +53158,7 @@
         "item:renaissance_science_sector_rule"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a0601a2c09f6f6a758826c8b517af5ed2ae05d4bc15f73cd24bf89f4c528c02e"
+      "fingerprint": "41c723623f41d67ab6b1ab954b83ad2af72f65ecfaeefc3feaa178b57f3a4982"
     },
     {
       "entityType": "craft",
@@ -53171,7 +53171,7 @@
         "item:renaissance_andean_fringed_camelidshawl"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "112d94c52b1a009253df25b63faa21961c5dfe4571fb7772ae830188368ac6d7"
+      "fingerprint": "9bc4d39ae224cad6ec034e08ac5dbec01e021edb5ccd7d88e346d48fcefe8626"
     },
     {
       "entityType": "craft",
@@ -53184,7 +53184,7 @@
         "item:renaissance_military_tournament_helm_frogmouth"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b73623008a4331d801d3f6f24c49dd3039a2ed93029036cded5742036deb8e70"
+      "fingerprint": "3506905de03425d1428598dac1e25968a1b3eb666e7d2803483de6069a939903"
     },
     {
       "entityType": "craft",
@@ -53197,7 +53197,7 @@
         "item:renaissance_ottoman_full_outdoor_overrobe"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7c010c35364a169cf6b3697b67bda3e24b09074af559255716dadcde9a075b76"
+      "fingerprint": "622f8ebe90ef5368960e5679886c7d140c36b67204961e0666b7b5a89c96f8ee"
     },
     {
       "entityType": "craft",
@@ -53210,7 +53210,7 @@
         "item:renaissance_frontier_muscovite_long_caftan"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b3113a30e2ebe21fe0ebf17d836e713fdccc2f3163f749d60fc84823ae54e6fe"
+      "fingerprint": "114adeb899a545f092efc833802971046b20a37c63ae357ff88976401931f0b1"
     },
     {
       "entityType": "craft",
@@ -53223,7 +53223,7 @@
         "item:renaissance_institution_preaching_gown"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "f9a1724fa683976866c52bc741bf36c7c6cbd2ea78ae92b808326cd15d68cf21"
+      "fingerprint": "b06a27fae6aa00eb2c30753ad9e82a748cf5ea5113fdf9600e752187f2911607"
     },
     {
       "entityType": "craft",
@@ -53236,7 +53236,7 @@
         "item:renaissance_steppe_fur_earflaphat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "58cff1768bdd2ed708af3e12ad6144b507f3d50added88191d8e3b9d23c73bf5"
+      "fingerprint": "24e9149e93d24cdcef7fd72110d5ed9ccdfaad5eadeed7665d1eb23fe64aa365"
     },
     {
       "entityType": "craft",
@@ -53249,7 +53249,7 @@
         "item:renaissance_furniture_cen_lock_fitted_armoire_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "0eb965f6764533a969d60b968d7283007e6a61b19588e35ed98495810f0c0578"
+      "fingerprint": "fa53967b8358fc9bac4055d05d53df9ce5dc2d9c7331f58b6b4d13bd5977b8b0"
     },
     {
       "entityType": "craft",
@@ -53262,7 +53262,7 @@
         "item:renaissance_furniture_sem_armour_tree_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "26fcf4a5f32dcaff1f0449cb098c4c18567a8b1d01b4c4c046d10268f92f5656"
+      "fingerprint": "0588e68ec3a1f1586b2e98c0c917252aa348ecdb1aca6e7d56a9ae55b0721602"
     },
     {
       "entityType": "craft",
@@ -53275,7 +53275,7 @@
         "item:renaissance_trade_ottoman_bazaar_oil_merchants_jar"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a6cf1b6594e4d1c73d3c9f6bb3502d4bf4e9e447d9530d134e82ec22f4541a69"
+      "fingerprint": "fbced6c17b25501e631263f991979b04ce69ab868424a6274276c41bb57443d1"
     },
     {
       "entityType": "craft",
@@ -53288,7 +53288,7 @@
         "item:renaissance_science_brass_quadrant"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2fae99f272153781e5e8ef25011baf73a626be4ff8e3fde16294bac5e1005c15"
+      "fingerprint": "09dbd239c8c319d0d2f0337566c19e605465969cfd41dad15c421fda83fc64b2"
     },
     {
       "entityType": "craft",
@@ -53301,7 +53301,7 @@
         "item:renaissance_art_granite_muller"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7c56b6fdfc99621e3a27172668cfd6052c5ba4f0266997dc7616e401fad72985"
+      "fingerprint": "27b723ae76da5315bf54d8a1285ae9f5214f3c110f76d1ff27d5d1f945adf068"
     },
     {
       "entityType": "craft",
@@ -53314,7 +53314,7 @@
         "item:renaissance_personal_urban_kitchen_recipe_wallet"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8484ba25e98d0e7bbf146fb70a267d6a7263f802af0003678cb000269d48a3d4"
+      "fingerprint": "84e93caf6917693fec6ae88fd5734013d2e2e1237098ad17be9b63826d994e9c"
     },
     {
       "entityType": "craft",
@@ -53327,7 +53327,7 @@
         "item:renaissance_furniture_west_african_court_storage_hamper"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1d9502c894ae7cd9d2f62b93f7c31f2838f5ae8edbb77e6e22d7ac28a8523b24"
+      "fingerprint": "53b401aa76ed047b69d7d2a54497c2e1f1585ee2583a008e5bec7c1fec535e97"
     },
     {
       "entityType": "craft",
@@ -53340,7 +53340,7 @@
         "item:renaissance_domestic_west_african_court_copper_ewer"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "fe989da699ce535fda3a4f11c793b154db4d1ab2786275d5aebd82a736f7593f"
+      "fingerprint": "13ddcb538c8e8a6b884ac812e381bafbf228ffe31d8353881f8e488c1e078dca"
     },
     {
       "entityType": "craft",
@@ -53353,7 +53353,7 @@
         "item:renaissance_domestic_civic_guild_service_pitcher"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d9235d3246e03af546cbb304bbae7eed5ecbc045e41fced23f23498d39d14362"
+      "fingerprint": "089caa2fc056ee97ad4102f3f422556e8a6b036ce07da3f34ef6e2fd56f11b01"
     },
     {
       "entityType": "craft",
@@ -53366,7 +53366,7 @@
         "item:renaissance_container_rse_trade_sample_lockbox_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "bcc9a1a0c71d18b5abe6f4abd986fccd0f8a30cd60e763fb729a50f93bd0ee71"
+      "fingerprint": "7aa53c2b92b617a713041c976e0083c811034ebf030f9a305ae307d082e16d50"
     },
     {
       "entityType": "craft",
@@ -53379,7 +53379,7 @@
         "item:renaissance_domestic_urban_kitchen_pitcher"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c822d049838a67ad803e25124a8693a01704745fe5696cf721c62ad83b19ef7c"
+      "fingerprint": "24f1f535476207742f96974c55e29381fa97d1ea3aee8153ddfcac11a55159e5"
     },
     {
       "entityType": "craft",
@@ -53392,7 +53392,7 @@
         "item:renaissance_military_yew_war_bow"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a1ec75d3a8d5f4f02c31daa5a50a86a49208bb84767b035859d81d60d4792e59"
+      "fingerprint": "4827018b1b5368dbcd5cc360ed4ece2657b119757211c550be604fc1f4e211f1"
     },
     {
       "entityType": "craft",
@@ -53405,7 +53405,7 @@
         "item:renaissance_domestic_shipboard_purser_sailors_tankard"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2694447b5b9d766bdc278e81a7d4005f32a3ca7acf6c2dbbb3fb84609f7f4c4a"
+      "fingerprint": "e6f74f5a1bb55c76e43ff5e664b9734a0e311942e55c8b5737e25ed2840d48e2"
     },
     {
       "entityType": "craft",
@@ -53418,7 +53418,7 @@
         "item:renaissance_furniture_nac_helmet_cuirass_stand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "af794fdb437c1b21389bbf08a141fc573f212d288fb8fcd7e060e6587ef1df0b"
+      "fingerprint": "acef913915c1ef6e4beae55a9939560b60f59b38bfcc63f7f8c9db3469e51507"
     },
     {
       "entityType": "craft",
@@ -53431,7 +53431,7 @@
         "item:renaissance_furniture_ott_porcelain_display_cabinet_06"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7f9009972b82e5d75ce2ad7754830b03912227b2b195b94a4b7364ad6f67bc49"
+      "fingerprint": "67c5f33e824d5bde6ba1746afcdfac78e0778278b2f005e5c16f62a6e7722edd"
     },
     {
       "entityType": "craft",
@@ -53444,7 +53444,7 @@
         "item:renaissance_furniture_wer_metal_armour_display_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "6f82670983ac78e5d3f10f82853f7d85badaad7774e427e3a9f4bc7832d98c99"
+      "fingerprint": "7dae137ec37ae5fd39b0cc217f523618b9add9780c7661d407c38431455ee194"
     },
     {
       "entityType": "craft",
@@ -53457,7 +53457,7 @@
         "item:renaissance_furniture_ott_folding_side_table_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "576624a729903a16b5ebcbdbd31fdd72b725ea7827dedc0c16d9999d1e1bc121"
+      "fingerprint": "78dcc5b2aab1eef96ed611dd68a6ab298ae6058fae5ce92af7daa472f34e0c2a"
     },
     {
       "entityType": "craft",
@@ -53470,7 +53470,7 @@
         "item:renaissance_furniture_cen_folding_display_stand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1a0ea9f46280bebc3b98cce0a5f4230bca31ad858723e4d0bdc646ccd6a96621"
+      "fingerprint": "11268eef1ea3618a4ef1b1d2fcb676f89fc1d7dabefd56c036847cb22ab9677c"
     },
     {
       "entityType": "craft",
@@ -53483,7 +53483,7 @@
         "item:renaissance_furniture_eon_open_display_shelves_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "980846288a0fdc06b26023b6d51e153b74e164ae5339b163d1231d09774d8c94"
+      "fingerprint": "b6a63ac9e0a86406eeecca4d58c55e449fa8ec92df2d2ba14a4195cae6c3396a"
     },
     {
       "entityType": "craft",
@@ -53496,7 +53496,7 @@
         "item:renaissance_furniture_jpn_lock_fitted_weapon_cabinet_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c77ce2e399f25eaf39ffc3db12ec7653977e59b23b41d9b383e70fb992c8c8c6"
+      "fingerprint": "3b1e77151937375bba24ade276296260262bc933bf8f406007d78e8ebf4e1c52"
     },
     {
       "entityType": "craft",
@@ -53509,7 +53509,7 @@
         "item:renaissance_military_barding_flanchards"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "f7394fc33a10adce79e2f07fc72462aee425df6393d854f330bdd3f630af3258"
+      "fingerprint": "49f229f0e82c12e158ead583f591a7435d82fdd73ed0970cc69de9bdf5bddb29"
     },
     {
       "entityType": "craft",
@@ -53522,7 +53522,7 @@
         "item:renaissance_military_hussar_karwasze"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7f9d934a5b2a11082f2bc6c043f31584c6740fe92dc5b8855eb9d2498d86ae7b"
+      "fingerprint": "60be7082a0fda4305bd95211af54a9d03dae5ab68b57165f0112ba15cca1e829"
     },
     {
       "entityType": "craft",
@@ -53535,7 +53535,7 @@
         "item:renaissance_container_ind_domestic_serving_tray_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "511c3aaa2255f8fe50b2baf2c6ef9f0e4af2405abe34503d78507806e55c22ed"
+      "fingerprint": "5d54309cc940ed570b5d88ae08c95b479ca86137cf80644ba16e333d6ae6da92"
     },
     {
       "entityType": "craft",
@@ -53548,7 +53548,7 @@
         "item:renaissance_container_nac_personal_waterskin_sling_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "41e73bc2d3aaa6606235c4aec07b7a4d5a285d788e39bdcdaf7fd49074dae2be"
+      "fingerprint": "f5904470d7ec878675ca62ba1da18598ed65104544414abff79f51d6f2df4297"
     },
     {
       "entityType": "craft",
@@ -53561,7 +53561,7 @@
         "item:renaissance_furniture_persianate_court_garden_service_table"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a2d9f725bfb96a931b57f5ac6ab65bcf183d4bcf2c90dd9949c62f1450ea79ec"
+      "fingerprint": "911fdb73c596aba5bd65c9dadc51095478d0d32e76bb06a1bd142c24d7447d00"
     },
     {
       "entityType": "craft",
@@ -53574,7 +53574,7 @@
         "item:renaissance_domestic_persianate_court_inlaid_serving_tray"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "09863c2cdf7939faeff855286a54ec505fa46dc8e038d489d9f81e63099bd2e1"
+      "fingerprint": "d975bc21986136725466ae81e16e3d8762a7294af0f37fee7de5eab3e181c015"
     },
     {
       "entityType": "craft",
@@ -53587,7 +53587,7 @@
         "item:renaissance_furniture_stp_wall_weapon_rack_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "df5298b94099332cc099121a8066dfecd5128f454351b5f836760ef5bdbad624"
+      "fingerprint": "71103207e55b7d0836427942a7dc7dda5ef0804777e2fe0623f5b5a101d561b8"
     },
     {
       "entityType": "craft",
@@ -53600,7 +53600,7 @@
         "item:renaissance_furniture_col_bow_rack_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b9638ab525a00c7e9a22c547f97a2a322fc56992683ef7e9a2e84a493f06a9a1"
+      "fingerprint": "329e6336375a21fbae986aee3b6d5d0bbb3b130fbf4931c8ae5df5a70cc37ffe"
     },
     {
       "entityType": "craft",
@@ -53613,7 +53613,7 @@
         "item:renaissance_furniture_iba_cloak_cupboard_04"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c577fd5d18f6e5500305f630dce17930aabafdc79b62016320fc4a97477bacaa"
+      "fingerprint": "3b0fc05331e88aa1176b10c0bbc89e1248967014d4281216801a6f4706d1c0b2"
     },
     {
       "entityType": "craft",
@@ -53626,7 +53626,7 @@
         "item:renaissance_furniture_cef_textile_drawers_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "311b8f4bb1855c54e9f378ebe702f1316cfd04a0a84d9a60358b0ae1084207ef"
+      "fingerprint": "63d359285cdfd3f17993e127185c7acb10dc10fceaa33913a26ebcc9a2ef781c"
     },
     {
       "entityType": "craft",
@@ -53639,7 +53639,7 @@
         "item:renaissance_military_sidesword_knuckle_bow"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "82f561c256397c3043cb8446265431d5802d147367ed4b2a363427c12cc6d96f"
+      "fingerprint": "5778f874e8b760911bfb3e7fd71f56a8fa31b086fa8d7dc5ba50130cfc7549b7"
     },
     {
       "entityType": "craft",
@@ -53652,7 +53652,7 @@
         "item:renaissance_trade_persianate_court_jewel_coffer"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "0bd9a59afb1473dcdd8d59796ace10ed5d4a9c168ee4d5094d51d512727f84c5"
+      "fingerprint": "9e459fe932277e7d9884efe581f89c6e3668595751b1ac4357a3c44144e94ce1"
     },
     {
       "entityType": "craft",
@@ -53665,7 +53665,7 @@
         "item:renaissance_furniture_sem_chest_of_drawers_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "063cfd65104246cc9fd7dd8437c6591404f201dfb046df9c9312b0c6a002b4d7"
+      "fingerprint": "9abe03c52c6f4d18b7618d0e10b3174c6a779dd80150c1b4bb6ff023108afdc5"
     },
     {
       "entityType": "craft",
@@ -53678,7 +53678,7 @@
         "item:renaissance_furniture_sem_large_storage_cabinet_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d7e221d31ce6a0d52b6d03d7edceeeae994c4afaa01e27b942fce57f75209502"
+      "fingerprint": "913bb3d920f3a02d15a585268b9dca291a5c9d4c79911efd17f71ed98baf0161"
     },
     {
       "entityType": "craft",
@@ -53691,7 +53691,7 @@
         "item:renaissance_furniture_pip_lock_fitted_desk_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a0bb47e8ed7ffe84e4b08685ad033adc4155b03a31820de18d4d253529f506d1"
+      "fingerprint": "3b3e349edd03a6febddf6a0f169b1ac7080fd9e666a35bd272d64c01d26e33e1"
     },
     {
       "entityType": "craft",
@@ -53704,7 +53704,7 @@
         "item:renaissance_trade_east_asian_literati_cash_chest"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "fcd2ad9a92239729d96b42b6137276a798714abb99fe60b1bda0024526a7f52e"
+      "fingerprint": "4ed324759e348c140f8e6c1f37da8a8a2c86f57182556527c8d926f949083385"
     },
     {
       "entityType": "craft",
@@ -53717,7 +53717,7 @@
         "item:renaissance_furniture_sem_urn_stand_04"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b4eb4f97e62462cfc20ec42c0c655db913d419e09c8f6424f3625385c98fcf7d"
+      "fingerprint": "3ba6997bd5802dec6bb8fe0e1602ffd85454eb162f694d596805d5cb84e49382"
     },
     {
       "entityType": "craft",
@@ -53730,7 +53730,7 @@
         "item:renaissance_furniture_eal_porcelain_display_cabinet_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "edf0b28efeb1153adef469cb518cd5665d69f9ed6cf9751a83bec3403e9ce92c"
+      "fingerprint": "fdc5d36f153d968c55f479e10330aa92b8fc447045eff451e5aac5942a439793"
     },
     {
       "entityType": "craft",
@@ -53743,7 +53743,7 @@
         "item:renaissance_military_barding_croupiere"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d7e129184ee19966f9989b2075beab863a4d0140dd4f7aa9a62fcbfb49e981b7"
+      "fingerprint": "07a67ec1882233bf39113c04f48e903d78ef8b799c773b84f46a0f4757d0427c"
     },
     {
       "entityType": "craft",
@@ -53756,7 +53756,7 @@
         "item:renaissance_military_sabatons_lamed"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "6cbb80bf7ab9b97d1649cd3b8200e4556f7e4a972eab0cedeb7b2552585dbf3e"
+      "fingerprint": "b09af52b0e3c462afe589b48eeb909a69a177c12fd7c47e402d97dc12f276829"
     },
     {
       "entityType": "craft",
@@ -53769,7 +53769,7 @@
         "item:renaissance_military_barding_criniere"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e54c75105257b7bb39adc19ec72953a7f00b6c8a015794bdfc821023019be89e"
+      "fingerprint": "d3e6d9518a0605ac0e8e696b4c87fb07bc302cfdf38abbd7519951e3d7be9498"
     },
     {
       "entityType": "craft",
@@ -53782,7 +53782,7 @@
         "item:renaissance_military_deccan_cuirass_laminar"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a71ded72454b83561cc913ddac6a6a139441e563ac257bf996ab71e8363b0b71"
+      "fingerprint": "67adbf5b95307508426e213364260e0f713b698c5ac3b748816ba4d63b83c20a"
     },
     {
       "entityType": "craft",
@@ -53795,7 +53795,7 @@
         "item:renaissance_military_spaulders_laminated"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "6390dc9618bffb905045caaf2abc6e00873dbe4919e30020e8f61cb202bc7bbc"
+      "fingerprint": "e1dcb94c37b63d11142c81d50f1e2c90338c161c7cca244ae4264b3a358de17b"
     },
     {
       "entityType": "craft",
@@ -53808,7 +53808,7 @@
         "item:renaissance_furniture_and_campaign_armour_tree_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e8b4bb699ab2abd6c813113c64b3e9f42dc2224a14c1313f75cf0aba68fdc9b7"
+      "fingerprint": "e0f8fc0430949725f67d60974ec8f7a23d82fb17ee8ee5d5d17877a92798581a"
     },
     {
       "entityType": "craft",
@@ -53821,7 +53821,7 @@
         "item:renaissance_furniture_nac_open_display_cabinet_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7a7f9a5ab2b58f1fbd02366ff5d175dfe90ad24742212df69cdbddcbb51d7db4"
+      "fingerprint": "b7316361cc8d11e06f97983290b3dec5ee32c18c4279be95628355802a55e92c"
     },
     {
       "entityType": "craft",
@@ -53834,7 +53834,7 @@
         "item:renaissance_furniture_eal_urn_stand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "5af3a34dd468675ce6e7dd617187f60ba7e654af73e94587f9cf3a6940206a32"
+      "fingerprint": "ccd42b539955798f28f7dec7289166acd4960b8b56b9d29d70fbc0781f6ac075"
     },
     {
       "entityType": "craft",
@@ -53847,7 +53847,7 @@
         "item:renaissance_furniture_ind_folding_side_table_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d6fced39ab2ba4ada0b08d5b278816e4b810a0dfa15b630233002f7738fed30a"
+      "fingerprint": "434bf77d1f0849f30613a3a53e8735614bed37ef476b56036103fbc23fdb4a38"
     },
     {
       "entityType": "craft",
@@ -53860,7 +53860,7 @@
         "item:renaissance_military_partisan_leaf_blade"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e1fff14fc6762bdf2ef4edd95f3894300346515169ef88a1168b3995dde4e709"
+      "fingerprint": "be892ec4f07ada7e470b79dd52d94f0e43372c97bc0bafc179cdf180ca20d5e2"
     },
     {
       "entityType": "craft",
@@ -53873,7 +53873,7 @@
         "item:renaissance_furniture_rse_large_storage_cabinet_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a315a9e06a64a8bd1b16710d2f6c18f945187f21bbefa1039c23694b3dbd68de"
+      "fingerprint": "bad56bf7215a5bb0ff6bfdfbf6cf9feeea4f6cf384a2f9526b9bad0e3847f8c7"
     },
     {
       "entityType": "craft",
@@ -53886,7 +53886,7 @@
         "item:renaissance_furniture_stp_mail_stand_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "6756c13e33797c3e8164f3bf284c806405387711cbccd49056745b67f13b8d9c"
+      "fingerprint": "f312969409a4a37ab356b7ce546b70ba97380d56b3a76e62ce4b2c20a553deee"
     },
     {
       "entityType": "craft",
@@ -53899,7 +53899,7 @@
         "item:renaissance_furniture_iba_lock_fitted_drawer_chest_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e2e31d76ede8f92cac1292bba6d7e35cc6c17ca9cf8cab456b71c4f5359dc75f"
+      "fingerprint": "5b38e7112232de2a96a08a61b356630acec76f8fc1296fe1ed673df3760f6bac"
     },
     {
       "entityType": "craft",
@@ -53912,7 +53912,7 @@
         "item:renaissance_container_mea_personal_shoulder_basket_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1174402452ee72880f6d8c26a58324e77d6a921b575ad57015a7b4ac684128b6"
+      "fingerprint": "7433309001a49f3f68ec1c27423576ae633256749e4e4230e7337f1c3f8d379d"
     },
     {
       "entityType": "craft",
@@ -53925,7 +53925,7 @@
         "item:renaissance_domestic_southeast_asian_port_rice_basket"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "5f03fb289d2b418ff73d2bab0c7ff18d837f07c1a3315197b7e23301d575491f"
+      "fingerprint": "540d0ce52d238c6c7d3a9f622614ae1d34b18ffdc56e26c6a4b2a3712e97e184"
     },
     {
       "entityType": "craft",
@@ -53938,7 +53938,7 @@
         "item:renaissance_personal_southeast_asian_port_shoulder_basket"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "70592db2ccabf013ba9625227d8cb0ced8e7beecbc0ab4cfdf4d5a90d10ba2cf"
+      "fingerprint": "04578f4c0570c3c08445463ab75ee559fe8b4297e18cf3bd99ee6b06f9f3171c"
     },
     {
       "entityType": "craft",
@@ -53951,7 +53951,7 @@
         "item:renaissance_trade_southeast_asian_port_spice_pannier"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "664f667408af763d8154f97c4f38281c0e37a87e08857eb196409fee008ad37f"
+      "fingerprint": "0e2dd0ee9ae800d60c18aaead427caca7298f6ff3a7d8ccc8ff6aa660405b361"
     },
     {
       "entityType": "craft",
@@ -53964,7 +53964,7 @@
         "item:renaissance_furniture_wer_urn_stand_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "940e04839961a99094dde3bd561d2618849b5afc1700c4eae9f793e3069f46be"
+      "fingerprint": "4457a3746e7dda3e472f611b5348a7eb823e1eca694ce7a54413ad4b4abf498b"
     },
     {
       "entityType": "craft",
@@ -53977,7 +53977,7 @@
         "item:renaissance_military_adarga_lobed"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a15153fe09f52e52e73a0101d2dc47ba979653937439ea630b693c2b033ff4ea"
+      "fingerprint": "c0c3cfc8d5948611bd5c74c18b5196da9759b31c16b94075ed3be1621dda5fc5"
     },
     {
       "entityType": "craft",
@@ -53990,7 +53990,7 @@
         "item:renaissance_furniture_ott_service_hutch_01_lockable"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "203fecb825922a57ab73d1fd881595d010c3728e7810600492dbe2fa80d4f616"
+      "fingerprint": "c8fa3504f5e3517fab2380d485a0190e2ad6b16ac72f8ef2a04c4b4b9c6e19cd"
     },
     {
       "entityType": "craft",
@@ -54003,7 +54003,7 @@
         "item:renaissance_furniture_eal_hanging_cabinet_01_lockable"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "fe9c42fa8f8f89818273271869a66593b7e01f284ceba4a4b5f6e9cbc8f6bf45"
+      "fingerprint": "a68206862701ee6a4fd4ca3887255d4a3ff9e7395d3cd55ab463d750744c492a"
     },
     {
       "entityType": "craft",
@@ -54016,7 +54016,7 @@
         "item:renaissance_furniture_msea_end_table_02_lockable"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1f3725550e22cbc2710cc90a75975dd708680e376bfe12104f5475722ed4d16d"
+      "fingerprint": "84d0011944f3ab352c3d4bdec3ab80673c6417d3dca3e69fead83ed4aa932b0a"
     },
     {
       "entityType": "craft",
@@ -54029,7 +54029,7 @@
         "item:renaissance_furniture_col_glazed_display_case_01_lockable"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1b5d4f29af432e543a5f52f8519fb07a71676845af4aebec9fabe2c5906d2ec3"
+      "fingerprint": "ba05ea98bc547f0083a27c27c22cd52db3d5d012d4587353682c908b08b67c3f"
     },
     {
       "entityType": "craft",
@@ -54042,7 +54042,7 @@
         "item:renaissance_furniture_sas_scroll_display_cabinet_02_lockable"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2664352bd0da55b0ca418cd1e629cf7062832a7f6ec87b8a0d8721758a12ca43"
+      "fingerprint": "28274fcee7d30e508d4d0f1111257352397ee7b06acdb65440866760078d1cd7"
     },
     {
       "entityType": "craft",
@@ -54055,7 +54055,7 @@
         "item:renaissance_furniture_eon_slant_front_desk_05_lockable"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3508a0b00a8b9408b70b87ff62521e6120758a3ca843cb60c08bd0857eec3b3d"
+      "fingerprint": "8ce5e203304daad45442bb5dc80b3e90be0c4a8d2a630cc1f1a54741dd7ecd49"
     },
     {
       "entityType": "craft",
@@ -54068,7 +54068,7 @@
         "item:renaissance_furniture_nba_secretary_cabinet_01_lockable"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "17b95fe9df030670bdce815af6e38db130f7db29c97527bce2fad1cff0e66428"
+      "fingerprint": "0a01eade0a3c4e00b283c9370f72c6c111475d61031d1dd412504354affe89e3"
     },
     {
       "entityType": "craft",
@@ -54081,7 +54081,7 @@
         "item:renaissance_andean_long_headcloth"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c6f62c663f240a77fac9f9efcbf4aeae9315814c021a8cacdcd8239fdcefb9f4"
+      "fingerprint": "1a7c5e16d27068abdb4c11f1a94db31177ed44fc66ab066fa7eb69ad09dfd500"
     },
     {
       "entityType": "craft",
@@ -54094,7 +54094,7 @@
         "item:renaissance_institution_academic_robe"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "9ee3bbd8f45a46b44c1d243eb8c696485a72f4d749462314519d79eef3515d62"
+      "fingerprint": "3f43f027c14ec686d385f5d58e50e21ccd45b4a1b44a83e6274f9588f1352fba"
     },
     {
       "entityType": "craft",
@@ -54107,7 +54107,7 @@
         "item:renaissance_furniture_aca_low_drawer_chest_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7b60798ffce3fb01af47802a985eb263ffb8b34ba9eb8820be606e9a1a41ee1f"
+      "fingerprint": "aa1c01af80f74bceb6efa027d333dbbb5a7fc962a1fd79f30720381abb3e4a72"
     },
     {
       "entityType": "craft",
@@ -54120,7 +54120,7 @@
         "item:renaissance_furniture_car_helmet_cuirass_stand_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "63280ed32ac2f102a5a2fd74930d242afe728f345e0beed591be3d3195c7d2e7"
+      "fingerprint": "7b0b680c0ea76f07e485ae615436ece93355ef247b34fe8a25c7b9aa2d9dd6a7"
     },
     {
       "entityType": "craft",
@@ -54133,7 +54133,7 @@
         "item:renaissance_institution_plain_cassock"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "65954319a2a51643f8e5068581217972f29767c35bcd0425b7c7fa33ccba639a"
+      "fingerprint": "875f0069d8397e49a7d3de8eb58a800fd742a9925e73ce9229ad0d83b20ec348"
     },
     {
       "entityType": "craft",
@@ -54146,7 +54146,7 @@
         "item:renaissance_military_demi_culverin"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "de3116f82fa31ee32f2d998ddcb0bb44294c8dade9cbdb7c700ebebd44b1eaa2"
+      "fingerprint": "9d19d2cfbd20faad1699b74280dc4416caef105d04cd04867ba7d8e26131023d"
     },
     {
       "entityType": "craft",
@@ -54159,7 +54159,7 @@
         "item:renaissance_persianate_long_fitted_coat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "9212937b5f95810976a912cd868d639fbe49e39bc8842a488fea09d6ddd5d02f"
+      "fingerprint": "1dbcb732137937209fdc2c88bf23bdf77a52e988f36508432ad5b632a6aba272"
     },
     {
       "entityType": "craft",
@@ -54172,7 +54172,7 @@
         "item:renaissance_furniture_nba_chest_of_drawers_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3b67cdcb5a3341ccc2e7f89ad00c4095ecde72211f0b1e12f277ae6108043911"
+      "fingerprint": "c9c530c01b656f60c88790470a9072d6cdc3441275c69b6a74eac4fd00f0ac1a"
     },
     {
       "entityType": "craft",
@@ -54185,7 +54185,7 @@
         "item:renaissance_furniture_eal_vessel_stand_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "841e794aa87851031491d9856bf0a8743618cc4b91663aa13727f6dde142a17a"
+      "fingerprint": "a80be65e5ff319872da8baa0a0ab2ffc5a45128e487fd17b942f1b221653e283"
     },
     {
       "entityType": "craft",
@@ -54198,7 +54198,7 @@
         "item:renaissance_military_matchlock_jezail"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "404c5dd1ffb7a6c2089c2fdce1ac9384af03f51d4fba2c50c20e44999f33df34"
+      "fingerprint": "3cb81f728988b384cebafdb8c54069bf81da93ae4c2a25333d0d093bc0fe4020"
     },
     {
       "entityType": "craft",
@@ -54211,7 +54211,7 @@
         "item:renaissance_furniture_stp_freestanding_weapon_rack_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "4d3cb7c27516e44392afd2c47a95a0dd45f0d1c0b3a838fa6bb7ad9a9a7b7f65"
+      "fingerprint": "71ccf5166519ad0a6c8139a8a53ef2e341a556d229c9d2c37952f5b403e0a45e"
     },
     {
       "entityType": "craft",
@@ -54224,7 +54224,7 @@
         "item:renaissance_furniture_jpn_linen_press_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a4236c00cd6abce6452b2205406e60bdec1b7ba4f3d1e90db6bf297d87f88849"
+      "fingerprint": "2ed30469b35c6085d86c2768515f4b443824e5ec45bf2da5d9b55a81a8ac4d92"
     },
     {
       "entityType": "craft",
@@ -54237,7 +54237,7 @@
         "item:renaissance_furniture_mea_campaign_armour_tree_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "dd12151bf0cbc20ac7e5fadce0b3fef14c34ac8d0cb07f621f59dd167e321da3"
+      "fingerprint": "6d787151264d0719948b6125b44007ff40bf92a936cae35a59646b04ec0323b9"
     },
     {
       "entityType": "craft",
@@ -54250,7 +54250,7 @@
         "item:renaissance_furniture_mea_scroll_display_cabinet_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "fafae0c07d25b68d1e1fb2b7cc6f1ad035f52073da1be740e0a2049aa7c19028"
+      "fingerprint": "e24fe48b9009594eb4ff37db01080a3cfae1f84b75c0bc6dd1d5470db6b45a3b"
     },
     {
       "entityType": "craft",
@@ -54263,7 +54263,7 @@
         "item:renaissance_furniture_elite_household_banquet_table"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7ed3bccf67fb82f7ba12a83cf8c739f44341d507cfd106058cf6ba3c8a09895b"
+      "fingerprint": "88aed294732dbc2d04f2738a01a8d1f6fde174f69dbd49a67e2d06355535b69f"
     },
     {
       "entityType": "craft",
@@ -54276,7 +54276,7 @@
         "item:renaissance_ottoman_sleeved_outer_robe"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "857510a069bd0cf2074ab00b5f3924ebd29db6c9271cf3788766830c97e89ee8"
+      "fingerprint": "b185ebdb5b0542691e05440495ceb86f3bd55f4898ad99e38b2a635725c4b234"
     },
     {
       "entityType": "craft",
@@ -54289,7 +54289,7 @@
         "item:renaissance_domestic_ottoman_bazaar_long_spouted_ewer"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "39c60abb078035688570ba4afd75ad328362686aa1546b86b31ede96364c0f49"
+      "fingerprint": "35a0e762bc1821ae3bf204998e29fdf099cd4a227de8985c3d34eae18955ae7d"
     },
     {
       "entityType": "craft",
@@ -54302,7 +54302,7 @@
         "item:renaissance_shared_clothing_travelling_coat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "07253df71be0b6176fc5acd6f6317295bccc8fd432fcc5908a912b85d8343350"
+      "fingerprint": "67ebec8ca488be2a7fe9b782c80d71558373cb6a7ce52bb03ebba768252bda4e"
     },
     {
       "entityType": "craft",
@@ -54315,7 +54315,7 @@
         "item:renaissance_furniture_eal_drawer_nightstand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "f22d6413b9bc8b680ae3aa123b5c74c09cad34559813482e287195945ac03688"
+      "fingerprint": "0ecdc5ca1f7ea2b8726e3d2021e2f3b9ee7dfc4811b817f6d0762c94a25cef9e"
     },
     {
       "entityType": "craft",
@@ -54328,7 +54328,7 @@
         "item:renaissance_domestic_steppe_caravan_serving_tray"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "00d67dded4527aa6bf6f237fb4d53b8389a4b94c64daa8047c38f598d677e2ed"
+      "fingerprint": "127034989e3915c641eff0b4f26ab5465a4242219b28b832129bba20997ef3b9"
     },
     {
       "entityType": "craft",
@@ -54341,7 +54341,7 @@
         "item:renaissance_furniture_stp_large_storage_cabinet_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "694fbe56d7268188b6629bd04c6dc370276980df17a5fa011fabb657d4093bb2"
+      "fingerprint": "9b9e1aa157830e353c06ec4e08fc5733aac22f8d4b2a385ab5d83a8c60450e11"
     },
     {
       "entityType": "craft",
@@ -54354,7 +54354,7 @@
         "item:renaissance_furniture_ott_lock_fitted_nightstand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ae2fc8c0c4283006bfebff48467d19e75d1d161ae7fa5e34c97ab9b9ae828b8c"
+      "fingerprint": "d7bc93b1c251c85addd8571ea1486964779f8110c6c862a4cc950eab697a326a"
     },
     {
       "entityType": "craft",
@@ -54367,7 +54367,7 @@
         "item:renaissance_furniture_sas_tall_wardrobe_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1ad63d457efce065b42bac6ff61dc746d122d40ad7b50d5e13e71cd0a20e4771"
+      "fingerprint": "26fece39cfe9b65cb9fa8a64ecf78a233db3a207c0bce4926dfcf390defa7fd2"
     },
     {
       "entityType": "craft",
@@ -54380,7 +54380,7 @@
         "item:renaissance_furniture_ott_textile_drawers_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "46e84d0a9e29d0aca2c7531f65820ad8f599ce83247a51f5e22e8b1d0030d990"
+      "fingerprint": "d75e9e476a1afbf15b6019377c2758092b6fc8fbb586f4cd85cf894ddbe11fa4"
     },
     {
       "entityType": "craft",
@@ -54393,7 +54393,7 @@
         "item:renaissance_furniture_steppe_caravan_low_folding_table"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2d1472720e65b6b62c2d280cc0c26c8c939aef500f04eead23f68131b4b459fe"
+      "fingerprint": "cfe080df3c1ac2ea2049fc0446707e2831f69638a4179edf84fc9bbb173b02bd"
     },
     {
       "entityType": "craft",
@@ -54406,7 +54406,7 @@
         "item:renaissance_furniture_ottoman_bazaar_low_service_table"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d25de498e5fb7922569ffaca654c4b8ca81bc29e8769d28659fc711fc41623d5"
+      "fingerprint": "5304e8e27ff49d973f9ce74bc513497170d79f274aaf60a520e809684066105f"
     },
     {
       "entityType": "craft",
@@ -54419,7 +54419,7 @@
         "item:renaissance_furniture_cef_household_cupboard_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2d7688b581d67b016b0933551d3f162ca01dbd958ae2067e42491083cfd10cb3"
+      "fingerprint": "b8a5cf2e1f3a11ddb3d0b1bdce67b0304746c8bfad291383dd8875a1d066e142"
     },
     {
       "entityType": "craft",
@@ -54432,7 +54432,7 @@
         "item:renaissance_furniture_iba_clerks_desk_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "cc216990bf5e16109708450c0f72d9e58b0485f60c22cbaeae5108398f5501d1"
+      "fingerprint": "1cbaedeb21c7e1bebc1bd2a79fbaffaa94a96e8ef9bd96520ff85049cff46d00"
     },
     {
       "entityType": "craft",
@@ -54445,7 +54445,7 @@
         "item:renaissance_furniture_wer_tall_drawer_cabinet_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "54fe40d2cd2ab1524571c8b0bda142cfe3d3f8f471f06a7d571d7f65d2963d93"
+      "fingerprint": "3952e69159bf1fcfa2018728c0dccfed7363f529b5037317eb6a4517fcb37076"
     },
     {
       "entityType": "craft",
@@ -54458,7 +54458,7 @@
         "item:renaissance_furniture_cen_helmet_cuirass_stand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "31dafcec8e120dbf41dc4af9b810a038f1e93c0e9b6ef5dafffc7eb450ecdc39"
+      "fingerprint": "ec6486baf3209b99314e93fe915db7154e9ccaaa20552456bbeac7a87ea5c7d5"
     },
     {
       "entityType": "craft",
@@ -54471,7 +54471,7 @@
         "item:renaissance_furniture_wer_two_door_wardrobe_05"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "68b019900815ef465c506ec04d95043e9ad16fdf9373e24f5f34ad09ed622aa2"
+      "fingerprint": "8d67d13d7443a2c39595d37fe2132b02b52a28cc2bdb496f3ce62587623f8253"
     },
     {
       "entityType": "craft",
@@ -54484,7 +54484,7 @@
         "item:renaissance_furniture_msea_counting_desk_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d93ac791e5bbf17c03e17e525c2df50f7bb2f942208f84a332265ebbceafea90"
+      "fingerprint": "68ba0effcfe83b03c0bf9bb7e11fe2a01d61e80ca7f5a801d378e78c2cce999a"
     },
     {
       "entityType": "craft",
@@ -54497,7 +54497,7 @@
         "item:renaissance_furniture_msea_large_storage_cabinet_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "6f894d8fb5d54be3af7d13fbc86444c028f1ad99a5ad2e679bda25c40a68e610"
+      "fingerprint": "be08e6140c2755a0515d6075f9fc8ee65a817cb9b755667f15dc308031cbdaf9"
     },
     {
       "entityType": "craft",
@@ -54510,7 +54510,7 @@
         "item:renaissance_furniture_ind_side_table_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "866b78420b525f2f2c29f9d3c3df75d3bf97973ca2707c2566c2952a92b5b49c"
+      "fingerprint": "2c88cd7c7bb36a17f01e084e390f958163836f239cb701d8699d2409b65dd1b4"
     },
     {
       "entityType": "craft",
@@ -54523,7 +54523,7 @@
         "item:renaissance_furniture_jpn_urn_stand_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c78183a6fb197a4f7879f6a4f12021d26f7ad0196995651fb504badb98bc1223"
+      "fingerprint": "d42fe449bf5b8af7d71e51d7eddbba023cd78d1dfcf275073ee44ddc46b6df6c"
     },
     {
       "entityType": "craft",
@@ -54536,7 +54536,7 @@
         "item:renaissance_furniture_warehouse_dock_warehouse_bin_rack"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3b5f9dafc941ece577132f44563abfa3e8e3d288bda4400380152713a95a90e5"
+      "fingerprint": "918697686a882f515d5e3868e68280c3d68e3c5419990b7de197bac8d70f8368"
     },
     {
       "entityType": "craft",
@@ -54549,7 +54549,7 @@
         "item:renaissance_furniture_apothecary_perfumer_apothecary_drawers"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "26e14d8ec76a8a93cf48ff0e47063f1ef41e677ad67b9b3819505e553288d9dc"
+      "fingerprint": "dcc65915ab27e17120d963a6b9f5a7f6dd2332e6da72ee735ce2cc797751d4f7"
     },
     {
       "entityType": "craft",
@@ -54562,7 +54562,7 @@
         "item:renaissance_furniture_east_asian_literati_medicine_cabinet"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "442beb65af96e87251c6892c5b60abf4346e33ce6535c032998507ecceda86b0"
+      "fingerprint": "3dd83f7d0ef9767bab6bfdc2e793aad6759149f027c4421bc9be452a03217309"
     },
     {
       "entityType": "craft",
@@ -54575,7 +54575,7 @@
         "item:renaissance_furniture_iba_offering_stand_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "fc0efc9b1f5618966bcd97b11f260246d180b35b4596859967f613fd89d7fc41"
+      "fingerprint": "e877a07f41f0a2d4429cbed807220865bcf4bb5f190bb4cfcadb849f6abda6d7"
     },
     {
       "entityType": "craft",
@@ -54588,7 +54588,7 @@
         "item:renaissance_trade_southeast_asian_port_maritime_storage_jar"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "665699405061caeb64db2e385117ee571885f431d0266bbcf74ab628a8b6ce33"
+      "fingerprint": "efc42f9f77c0c1b3b52428ada2dd7d81b92a74a7bd8e82dd9eac027c189aa31c"
     },
     {
       "entityType": "craft",
@@ -54601,7 +54601,7 @@
         "item:renaissance_furniture_eal_linen_press_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "57aaf6e952da3e2297ca6533fecf4a54ddeeda36b6295ab90f8ecb8d6131b99a"
+      "fingerprint": "fd044f6661fdf0189ca33e799d5c40dec9bd24cd5b520b673b002705466522af"
     },
     {
       "entityType": "craft",
@@ -54614,7 +54614,7 @@
         "item:renaissance_furniture_sem_lattice_display_cabinet_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "50d615bcc93cc6dfe7de8f05a1aa3f816be4e26c8a91bd2a4983fa5e3dcadef8"
+      "fingerprint": "f98e562aca7ecaa25c9a9679c401c14d8e90601a3fdc65393aae045b99c5dc87"
     },
     {
       "entityType": "craft",
@@ -54627,7 +54627,7 @@
         "item:renaissance_furniture_and_folding_side_table_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "32d98addbaa538a6ce2ac5a871b787ef7052af38da433823f954e2ce443b16f3"
+      "fingerprint": "d5793d63772c7dd41cf92ae8090bec15e964b0e756ccd27ee831a6340c215b3a"
     },
     {
       "entityType": "craft",
@@ -54640,7 +54640,7 @@
         "item:renaissance_furniture_eal_plate_display_cabinet_04"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "523e0bf3c1e3e8d4f1eaed7047fd149a6bfdda20cad251db5ceb164cc6c41d46"
+      "fingerprint": "25cb2c97c4b60b97205464dc136c697e88013e9ada3311fd45d7526f714fb760"
     },
     {
       "entityType": "craft",
@@ -54653,7 +54653,7 @@
         "item:renaissance_furniture_cen_campaign_desk_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e2f04398a3e48625f0750a8174de143cab213eb713d173d6a6e1bac52274199d"
+      "fingerprint": "3d406bb881b1199ab11a953a65b23d5cf06ed6f2762a2367cecb5502e3d4290a"
     },
     {
       "entityType": "craft",
@@ -54666,7 +54666,7 @@
         "item:renaissance_furniture_nba_lock_fitted_nightstand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "141aeb912c8b563ee2d40e6894bfddba81f111628cbf47314dbf0841e680d39a"
+      "fingerprint": "c82c65a574d6b4728db4fa5a486000f5993675fa929830d5a4ad829cf15cb33b"
     },
     {
       "entityType": "craft",
@@ -54679,7 +54679,7 @@
         "item:renaissance_trade_elite_household_portrait_casket"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a42f8062f44694a9d2ec0914b9a332b2f1e10bf2549ca4ce04c1c559c5d6925f"
+      "fingerprint": "2c63cc4bc24e3917d98fc98fcbf792c6308e34e120c6cd6a62f8a259a693c5ae"
     },
     {
       "entityType": "craft",
@@ -54692,7 +54692,7 @@
         "item:renaissance_domestic_elite_household_inlaid_tray"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8bb6861cc7aac3dfda8eb01a5e37d6c7b4076f33c044c81a76375e93a8e7cb1e"
+      "fingerprint": "551989ea9806589f2048bfd231260c03d8ed8f60c456fd2c56f3580e0b56328d"
     },
     {
       "entityType": "craft",
@@ -54705,7 +54705,7 @@
         "item:renaissance_furniture_wer_slant_front_desk_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "aac123f9d0ade54522f6fe6e687e28dfbc0886c97604989ce2416a204c9aa22c"
+      "fingerprint": "d47a279e6a75bcf8e2054b82c6b7ae491f029d930ee4d40959e338e4392d09bf"
     },
     {
       "entityType": "craft",
@@ -54718,7 +54718,7 @@
         "item:renaissance_container_ind_domestic_serving_tray_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8860cf58dde831e250bca1891ca7303ee51e0cab0308e0858431cc2edf283873"
+      "fingerprint": "56c816485981ddb7c53d01d781c0f8b34c5b363207b4547e1972feab293a352b"
     },
     {
       "entityType": "craft",
@@ -54731,7 +54731,7 @@
         "item:renaissance_furniture_cen_lock_fitted_wardrobe_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "16651b31419259829b5238edbc517a9aff295e93a9f9de2141cba3fccac990a2"
+      "fingerprint": "29053d034d014c0c34672990388e36136df2d4010faa81b5c641ae0a8bf50cc0"
     },
     {
       "entityType": "craft",
@@ -54744,7 +54744,7 @@
         "item:renaissance_furniture_eal_two_door_wardrobe_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "9e5cf1d3621a49a9166d63588a94e7f76b51ed9dee32c1d3d79ef2c2a941daea"
+      "fingerprint": "20b9443d6acdfe52c2b1a930d6478afffda1f66828eebbe80b9a6cdb25a89137"
     },
     {
       "entityType": "craft",
@@ -54757,7 +54757,7 @@
         "item:renaissance_domestic_apothecary_perfumer_instrument_tray"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "6cc223376db425639633d4589af8cb93d93b1037e91fe889c1f59aee797b8101"
+      "fingerprint": "c93f9cfa66c01d604a1a9cb2538125e26309e10a1e84d93206d20632e2963b01"
     },
     {
       "entityType": "craft",
@@ -54770,7 +54770,7 @@
         "item:renaissance_domestic_japanese_ryukyuan_sake_flask"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "9f09a5e816b82e4afe3ec8bbb2adf3c89bd9e1c3d49ade17a61dd494e4168a40"
+      "fingerprint": "03b9d22f91e84417149bb4b3fb3f26935f275557bb8165e074665eebee430f46"
     },
     {
       "entityType": "craft",
@@ -54783,7 +54783,7 @@
         "item:renaissance_furniture_sas_folding_display_stand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e607b959ba9e9786443059116cc2f191a20a403612c2c8551ea9adfb2186fa4f"
+      "fingerprint": "6b5fa8cc670440316540c957d2e6bdca8de6cbd27c86d961005d908033d70aba"
     },
     {
       "entityType": "craft",
@@ -54796,7 +54796,7 @@
         "item:renaissance_furniture_car_harness_stand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7da81fc35f64d92f20e7e890e40077272c50ec9d6bd04c9943e6dcbd02ae9d68"
+      "fingerprint": "0be8dd3da8a95864f267351e58a703ab481260f3d7c066702d859b77f071ae4b"
     },
     {
       "entityType": "craft",
@@ -54809,7 +54809,7 @@
         "item:renaissance_domestic_sahel_redsea_indianocean_brass_ewer"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e05d5e15c685fd6df1a6003e13ca7bff2dd56f7ec3bded195973b40595458a7c"
+      "fingerprint": "69d1ada37dbfbc0ddd1c156c4cc2cc335028e81a13d795c973c564f67583a50c"
     },
     {
       "entityType": "craft",
@@ -54822,7 +54822,7 @@
         "item:renaissance_military_hussar_peytral"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e3f6f88c4b0d8eacbd6aef86d2af583a13bc3e41f30bb4fe8b36b41a368192b7"
+      "fingerprint": "559b4d0bab97d0d464725bb057e7dd1aff85c2a3060c9ee0e20b8121871b31bb"
     },
     {
       "entityType": "craft",
@@ -54835,7 +54835,7 @@
         "item:renaissance_furniture_iba_campaign_desk_04"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8e9450d090fed766753e4faf50c8a8cb0fe208411ff894597b0aa68ed9116ffb"
+      "fingerprint": "d110b2af30a4e9ab08aceac7a15c8db4fe666785acf10fed187dd50226b4a11e"
     },
     {
       "entityType": "craft",
@@ -54848,7 +54848,7 @@
         "item:renaissance_personal_japanese_ryukyuan_brush_case"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "5ee737875bc12a2c9ed88ef204b2e3490966118dedbca56ca51f4201ed8b9d2a"
+      "fingerprint": "7575b9a8b84b1e1a4f0da53765d175b321e1ab804d6063403fb036576bfd794f"
     },
     {
       "entityType": "craft",
@@ -54861,7 +54861,7 @@
         "item:renaissance_furniture_ott_glazed_display_case_04"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ad4d0d1ff5aa31a07a79825d904100d09d03db2e46317eced3b8c69d4453a170"
+      "fingerprint": "41c9316c0b86b9d9398d2765adf6e387d78eb46e5d2dfae476b6fad52440eeb7"
     },
     {
       "entityType": "craft",
@@ -54874,7 +54874,7 @@
         "item:renaissance_domestic_south_asian_merchant_ghee_jar"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "6b0153d03495b36c8dbeecd6e635322d90c32b47befe864dc09b266695b64fd8"
+      "fingerprint": "d57cbe56277f439419104cdf9afefaa09b4dec143aafd6603346596e9b26e5f5"
     },
     {
       "entityType": "craft",
@@ -54887,7 +54887,7 @@
         "item:renaissance_domestic_western_counting_house_counting_room_tray"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "f333502c9441efc7bbcb5ce2dac760786288dcc00d8f8c41fd9765f049b1698a"
+      "fingerprint": "8bef7675f2a73a0a1e331760f2fde40c8fd5f38c3bcc31435eb7a9ef63ff72db"
     },
     {
       "entityType": "craft",
@@ -54900,7 +54900,7 @@
         "item:renaissance_trade_japanese_ryukyuan_lacquerware_shipping_nest"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "86c53523f4cfd249bf3ed0edfc014a23eff9c01c85cca63212e790ac6d0d9e74"
+      "fingerprint": "f3409bfe5c1583ce161c9862b94391443b721c6fd5a3f486d1abecb2ae392973"
     },
     {
       "entityType": "craft",
@@ -54913,7 +54913,7 @@
         "item:renaissance_personal_west_african_court_calabash_sling"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a3ee6fb6cfe32a6d5aab21d230ec298adab4bef791d056e41b0a97d2babb1a18"
+      "fingerprint": "05bba999222d6d6efae7a7e080cf50af056c3db97d3583ffe25dcbff2fe0d8f7"
     },
     {
       "entityType": "craft",
@@ -54926,7 +54926,7 @@
         "item:renaissance_personal_southeast_asian_port_gourd_bottle_sling"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "5ec3eed4bd2d24e7a93eabe8d8264a6711d6cf46ad28eeeb84d4b9b41726bbf6"
+      "fingerprint": "a25b54ae336ca20e1c027ec9a8f4f81177f7eceed8039e662886cf6ba29d0d89"
     },
     {
       "entityType": "craft",
@@ -54939,7 +54939,7 @@
         "item:renaissance_furniture_eal_map_desk_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "905ee57f01a25fe9a36cd007b43f6c9409316212e1739b0a31a1c995f40a36db"
+      "fingerprint": "26dc9680238f7c9e2504d60d83673bbf4b95741b2dec671d21cbce363b3a1330"
     },
     {
       "entityType": "craft",
@@ -54952,7 +54952,7 @@
         "item:renaissance_furniture_stp_campaign_desk_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "94549b32655a50c24583935869195b1a2ffb50a0e2d8f00996c7fdd666ec8d24"
+      "fingerprint": "99ab7f2ae06c18cc81b00f74bf5818f4e876465cd55b707d8cbb045f3e9f12f0"
     },
     {
       "entityType": "craft",
@@ -54965,7 +54965,7 @@
         "item:renaissance_furniture_pip_wall_cupboard_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d5f1c03e3892c76395a6d36b771128f67b6fb61d7b788a578e48cc4d8f82aae0"
+      "fingerprint": "e6eed65451b9e875aa3c3aa83703597ba10678f464bd412fca3de0aa8953e123"
     },
     {
       "entityType": "craft",
@@ -54978,7 +54978,7 @@
         "item:renaissance_furniture_eal_folding_display_stand_05"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1cae1c15bb6bf2a81634181c011b7fcfc924fc2aecb1efcc0e939f8cf1383031"
+      "fingerprint": "501dc27de6622c9b9023da674a90ae323ec306b067404331bf0445288a550709"
     },
     {
       "entityType": "craft",
@@ -54991,7 +54991,7 @@
         "item:renaissance_furniture_iba_tall_drawer_cabinet_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "4e09dc3c2a2180e18a12fc990dc337f0b3aa2f9c7d78a81c2ef2aab3d711197c"
+      "fingerprint": "95e4911b764447d555676adadcc87e91e12e157bbac7a488359a4c5a0a7c756e"
     },
     {
       "entityType": "craft",
@@ -55004,7 +55004,7 @@
         "item:renaissance_furniture_aca_folding_display_stand_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d17d9e495260a591b0a24a0eeae6c8faed0e69a5729e0dcc92840c3a51cf389b"
+      "fingerprint": "a7420b0386e110fa9cb0f13b8ac6a21697109e98f65b69642e62024ed893bc89"
     },
     {
       "entityType": "craft",
@@ -55017,7 +55017,7 @@
         "item:renaissance_furniture_iba_harness_stand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "cb316b650e6deb1bc9a96a456d3b1df7e7e3ce75e4661b6bbc7b693f23f4a683"
+      "fingerprint": "bdb5643e85bc95e230e0cc2b15335f51d422df978d601694c3cafda4854a5d4f"
     },
     {
       "entityType": "craft",
@@ -55030,7 +55030,7 @@
         "item:renaissance_furniture_jpn_mail_stand_04"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "44c57bd9b3e81f05ed3c81226b00e1d8fdf3aec32aef1e4a40f6c8049a8025d9"
+      "fingerprint": "b29c7ff8a03070740908b2c4d665ed62d01a009fd838364971dfd0224a8825e8"
     },
     {
       "entityType": "craft",
@@ -55043,7 +55043,7 @@
         "item:renaissance_furniture_ind_map_desk_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "cdceea57c393b3c187e8504a1a572fa2ae36c59c74ccea2d915f3c45ec372fc1"
+      "fingerprint": "7c2f628e33036ff0697987c4a11356958b6f1668aa8cf14317b5e4719f9175f1"
     },
     {
       "entityType": "craft",
@@ -55056,7 +55056,7 @@
         "item:renaissance_furniture_jpn_nightstand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c7a211e80f6a10ebf614c8ba82673ab9fa908ef484118a131e7fb1e7ec43940a"
+      "fingerprint": "00499f0c69807d4e80078af8f9ea0aa24c7134e07079ed62004f3d1a09a36099"
     },
     {
       "entityType": "craft",
@@ -55069,7 +55069,7 @@
         "item:renaissance_furniture_east_asian_literati_display_shelf_stand"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "447f2111e035b9afa851d6b432deb758fb732344c33ea1d43ee1edbc73b3ea44"
+      "fingerprint": "0a60256ec091b826512b6d56c0ee200d8e48ac4ca4864a4e4369c97482be0a1e"
     },
     {
       "entityType": "craft",
@@ -55082,7 +55082,7 @@
         "item:renaissance_military_barbute_open"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2da9c3cabffc65aaf9ae8593fa7465e086e3c6875559abea01c1e787ce596e1d"
+      "fingerprint": "1ccd6ce001d621ad7d82f87837bb87118ec17be9a01ec7989444ac0826be3ffa"
     },
     {
       "entityType": "craft",
@@ -55095,7 +55095,7 @@
         "item:renaissance_furniture_sem_armour_plinth_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b8c2fac683587a353afbe5d511438a283f38b083f7fd7f0e94a361e89537fc7c"
+      "fingerprint": "c7dbeda36ef030c74029247ad97aa59cad5e053966224a59dd6680cf19e3569c"
     },
     {
       "entityType": "craft",
@@ -55108,7 +55108,7 @@
         "item:renaissance_container_eal_personal_shoulder_basket_04"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2629a6643ce39cd1791eb918a1a9a6c9fdd48f261ee54b6c20a8d4cda6f5d93c"
+      "fingerprint": "9c71d9e8a43c7058183e71470dae44e8a4ff016b7b977c580f304f25700460f0"
     },
     {
       "entityType": "craft",
@@ -55121,7 +55121,7 @@
         "item:renaissance_furniture_sem_glass_front_cabinet_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "dffce5a793e1eb260121c76f037ff90f522996a9b2512228469472d37734de42"
+      "fingerprint": "a4a868c83f1840cac4868aec19ada68c7a72126244bade36b34f3d800c57368e"
     },
     {
       "entityType": "craft",
@@ -55134,7 +55134,7 @@
         "item:renaissance_military_hide_oval_shield"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "740f9b3fe7906391200710ed1172680384a66ed5dd6bca7abde6be5f3276f580"
+      "fingerprint": "9e16db6b931a9e66e5f02e4baf9bb488e5dd4f5596f493aa11afe5c02be904ab"
     },
     {
       "entityType": "craft",
@@ -55147,7 +55147,7 @@
         "item:renaissance_trade_warehouse_dock_bottle_sample_chest"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7a21ac24ba2054ce50a8cffb56a560130ed90b7f55ad792d15688a96e5ea774b"
+      "fingerprint": "c5ac6dd5f2f8255c22201b2867b68561d625a103eec03367e25f30a00ef151fd"
     },
     {
       "entityType": "craft",
@@ -55160,7 +55160,7 @@
         "item:renaissance_trade_andean_storehouse_chicha_vessel_cradle"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c645e99e1b260c6fdd88fd43bc050f3b95912e591462dae4e5549ddd1c04ebda"
+      "fingerprint": "2480e7fefc11215b1a67e066b8c97379ab717566defed6523a992009f0f0fcfb"
     },
     {
       "entityType": "craft",
@@ -55173,7 +55173,7 @@
         "item:renaissance_trade_apothecary_perfumer_vial_transport_case"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d3e70c80623f1a957457c72751a9437ccfa859d6cee8f46c503c58fc97d41f84"
+      "fingerprint": "a3f43afc97624526f53ab10d5b8e20bc12e6ab32b5415acd6a5324115c7c1742"
     },
     {
       "entityType": "craft",
@@ -55186,7 +55186,7 @@
         "item:renaissance_trade_east_asian_literati_porcelain_sample_chest"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "09e3dde58044841ef13bae9002da08401faf21175beda51e96497a38b1f9917c"
+      "fingerprint": "074b649bb1be14cd9471e096f3fa8873b9bc7499f3e97cb99b2766c10fb27096"
     },
     {
       "entityType": "craft",
@@ -55199,7 +55199,7 @@
         "item:renaissance_trade_elite_household_scent_bottle_case"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "70d51eece9e3a23d7a0f65f98eb477c33d528bd69e94dbd0000dd3ac57542c5a"
+      "fingerprint": "4b326fdd28dc4ae5887b00c3211a5236cc846727fd4cc1c2a96afe8d6a62edaf"
     },
     {
       "entityType": "craft",
@@ -55212,7 +55212,7 @@
         "item:renaissance_container_ott_domestic_serving_tray_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "0728c22ed4596b945fd0d807b1b4e2e79f504632b3a0246ab6ab37adc8d7c4bc"
+      "fingerprint": "bba502020ae50c91fd7abc25fabb5bf6df4c8d5ac69bdf38e7c54f7ab7a95328"
     },
     {
       "entityType": "craft",
@@ -55225,7 +55225,7 @@
         "item:renaissance_furniture_ott_harness_stand_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "afc506d1eb5c20101f58fda1435f65d3d5aae493b02e63a0bff08c9e8e75b8be"
+      "fingerprint": "181a719cea23ba881e7645cf414f9192c9870e171b38e00c70cc870b96ca6e5d"
     },
     {
       "entityType": "craft",
@@ -55238,7 +55238,7 @@
         "item:renaissance_furniture_ott_travelling_wardrobe_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "6c5db847f5e1eea6c8ac7d947eb15672be24603c801c70e6e9a1b7e8418ace00"
+      "fingerprint": "fa895a45c00110d73f42d16a00871857a4a795892d6a3c099a926f7947e747d7"
     },
     {
       "entityType": "craft",
@@ -55251,7 +55251,7 @@
         "item:renaissance_furniture_ott_vessel_display_stand_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1b973d9862c18c5a3571b6a24b74fcafc71fd46a645f4166eebb0226678264d2"
+      "fingerprint": "fb1d5cfcb6acc453fb413450e00aeb3e270d34794b108a178140ba5fd80ba1a8"
     },
     {
       "entityType": "craft",
@@ -55264,7 +55264,7 @@
         "item:renaissance_furniture_msea_armour_tree_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "50fe191cad18beeebc34a78161c486b78bc0fe3c1c2acb2ef260c358f0074724"
+      "fingerprint": "1b525b0bb6df11aad142753eb7368ccbe1b80a36373db34efbf26f7efffcd451"
     },
     {
       "entityType": "craft",
@@ -55277,7 +55277,7 @@
         "item:renaissance_furniture_sai_campaign_armour_tree_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "fa58352d5d0b9f722509aa6f11aad36c3f297fc9c8b39d602319f59d06bcc39c"
+      "fingerprint": "9b034cc66ac0ec21acf26d5bcecb369e7d92adbf9eee204e42a8524857e25065"
     },
     {
       "entityType": "craft",
@@ -55290,7 +55290,7 @@
         "item:renaissance_furniture_mea_lock_fitted_armoire_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d367c6b43d756bbcec18789978bc0335b7360c239fc6db18991e0577df97e853"
+      "fingerprint": "15a6dc0e0ddbb9516d211ff68e74ce6ed64ad8885ad77738c1c5e479b27cd4c5"
     },
     {
       "entityType": "craft",
@@ -55303,7 +55303,7 @@
         "item:renaissance_furniture_msea_cloak_cupboard_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "70edbb20fc5dec72fadcf9be7612c5cc351564f756931216f21939dcfefb83c1"
+      "fingerprint": "d97a18fe22d8c3e7a84ba6779b44626ca365c79fda4202eb29607c3d101a5508"
     },
     {
       "entityType": "craft",
@@ -55316,7 +55316,7 @@
         "item:renaissance_furniture_persianate_court_manuscript_cupboard"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1e2610efc9bbfe8b4e42878682c45d147378307d2eb1e2721383575bab1cc8ba"
+      "fingerprint": "ee33b22bd1449467d45aaff1dcade355a368a53872a41a4acf700db849ef1700"
     },
     {
       "entityType": "craft",
@@ -55329,7 +55329,7 @@
         "item:renaissance_container_col_liquid_washing_basin_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "0e51d77f5e5ae3487d6ee3a58e50494fe6a800781c103d273e37fe2ac87049b1"
+      "fingerprint": "2d59a1443178086d91a1392d7746899f6852dc996613708664c9a2f425199005"
     },
     {
       "entityType": "craft",
@@ -55342,7 +55342,7 @@
         "item:renaissance_furniture_elite_household_bridal_cassone"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e53e1921a0df441718bc30f85e4ebdce53617ba507f97a2a0c5ff708cff20f56"
+      "fingerprint": "fbd07ab5d87771bcbab2b8fa15604420275ce81baa7a18460e00cbb96b52ca4b"
     },
     {
       "entityType": "craft",
@@ -55355,7 +55355,7 @@
         "item:renaissance_furniture_ott_open_display_shelves_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "444dcfe36106ce9c31b7968996c1185b170c29ade90e2c78c6eb93d08c40b286"
+      "fingerprint": "ef13ba9e9db1a9dbae1f82ca74d525c4a27f75a7e494a861ce9fb6b6ca56a844"
     },
     {
       "entityType": "craft",
@@ -55368,7 +55368,7 @@
         "item:renaissance_furniture_aca_glass_front_cabinet_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "550eadcd9c72c429cb982641d18c17b3451eea971c2731da6a72bf108e9af523"
+      "fingerprint": "479b6ee19e8ad1bcbc2053bd90902f86ce13dbd5c959445a105d6fba62a5fa2c"
     },
     {
       "entityType": "craft",
@@ -55381,7 +55381,7 @@
         "item:renaissance_military_ming_brigandine_panelled"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1587860ed8492a3c0500bc7280ed3ddec099d696ff67124a42ba0866ed70d6e6"
+      "fingerprint": "377b9abf1b94e6a69a47418776fe4403d7efce5e5ecedfb674e19581ab93ccc1"
     },
     {
       "entityType": "craft",
@@ -55394,7 +55394,7 @@
         "item:renaissance_furniture_western_counting_house_account_cupboard"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "15088c5c932ecfc77c5a1d840153893d0720da4f1c0481d6fa32635b0b72025b"
+      "fingerprint": "17ab15d7693565e5591567ee7e516fdebbffd2cd1b008824179b73959472f110"
     },
     {
       "entityType": "craft",
@@ -55407,7 +55407,7 @@
         "item:renaissance_furniture_iba_compact_garment_cabinet_05"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7df5c3801066551566308f01b1a0d7de7f5d2baeeec66650e1410d68a81d45d9"
+      "fingerprint": "ee5ea4070ef657d4f192cf6e8320df4920d8354e80bf29c89fe3b549f3c9807e"
     },
     {
       "entityType": "craft",
@@ -55420,7 +55420,7 @@
         "item:renaissance_furniture_col_robe_cabinet_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ae03471920e594fd4e9309e052fbbdb23665da01911afea008e2de2be4247cca"
+      "fingerprint": "aa57b5a5be9cf622e373aa0f646a3f7aa147636ccfd2ecb980717a73903b3a00"
     },
     {
       "entityType": "craft",
@@ -55433,7 +55433,7 @@
         "item:renaissance_furniture_civic_guild_seal_office_sideboard"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8d237cc3205984cd5a0a8a53ac8993a298b6a397277cd91c946ddb2358f8d74d"
+      "fingerprint": "30e8fc17f14577cc6c2ba8fd4845db97ff35266d2ef1c07f11d7e39c9fd5bc5c"
     },
     {
       "entityType": "craft",
@@ -55446,7 +55446,7 @@
         "item:renaissance_personal_andean_storehouse_coca_pouch"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c150fb433c377716ad1cb4fa760fca7b7adfeb60a4391878b8b6af2b708f6ca3"
+      "fingerprint": "c3518cc7dd69c8c37ddc7256d1b57bcdb625a2629eed6c9d67eea2420c2f49c6"
     },
     {
       "entityType": "craft",
@@ -55459,7 +55459,7 @@
         "item:renaissance_furniture_aca_sword_rack_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ea7b19ed12e8bc072518b94e8b723f41d9e8ad57c708f670350406ac96780ee2"
+      "fingerprint": "b0f0d227fc52e25a7188f0ebfdebb6ddeb2974386b1bf668733bf37788b9f678"
     },
     {
       "entityType": "craft",
@@ -55472,7 +55472,7 @@
         "item:renaissance_container_iba_domestic_table_service_box_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "28e78385da91eb5a962704e853dae260a2a1de02953b5e0f0a66972382e8a67e"
+      "fingerprint": "31a2376621098b9053dc266faca161d948edf4f798a042e673c66ddbcf4d106a"
     },
     {
       "entityType": "craft",
@@ -55485,7 +55485,7 @@
         "item:renaissance_container_mar_trade_fitted_sample_case_06"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "90013903b023a46b219d52008e6491c342a925901c8a63483065d07b6170531b"
+      "fingerprint": "840f2d42383cb36b7a0adb21830f8a27de72c46786739c4939a2c2ec3309123a"
     },
     {
       "entityType": "craft",
@@ -55498,7 +55498,7 @@
         "item:renaissance_container_cef_trade_locking_trade_coffer_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e79a73bd59337912fcdcc7026e98aac417eac71a852fc5f67228720e21c2bec0"
+      "fingerprint": "b856d116847bb40a25cd524ed0de5584549ec32f2778d1d057ef23db99f910e6"
     },
     {
       "entityType": "craft",
@@ -55511,7 +55511,7 @@
         "item:renaissance_furniture_sas_folding_side_table_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d204a88797c17cb46de536bd60ec3ca70a071dac5a61e1d0978a32cf9f049383"
+      "fingerprint": "a0d3182bc889a59f42a777ca41c3ef9fa8fb2a6ace4cf79b3aa3362a5f4c9b43"
     },
     {
       "entityType": "craft",
@@ -55524,7 +55524,7 @@
         "item:renaissance_trade_ottoman_bazaar_perfume_casket"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "5384bb90465a418bf3891eff8f42efe4d71fe0d050dbb2e25448c659c721ff82"
+      "fingerprint": "556f0819e0476e43d12e82146f1e290f09f5260e00bea8b132ac77d1d39fbfb4"
     },
     {
       "entityType": "craft",
@@ -55537,7 +55537,7 @@
         "item:renaissance_furniture_persianate_court_niche_display_cabinet"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b5ba5c510dd90104bb7f1d24f286cf7c4be370025e602082391b8deda90af371"
+      "fingerprint": "ad14768f32dc3931d8869ae4a6229cc7b60298404b3183d62c6e2cdc500b8774"
     },
     {
       "entityType": "craft",
@@ -55550,7 +55550,7 @@
         "item:renaissance_furniture_sas_textile_drawers_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2418b87aa1f5b6d6a3f11c84b9da99d299c4a42027c3de73558401ded739b2d5"
+      "fingerprint": "3cdd248e58beb99a6e327d382268bbb72ac22911ca387298843d86650c605b7f"
     },
     {
       "entityType": "craft",
@@ -55563,7 +55563,7 @@
         "item:renaissance_furniture_pip_matchlock_rack_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "f9e78e94db3be9e2287e43e333d9443db800f400f96774dc3711b2c0b7481cb9"
+      "fingerprint": "df396365830e7acb932d504bcaeed179f35286fd386a23cd83797e4da3472e5c"
     },
     {
       "entityType": "craft",
@@ -55576,7 +55576,7 @@
         "item:renaissance_furniture_wer_secretary_cabinet_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "00f8a90f4656cd77b729a1a2a51d89aa71eb590683ea46b83d283044c9dfd5c2"
+      "fingerprint": "d9380917ad0a37bc8e39d18f12bbed1eb9e04f4ad48439791918141f62178e72"
     },
     {
       "entityType": "craft",
@@ -55589,7 +55589,7 @@
         "item:renaissance_container_col_trade_segmented_packing_crate_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d1b0b329f548d45a01cc1badc59bdb56c86157eb1b65079c628c5dde59dd43d6"
+      "fingerprint": "762530b0c2463e7c71b241eb753b5860e9c5a870c3d83b953680de14009cd9e5"
     },
     {
       "entityType": "craft",
@@ -55602,7 +55602,7 @@
         "item:renaissance_container_eon_trade_large_trade_cask_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a8c5f44a92d5d429097a86b8292ccad863621130560540f433e6b96f558d759c"
+      "fingerprint": "053387c6d6a1db030f8adddd3912da771ff9d8c0f19c6428b528bb997593a316"
     },
     {
       "entityType": "craft",
@@ -55615,7 +55615,7 @@
         "item:renaissance_container_mar_trade_segmented_packing_crate_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "415605d0e501b377e41225ab6c66950051eec4d9d6d8a4a2edfb8ab72817297c"
+      "fingerprint": "b9e1bba3ebc5d8a39fd8171d50be0e38aa19a7b494b82dcdd3bf1f4fb5616ca8"
     },
     {
       "entityType": "craft",
@@ -55628,7 +55628,7 @@
         "item:renaissance_container_mar_trade_sealable_archive_coffer_07"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "bab3d6f34569926b6d2d6448fd96f4331cc0875ff2a4b757ef9b684b6d7b5b5c"
+      "fingerprint": "c250608a74babca39d369da5c6d753e55501541e80d567c7e265270561466ea9"
     },
     {
       "entityType": "craft",
@@ -55641,7 +55641,7 @@
         "item:renaissance_andean_pinned_wrapskirt"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b427a842c656b080c20b3e72922cddceb6eb5f1e2823034f089c73ba583a72a2"
+      "fingerprint": "a432cf588b283298709c368318d6907bbbbcc7c60f6a9c0f8bd7e6afa3064708"
     },
     {
       "entityType": "craft",
@@ -55654,7 +55654,7 @@
         "item:renaissance_container_iba_domestic_household_platter_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7ca0d5e0a2b11715c33bf6949352c5161c67d05315487ebc8bd765087f4698b3"
+      "fingerprint": "be281765ffce4af9c9676c015fb1b597ccae93deca2657674aea3f92050f6e8c"
     },
     {
       "entityType": "craft",
@@ -55667,7 +55667,7 @@
         "item:renaissance_container_eal_liquid_household_rundlet_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7c6bac455e58ccaa43653dcc85ba0ab612362909dfde88feded65404c277bf5f"
+      "fingerprint": "6ec0945781142cec446dfeae0276b1b79dc2ec47190eeb0f17e7e440c68adb29"
     },
     {
       "entityType": "craft",
@@ -55680,7 +55680,7 @@
         "item:renaissance_domestic_atlantic_contact_mission_plate"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "627ee4addea0cd5d9642640e9ef37ba005fd34a343c02c4eabf2bea940c49321"
+      "fingerprint": "bd42e9e756473267654d9fd2472b3c9527e2c3a8dc63330301a598d2bb2f4ae8"
     },
     {
       "entityType": "craft",
@@ -55693,7 +55693,7 @@
         "item:renaissance_furniture_mes_folding_display_stand_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c844417b969bad787d4f9a8d5aff1e8267ca143f556617d7d41df65b67a938ed"
+      "fingerprint": "5749ace4c369a65c2c06039cfa2b5e7fd27e6a32df3dadf3f9df5c8e79bff99e"
     },
     {
       "entityType": "craft",
@@ -55706,7 +55706,7 @@
         "item:renaissance_furniture_and_freestanding_weapon_rack_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "54180875acfb9e687b6fb7319f8527302c6f5a8c29357e94b7f1494eceb868cb"
+      "fingerprint": "5dcadad1f95a85bffaefcdd67e3fb31e3d955253a5782a8cb6d2f0c849ac4f30"
     },
     {
       "entityType": "craft",
@@ -55719,7 +55719,7 @@
         "item:renaissance_furniture_iba_slant_front_desk_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ec650ae59aa2387011bc7788fbd4375ad2cd3333bbf1d6ab1b7e1229c17acee0"
+      "fingerprint": "ff8a017cce69f17692b8ecaf553e15786b23d813dba27e2a8aba9c791a10bb2a"
     },
     {
       "entityType": "craft",
@@ -55732,7 +55732,7 @@
         "item:renaissance_furniture_jpn_campaign_weapon_rack_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "6f86b29e07215ecfe7834701a583edf19e6ca09ead1c8cdd1625c2f2ceb13585"
+      "fingerprint": "53553f266357a99ef361262bd791ccad0c564c3d25f3e82959d00c642e0a3a05"
     },
     {
       "entityType": "craft",
@@ -55745,7 +55745,7 @@
         "item:renaissance_furniture_eon_secretary_cabinet_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "449b93f5d9e2b010b9e45028927576cb47174202e9d8a71f2544508b28f9835e"
+      "fingerprint": "8f44b94b0c8169093c2e342218a603cc43d79e33d712398c3d756995522b92d6"
     },
     {
       "entityType": "craft",
@@ -55758,7 +55758,7 @@
         "item:renaissance_furniture_eal_chest_of_drawers_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "0418128f1421fa69a5fdca471f1b81e37c3a5a4f164bcf55f748ad35ed75f5b3"
+      "fingerprint": "364f031489bbbb5f563300ef3423f85cf313445a2da2f218d6d941d612a30f54"
     },
     {
       "entityType": "craft",
@@ -55771,7 +55771,7 @@
         "item:renaissance_furniture_col_escritoire_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "cebf48234164ad56b81b869c6ecc6096daaeb3709a2d9ce4cede8498cac9c974"
+      "fingerprint": "862d7fc26979eda55dea4b36f3234c626ed57619a87eb368bfcb8a6e77dabdc9"
     },
     {
       "entityType": "craft",
@@ -55784,7 +55784,7 @@
         "item:renaissance_furniture_eon_household_cupboard_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ee52fd7c2f0471c500e744584a063b9d2ada57cedcce66e6196346545e93c7f9"
+      "fingerprint": "042a9460ac8cf6997c453eb26e495d4f0bd65374fee408b0ebb33ffeceda4f22"
     },
     {
       "entityType": "craft",
@@ -55797,7 +55797,7 @@
         "item:renaissance_furniture_sai_vessel_display_stand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e2e95e686c43ee549d66e2be38dc6c5487b8833ddb4d08b79cf00d98901d19f7"
+      "fingerprint": "018cfdef6dfbe8e0c2fc23601ffc0ac1aacb6fe5125e05d25c9b3d13646f77ab"
     },
     {
       "entityType": "craft",
@@ -55810,7 +55810,7 @@
         "item:renaissance_military_katana_plain_mounts"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ee69661abbfe163ded3dd62bb640ad0693f41b35486e5e99f24e1da0cc92e091"
+      "fingerprint": "bb745b313945f163937a060d68a6922e32ae6ad2d250cad5baf6e6e58ddccd4f"
     },
     {
       "entityType": "craft",
@@ -55823,7 +55823,7 @@
         "item:renaissance_container_iba_personal_belt_pouch_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "54bdda4b42a30d71e179f64e13720ea96fc926d668935672cb873af1940a0c3c"
+      "fingerprint": "18857e8557362563b9481d23eb74f34d2046a331b9ef15016d2a0a3dd12f865b"
     },
     {
       "entityType": "craft",
@@ -55836,7 +55836,7 @@
         "item:renaissance_container_eon_personal_shoulder_basket_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "40c8f7b34bb9c22c0aa374a92451cffe36d1ac9c10c0fb294b24fdab3867b551"
+      "fingerprint": "1aef0373e08f3c12e7bc567a1a13cc6689235399301ee72ed16feaeb96dd8223"
     },
     {
       "entityType": "craft",
@@ -55849,7 +55849,7 @@
         "item:renaissance_container_nba_domestic_bread_basket_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7a9b16564bba2b704e9192704bf8fe00e9a896e3310953a255c97447241dd7bf"
+      "fingerprint": "fbbc224a499b0f6f9ecf8f57cb4b76366eb3ded5ef9c474783df050ab0968b27"
     },
     {
       "entityType": "craft",
@@ -55862,7 +55862,7 @@
         "item:renaissance_military_plate_greaves"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "78cbbe0feeae0fc5c0c49c7f916b5c101a5809bfa41cc34c08a7f8e9e674df5b"
+      "fingerprint": "e250c7e34ee1da441e5e9128a1459a34d32b9a038ffbbb707fc9e0b833ee046a"
     },
     {
       "entityType": "craft",
@@ -55875,7 +55875,7 @@
         "item:renaissance_military_kuyak_muscovite"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "eae1e877f9b86bf5aa94ec910b9b71b597a876ab9c523b376c378b0ab28693b5"
+      "fingerprint": "01ed648050f4e378b1f2ededee8e7f1daf40362c5632bf10a3433ec4cc5856dc"
     },
     {
       "entityType": "craft",
@@ -55888,7 +55888,7 @@
         "item:renaissance_military_barding_peytral"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "4a87e9adfc0f7b83470a1b07819110cce15398c03f48c25d5265dc79238b6ec1"
+      "fingerprint": "5b5fd8ef50e06d1f213a0ff0c786aa12fe5ad3fb689963b0278405e9ad6f7ab3"
     },
     {
       "entityType": "craft",
@@ -55901,7 +55901,7 @@
         "item:renaissance_military_janissary_vest_plated"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "90f115ee9d8ef10d26e9919cd6f24f6efdd2b3d54291f917650fef6fccc2d7c5"
+      "fingerprint": "102f7d0ce202080787f8fc27db96412f95ff2121a0e245fe9327ec106348c457"
     },
     {
       "entityType": "craft",
@@ -55914,7 +55914,7 @@
         "item:renaissance_military_zischagge_hungarian"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2938518c404a5f95885463aa0fe450644d498312d781ffa1abb6150bd467e0f6"
+      "fingerprint": "df40f91fdcd36f8f04e90e861b2906abfda0c76134aca467142f21f7208bc36c"
     },
     {
       "entityType": "craft",
@@ -55927,7 +55927,7 @@
         "item:renaissance_domestic_atlantic_contact_caribbean_gourd_cup"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d74f2e87e6db992ecd8c0dbc3a0d193c420049b0039af4568cf7baea5d068f4d"
+      "fingerprint": "35f794ff82893ec16c848d8200c9399028e5fa87261ebacd1853297f044add98"
     },
     {
       "entityType": "craft",
@@ -55940,7 +55940,7 @@
         "item:renaissance_domestic_mesoamerican_market_gourd_cup"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "63ac484df2e8900340fd311fce0647b7a02736be5e5f9c00b1aa54c04cd01c54"
+      "fingerprint": "9f134cd379b1d3fa05f89f809ecade6af1b4cad7b66afb5e4cc58dec9a6e8988"
     },
     {
       "entityType": "craft",
@@ -55953,7 +55953,7 @@
         "item:renaissance_domestic_sahel_redsea_indianocean_horn_cup"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b090c0a17553bfa043f4752bb5533e5ac957e8e53f2a8b75ecbff6439bc6b94a"
+      "fingerprint": "2640288d932b514ddc5093658049ffa0344b5e299abc564d140dc92bcca7f1bb"
     },
     {
       "entityType": "craft",
@@ -55966,7 +55966,7 @@
         "item:renaissance_domestic_southeast_asian_port_gourd_cup"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8570313a7acb4810d210b9ce091c29ab5c1da610984959733f0998057871dd94"
+      "fingerprint": "afb76711f5f0cdfc5d5cf569075a04a38cfd56d3c66898770104b1101bc9f171"
     },
     {
       "entityType": "craft",
@@ -55979,7 +55979,7 @@
         "item:renaissance_domestic_west_african_court_gourd_bowl"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "50e67502c87a0df03657aa34c09eaf9ec1db16dea20c6237dde913fb72a14d08"
+      "fingerprint": "25e42b34424b7b0a9f81ba94bf17b76fb8ff21ad4a7971dda7d80b07351cd776"
     },
     {
       "entityType": "craft",
@@ -55992,7 +55992,7 @@
         "item:renaissance_furniture_apothecary_perfumer_dispensary_counter"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8f62cb8cd2696c249d217a4037d7ae092209d8323646a27c8631f1cd888a46df"
+      "fingerprint": "478656d1439db2bca52fb29c3f8c71396f87dcdff4aa92b229cbc36bec7d64bd"
     },
     {
       "entityType": "craft",
@@ -56005,7 +56005,7 @@
         "item:renaissance_military_half_harness"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "78eff58a27ea720d406cd089396d8bb56ce2336e5b090f637dfb8411b6158959"
+      "fingerprint": "aa5141c90a7d4a31159a44f6be2773a6754c06e169d2c7dec5951fbf8df86a7c"
     },
     {
       "entityType": "craft",
@@ -56018,7 +56018,7 @@
         "item:renaissance_container_jpn_liquid_pouring_ewer_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3cdbdce72156e62bd7336a85021b0025e6dd4046fa0b16033baef6d40765336f"
+      "fingerprint": "74e8745813d2abae29651ed52e839da37e5362673f52c2d45e5170f28ecf1096"
     },
     {
       "entityType": "craft",
@@ -56031,7 +56031,7 @@
         "item:renaissance_domestic_steppe_caravan_horn_cup"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "9f42f3c47131bdf48a37ed004a9971316055ba749d0bd386fdbab190976a18e5"
+      "fingerprint": "ae3d371b708b8bd51c4dd5584c818ac9973ac488e935169a5181c66d44b9766c"
     },
     {
       "entityType": "craft",
@@ -56044,7 +56044,7 @@
         "item:renaissance_military_lead_ball_055"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8de67fbc0b8006a025b911a95ebe395ca654421007445ae9d69111061217d9f3"
+      "fingerprint": "709b6fa64cc137087dcde270e8f9fc25e7feec45392a4126b46b13bceda123a6"
     },
     {
       "entityType": "craft",
@@ -56057,7 +56057,7 @@
         "item:renaissance_military_lead_ball_060"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "cf041e2bf29bb250f8e651623e88ba1b3156c68656d502fab8af4a5e1a0328ce"
+      "fingerprint": "75a5c31ea99c0ac5d545fd5f9ffd783a2e0e79b4749433f5e70058a8fd338f3f"
     },
     {
       "entityType": "craft",
@@ -56070,7 +56070,7 @@
         "item:renaissance_military_lead_ball_065"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e94200ae8ec102abe5ba7cceecc839ab0cd7599f608ed29a2e51f708f037fc2b"
+      "fingerprint": "5f3d8ae83c19921c9743bf36cc76031561b535c7be2c4b8533aa674b5f08d869"
     },
     {
       "entityType": "craft",
@@ -56083,7 +56083,7 @@
         "item:renaissance_art_proportional_dividers"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ac200f7bf7fb389fef1dd518676ef6d85f2aa4c388ce653eb97031f7ca3101a1"
+      "fingerprint": "9d0fa3f0acc13c7b13adfef9ea375c77bea08551f075e7573feb789f8f5118de"
     },
     {
       "entityType": "craft",
@@ -56096,7 +56096,7 @@
         "item:renaissance_container_mea_trade_deep_trade_hamper_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "9f5682f0a793bda7aad2dc631a9929855c41c200bd8d3307279c0c78e0b9d5e6"
+      "fingerprint": "19575954c01a4bd6a8eb52ff79cbaa882f9255f009063c5f7b4445bfdf33379b"
     },
     {
       "entityType": "craft",
@@ -56109,7 +56109,7 @@
         "item:renaissance_furniture_eon_bookcase_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b1c9fc26592665202d8c55394df0e5f754f55e01dc7651d8a8beb653f5cc5e0d"
+      "fingerprint": "9d15124dce38f02718d42142830003ae34f02a8bdbca7c9c94f01038c8d9fcc9"
     },
     {
       "entityType": "craft",
@@ -56122,7 +56122,7 @@
         "item:renaissance_furniture_eon_garment_armoire_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "0e98f7441678cc8fa590ea6b45336371598413fdfd5346a3c39c50d0bfabda63"
+      "fingerprint": "60d6b1fab2dc2101d9cd3eac665db61e0d3a5443391947bfc8f42f59b0e31e2d"
     },
     {
       "entityType": "craft",
@@ -56135,7 +56135,7 @@
         "item:renaissance_domestic_japanese_ryukyuan_lacquer_tray"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "604a8ab39bb339aa28dd928115ce5691ce06ca7aa3009a6e3c08702d03d4f70e"
+      "fingerprint": "9a3967a646e33e31cf89d9c22689c56ba30f15f9a4c929c85199c625edf3a7d6"
     },
     {
       "entityType": "craft",
@@ -56148,7 +56148,7 @@
         "item:renaissance_military_composite_war_bow"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "cf4f894be0c61ec3474d0516ea9612e83d798fd7c9d90f707fd837be5c6bc18b"
+      "fingerprint": "8bcba78af7347fe652e0d71b62b2d0007427e4bf6175f405fbfc6481708ae982"
     },
     {
       "entityType": "craft",
@@ -56161,7 +56161,7 @@
         "item:renaissance_container_ott_trade_segmented_packing_crate_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a4e9fc34559f3f66fe67b3966e96f61559bbd3300d4ae9188b228366efbcb132"
+      "fingerprint": "0c9410737d17fbb2fa6c0a947300a42262ec1e1176b175c9e45068ba45e31c8b"
     },
     {
       "entityType": "craft",
@@ -56174,7 +56174,7 @@
         "item:renaissance_container_aca_domestic_household_hamper_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "0b0befc0df3af6b98beca7bc10710db993cdb0385083f5de2303a55679759041"
+      "fingerprint": "9a97b16dbcf4a47cb8f379481207423d466a4a5d89853cabfd6baccdc1f19ba7"
     },
     {
       "entityType": "craft",
@@ -56187,7 +56187,7 @@
         "item:renaissance_container_stp_personal_shoulder_basket_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "06674473388eeb31401c80fb7bff7657322bfd0eab7a38624afe758baeb177fb"
+      "fingerprint": "bd8a5fb45976943a3d916579c46f4f705671ac4bd16ddc0cd1422fb29ca0c040"
     },
     {
       "entityType": "craft",
@@ -56200,7 +56200,7 @@
         "item:renaissance_furniture_sai_nightstand_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "5e45b846dc5eafba0b6d03947251abb48fa4b8ed2307a00008c2627aea581413"
+      "fingerprint": "8731b7ebc6709c61f05d447dddf9ff21d59aff08c3748c434497e8201861ac9f"
     },
     {
       "entityType": "craft",
@@ -56213,7 +56213,7 @@
         "item:renaissance_military_jousting_breastplate_reinforce"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "83de780ee2caf63aba3148f171278dc654123e692326a291d0277c74c4b5b12b"
+      "fingerprint": "b4ddd21b5b2c259594888dbdc3ef4978df0f8e52d2e23e6d784956d9e455c8be"
     },
     {
       "entityType": "craft",
@@ -56226,7 +56226,7 @@
         "item:renaissance_military_hussar_chanfron"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "4fbbe2b55e0a715d6eb2281bb817a98e937842657b8d0327acfe0354cc8e0912"
+      "fingerprint": "09f8d1994c27b8c978648c8c40888809833cbcd18eeb6bcf7b9723bd8aca91a0"
     },
     {
       "entityType": "craft",
@@ -56239,7 +56239,7 @@
         "item:renaissance_military_hussar_cuirass_ridged"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1fa8c6186146f5af7f24e2f6ad780c670e8280736fe564f2910f4fefdf24903e"
+      "fingerprint": "f8e57def6ff798a201ffcb58be70635150864d022caf8a49c8796f4938f7ecc8"
     },
     {
       "entityType": "craft",
@@ -56252,7 +56252,7 @@
         "item:renaissance_military_main_gauche_ridged"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "bbf7003339a5ea213a277bd5f754e931d2a7507ea103cd9891b4f667a4eee084"
+      "fingerprint": "3e2a59382d4e0bd72f73b48af46f008e56dab86bff0657af5e8132e7e7e0ea6b"
     },
     {
       "entityType": "craft",
@@ -56265,7 +56265,7 @@
         "item:renaissance_military_pasguard_plate"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "85accb78cca3c573f2de48d3de0fd342092b92855b610738c834c5ac411d8d3e"
+      "fingerprint": "126da7f54e964bfcf2afce4e9a4dfdeda2a9f0f12681b27267e602b02ab5b9cd"
     },
     {
       "entityType": "craft",
@@ -56278,7 +56278,7 @@
         "item:renaissance_military_cabasset_ridged"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2f5e6410818a18ac2fb9804cbae9261948a12df53e0523d1fb1aab9eff1b1a44"
+      "fingerprint": "6e5e3c029d2b07e02277aa4261ec5278785bc27bc65a67d2f83fc48e3a2031e6"
     },
     {
       "entityType": "craft",
@@ -56291,7 +56291,7 @@
         "item:renaissance_military_barding_chanfron"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1faaefe088fe56a8c9c09afcc84cf59915e39b7c51cc423459bbbb76257e1395"
+      "fingerprint": "c5952999f4896d34642d819bcb0c9125dc5bb93c4a0825dbeff12af4f407bbf0"
     },
     {
       "entityType": "craft",
@@ -56304,7 +56304,7 @@
         "item:renaissance_military_brigandine_coat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d3ff57747b3d08dd77668841d436bff51be9d3f4021a4cff778b92a26eaef4a1"
+      "fingerprint": "988dc456218f753824f79ae5ce7aa3b38989c2710ae9e125ecf25f19c5d44201"
     },
     {
       "entityType": "craft",
@@ -56317,7 +56317,7 @@
         "item:renaissance_container_wer_liquid_pouring_ewer_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "5cb089c571b5093abdd4eb3dacb81a8e18d01a6a06ddce457eea4744e04e13eb"
+      "fingerprint": "4f54ca29fbebb63d99104d264c4ac32cc4ad72c6a8052468e28e5cb88af16f19"
     },
     {
       "entityType": "craft",
@@ -56330,7 +56330,7 @@
         "item:renaissance_container_ind_domestic_utensil_case_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8903a07d3146c41a2844f88c147c3a89af05b1c794ada9a90a07d1cc4decd7f5"
+      "fingerprint": "a276cf9d1650954ce9d628dc0d3973515ca7d8c956e07ac8659960d1714902ac"
     },
     {
       "entityType": "craft",
@@ -56343,7 +56343,7 @@
         "item:renaissance_military_artillery_gunner_tools"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "577bb6b205d2d20f5b03b1ff1af15f3f63c0922206300bb0fde0bbee4b1679e8"
+      "fingerprint": "07c7f8ad7e7b7d10a34475848b8105722be95ac8a8c81e0a2f0486bfddf14a32"
     },
     {
       "entityType": "craft",
@@ -56356,7 +56356,7 @@
         "item:renaissance_domestic_south_asian_merchant_spice_box"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c0154c78ff723f69e33524a0539564491d9b909a980eb922f70a9b3672675c5b"
+      "fingerprint": "a4cc7df9dd86d019acc133eed255866645f8427b50edf940fc13bc5659b91538"
     },
     {
       "entityType": "craft",
@@ -56369,7 +56369,7 @@
         "item:renaissance_military_buckler_fist_grip"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "5eb4e7d7229f1a7d6245a45b09c7e165354190646fac752c296a519434955dbb"
+      "fingerprint": "fc901e865af280b5dbf218bd6333121dfd1c2e8ae8dd5990e469a8d41129875d"
     },
     {
       "entityType": "craft",
@@ -56382,7 +56382,7 @@
         "item:renaissance_domestic_andean_storehouse_cooking_pot"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d126ef6a84d2b47e8b9cc464f57d61f2bc21b5c57aa59eee96980b5df4349a5b"
+      "fingerprint": "7d29175fd464615d848c4cdae922f33a3b1dc08b3d2e4d46beb10507d177d074"
     },
     {
       "entityType": "craft",
@@ -56395,7 +56395,7 @@
         "item:renaissance_furniture_wer_tall_wardrobe_04"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "77d40cb0a25c909b704c9bf3fc55f9a92bd767aff2e6319a028a3c7803e89e2a"
+      "fingerprint": "f0b3b26e921f871771cd395fcbccb77178cbeb5c86946847cbb7c04c9f98625e"
     },
     {
       "entityType": "craft",
@@ -56408,7 +56408,7 @@
         "item:renaissance_furniture_sai_household_cupboard_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "bb1bdcd8b06258ee4f4c205eab19d966fa14b16bccc063c0e2014bba09a0ce4d"
+      "fingerprint": "bdb62f0dc1b79948908f6739627e517d4b6dd9e5e9f2a7bc1bac97b86b8c33a8"
     },
     {
       "entityType": "craft",
@@ -56421,7 +56421,7 @@
         "item:renaissance_domestic_south_asian_merchant_water_pot"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "9f2847378efb81823244c9e4a759fdfc0641f1c2d5cbee7b9f3c4a42db90eb8c"
+      "fingerprint": "648fb116b50e8325e7d6c339b8535bb25579d5334cbf7b61eee187e55c84a72b"
     },
     {
       "entityType": "craft",
@@ -56434,7 +56434,7 @@
         "item:renaissance_military_poleyns_rounded"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "22127ec3a6ef21d9bafae32b54bc3117ab7f4810e6aeb8bed4b15700a9be6c11"
+      "fingerprint": "737706f1d2f8a3a793cb970875e314af45153d58b0f9a6776f861d7bfaf26d0b"
     },
     {
       "entityType": "craft",
@@ -56447,7 +56447,7 @@
         "item:renaissance_furniture_stp_statue_pedestal_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2b6506de04a5890f3932ef03bf8118ec30753fdd01d235b903fc4552339f8d0d"
+      "fingerprint": "684b5780b245d02e84dc951e8e3376c99ad9e58da391d282dcc44871eb4f32a0"
     },
     {
       "entityType": "craft",
@@ -56460,7 +56460,7 @@
         "item:renaissance_domestic_tavern_inn_stoneware_mug"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "49018f407153b4d49ed5dc537969d4e859bc63239b1732e7a7f0ba36dcf69056"
+      "fingerprint": "43d5340760d2508073adc001eec91881752be10b923ab19f3ef6328a81d86379"
     },
     {
       "entityType": "craft",
@@ -56473,7 +56473,7 @@
         "item:renaissance_military_tassets_scrolled"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d052493b4120441fc3741268cbb3d015e556b571c0e3ce3ad840cf62a1802fa5"
+      "fingerprint": "a3b189be41ae6aecb76f7389b89a7a65d88bfeeb877ab915489f0305013a624a"
     },
     {
       "entityType": "craft",
@@ -56486,7 +56486,7 @@
         "item:renaissance_trade_persianate_court_rosewater_transport_jar"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1d7c5ef9d63e26f518402e68f9b997e9ba031720c93908e7fe2aff6b8ba2e262"
+      "fingerprint": "a78649fa29c56cf4c6629dd4c28346aae1e313a8accf0fd77e303d06b22278c4"
     },
     {
       "entityType": "craft",
@@ -56499,7 +56499,7 @@
         "item:renaissance_domestic_steppe_caravan_wooden_bowl"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "5f1c632f9d217382676eec727b470530763d50b4c7b3d937bcfb842c9d06f81a"
+      "fingerprint": "00eb60ddb5685dac9db9dd33c6d3f1ea41647c1a41549cc90613feecbd358a5e"
     },
     {
       "entityType": "craft",
@@ -56512,7 +56512,7 @@
         "item:renaissance_trade_civic_guild_charter_packet_chest"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8c927e03d2bd4807fc2f927d3645c796e54f2e93ba4a16db7284f884f3f4518f"
+      "fingerprint": "855678e1695c7ac33f7f56576a14183cb793ba62e7bf103182f24d688ce0d10e"
     },
     {
       "entityType": "craft",
@@ -56525,7 +56525,7 @@
         "item:renaissance_domestic_tavern_inn_plate"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8ad3ff126ce564e739bcaa72ba5531012b6cd92a59c4e3da9f16534edbc1ed47"
+      "fingerprint": "7ed10efe75e57a371c32205937e615018792a00a6c3cc23786ed37f3732762af"
     },
     {
       "entityType": "craft",
@@ -56538,7 +56538,7 @@
         "item:renaissance_trade_ottoman_bazaar_textile_sample_coffer"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b3d2df296bf9d43452616d3e64861ebe345f71fa5e4695b35dcd96d223d16284"
+      "fingerprint": "91904038a63406f0f54fda19b110b47d672414f7a1158e37e6223d4786ed6eea"
     },
     {
       "entityType": "craft",
@@ -56551,7 +56551,7 @@
         "item:renaissance_trade_japanese_ryukyuan_shell_faced_export_casket"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3fb759dadaec35d93c6ebb01d1f718481818ee318f1ba5546403b5e25033843c"
+      "fingerprint": "d62f09a56f748b4a752d382b32befe8e7a717d2f4257443393c896c388d16cd0"
     },
     {
       "entityType": "craft",
@@ -56564,7 +56564,7 @@
         "item:renaissance_furniture_car_side_table_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a549197069f470b1256a6cd8c1004927dc229ceb3c82c6a76524e4046097868f"
+      "fingerprint": "3bb18391189f2f7d1d2bb48673705e519aae42fb6c04d169a97b577f691b27f1"
     },
     {
       "entityType": "craft",
@@ -56577,7 +56577,7 @@
         "item:renaissance_furniture_car_urn_stand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3ae4bab2a2d654f75d1116eff6d37b4e770c9cb8747abf637af56309dec58663"
+      "fingerprint": "bf1f0a91bb03f8f967b9d157c48e31e0652a863bc6a6f8eb3aba8e33ee6716ba"
     },
     {
       "entityType": "craft",
@@ -56590,7 +56590,7 @@
         "item:renaissance_andean_short_worktunic"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "561f4f540bef4c2a565d0089458ee6db2a18570c223f15a3906b1cdbf7ac4c82"
+      "fingerprint": "46c5b0743b51b4d9c1d90222f43bb446879ed1da143441b73c65a7ea7856a173"
     },
     {
       "entityType": "craft",
@@ -56603,7 +56603,7 @@
         "item:renaissance_personal_persianate_court_manuscript_case"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c87d30e61a0bdebfe44da4ee0c3d3551fa85c03d875ea31b32dd85cc6acd4ee2"
+      "fingerprint": "e471406f448e06acd8b33dcce2fea7b20f976f819ce890b76ae7ccfb421a4692"
     },
     {
       "entityType": "craft",
@@ -56616,7 +56616,7 @@
         "item:renaissance_military_sipahi_greaves_lamed"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "f4855a842b7bf091fe0cf50dd3c4d59942236c812741d21015931385fa02e0c4"
+      "fingerprint": "079679c0b2462128f406bc5c734a6865adec1b60e64806448e5828e217831122"
     },
     {
       "entityType": "craft",
@@ -56629,7 +56629,7 @@
         "item:renaissance_furniture_col_lamellar_armour_stand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "364521ef067e1a689b9d7ed95118e408f0ce0133ba50335fdb0c05229871bd7a"
+      "fingerprint": "f559868c0067ee421c17953c7e0f7def6a561ba90275260f33ba04a07d958c67"
     },
     {
       "entityType": "craft",
@@ -56642,7 +56642,7 @@
         "item:renaissance_furniture_ind_nightstand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d9a6ceb7b980731cf2b49d73883e8f62628b837370a187ed563ca1a91c75690e"
+      "fingerprint": "8b8500507e3c9ee12872cd112842775606a90c65ca94322d5d029b8041b57aa2"
     },
     {
       "entityType": "craft",
@@ -56655,7 +56655,7 @@
         "item:renaissance_furniture_jpn_glass_front_cabinet_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ca13c96ad1d8e40eaa95838069ca27ee214a3194db986008fc12b43a79d11dc5"
+      "fingerprint": "fe376d295f233ce8fe82f0b4a5bcc745d6c4696d9888607522c08c75949866ac"
     },
     {
       "entityType": "craft",
@@ -56668,7 +56668,7 @@
         "item:renaissance_trade_urban_kitchen_pastry_delivery_box"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b01cc1e114f89e7d0798a41177c0aa17d711c2051959d738d0d429337e40a084"
+      "fingerprint": "5cfaeaf98c505122aa7e2d170ad579f495b3017327eb8dbfff008f98469ad5a8"
     },
     {
       "entityType": "craft",
@@ -56681,7 +56681,7 @@
         "item:renaissance_frontier_sleeveless_long_gown"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "437f43bb01f6fa4a2d02914a563ae9b37bb2250473309e06dbfc070d588db8a7"
+      "fingerprint": "82cbdeb7c9da1a146cb614187a751c2749e6f90c762cedc5f110866dbda350dc"
     },
     {
       "entityType": "craft",
@@ -56694,7 +56694,7 @@
         "item:renaissance_furniture_pip_cloak_cupboard_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2fd0c57517d3b7b8f88c3c51fc08b52e01bac505cc94d42a65c09fbf14556246"
+      "fingerprint": "4230b837c4e01d9be7fb20162e60cb8cf29db252960435eabca5366f9306d679"
     },
     {
       "entityType": "craft",
@@ -56707,7 +56707,7 @@
         "item:renaissance_furniture_sai_campaign_weapon_rack_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "eb32860f456e2351e977dbed5840b4affa27b362d0ee7effa098e35f4e6692e7"
+      "fingerprint": "085714d8504adc0894df7b7bf35b9ea3cca1398edb62d884e434bd2f2921702e"
     },
     {
       "entityType": "craft",
@@ -56720,7 +56720,7 @@
         "item:renaissance_furniture_col_lock_fitted_wardrobe_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "07fe2ce2d0497cc09d391fe4880a68c5c04045828dcb08659d4779adf52b6d95"
+      "fingerprint": "73c02ee06c438d18b378227eb5f1beb4540ef229bd3241ab884af69be7a87306"
     },
     {
       "entityType": "craft",
@@ -56733,7 +56733,7 @@
         "item:renaissance_domestic_western_counting_house_brass_ewer"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7044e5e500f27d332b3435ec166e69eb024b0370d394285b2c77708d18e480af"
+      "fingerprint": "91b695f4abb467be6cf30ff84f3135ac1ec9069ce7951193e7d6019780e79bc2"
     },
     {
       "entityType": "craft",
@@ -56746,7 +56746,7 @@
         "item:renaissance_furniture_ott_scroll_display_cabinet_07"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8d906b55ad52bfd06390408965d64dd1fb8374563659406ccbd12c7e983203a8"
+      "fingerprint": "ca447c22d0fd753a41a69dca86cd00cd46805493143fe907b1dc622ebad86eee"
     },
     {
       "entityType": "craft",
@@ -56759,7 +56759,7 @@
         "item:renaissance_furniture_nba_matchlock_rack_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "98cd47d0751e580612524f85607c4e0a419863e37ad4b3436dfb4f1dcabc5562"
+      "fingerprint": "5472854ebeefe163201f8e070dfda0579bc5a522ae30fff076704a49aa5d7760"
     },
     {
       "entityType": "craft",
@@ -56772,7 +56772,7 @@
         "item:renaissance_furniture_msea_tall_wardrobe_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "32846af9f35c4d7850d20b60749a68e563191caeacd277036956a6c60f29725f"
+      "fingerprint": "b828a062cd4c70ebe490e452328414f31781401d1859d26fdde8b7ebe978d629"
     },
     {
       "entityType": "craft",
@@ -56785,7 +56785,7 @@
         "item:renaissance_furniture_ind_harness_stand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "193744503b368b323b4633111dfb69c3775c453dcd9065e17239ff3b45452742"
+      "fingerprint": "e4ee702752b09f81ef750c5193684230c3746cf9301de363b774d4a5cae6c0fa"
     },
     {
       "entityType": "craft",
@@ -56798,7 +56798,7 @@
         "item:renaissance_furniture_jpn_glass_front_cabinet_04"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8d5ecad20ab0c4ccc6b9a0b7a0b2b061c28c499fd1e8dff7c6059353baae736a"
+      "fingerprint": "5145e356777ef31dd9ba0bfd6d817264b0ae786e826bc9ef3e15b2478af2ff98"
     },
     {
       "entityType": "craft",
@@ -56811,7 +56811,7 @@
         "item:renaissance_science_armillary_sphere"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "65c0abe8c465aedaafa49c4acd8a402e03a69c6f72fc6f27b2182c8976dd816f"
+      "fingerprint": "b93734af0bc896d4ff3e623d8fd491fcc37080b1d33acc06ff286cf1843ca5a4"
     },
     {
       "entityType": "craft",
@@ -56824,7 +56824,7 @@
         "item:renaissance_trade_west_african_court_ivory_trade_casket"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ccaff8a36fdfef91f84836a13f40d814950989aa8828acdb9f8fd7ad077067ed"
+      "fingerprint": "c107d9b04bb810383971c34a2b46036c4e6e67fb930e0e60898e7aa359beb016"
     },
     {
       "entityType": "craft",
@@ -56837,7 +56837,7 @@
         "item:renaissance_personal_south_asian_merchant_betel_box"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "6ef6dc9f161999a369b5ed434f4f9db2ce0f6766d1edfcd83773103a076ddc95"
+      "fingerprint": "4ec86762376fe605c38c597fc76b866254a349998fa1f82190dd08cbec3076a1"
     },
     {
       "entityType": "craft",
@@ -56850,7 +56850,7 @@
         "item:renaissance_domestic_steppe_caravan_copper_cauldron"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "4da9e44396b5836dffc0dd5b10fb43dcb47b7c17ff64135e3dd51059b7c840a3"
+      "fingerprint": "5c6aba0965ef259ea125ae1e84083fee937137afb8d3e49a93ff28464bf08774"
     },
     {
       "entityType": "craft",
@@ -56863,7 +56863,7 @@
         "item:renaissance_furniture_cen_porcelain_display_cabinet_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ea9bdaf1de2f0c5f5d8ad90d5f26e61c777201f0a83651f2c829d1defa8632f9"
+      "fingerprint": "3b3b9f5f358bf29c37c7d098ea4258e500703471eb6d00f1181d9d7a1ade94c9"
     },
     {
       "entityType": "craft",
@@ -56876,7 +56876,7 @@
         "item:renaissance_furniture_cen_drawer_nightstand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ed754ec1b98b07cb68472e18769192b2bfecdaa0d9847a4d8d1fa4adb19f1875"
+      "fingerprint": "d76b957e57fa59a1c207ef506493d546416e76d28301b27aa7d9080acdbf3123"
     },
     {
       "entityType": "craft",
@@ -56889,7 +56889,7 @@
         "item:renaissance_personal_steppe_caravan_medicine_gourd_sling"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b13a17273760bd72455e98b65dad7ae52ad74ad12c832d446000c23e536048d0"
+      "fingerprint": "ec5dd5ba5ce9f6ce711786cb6a06b65e41f5084ca740db2534754fcc6c5a2403"
     },
     {
       "entityType": "craft",
@@ -56902,7 +56902,7 @@
         "item:renaissance_furniture_pip_glazed_display_case_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e5293c3336dfef011243c4393d79b59cb35a5420a9ec81fec67a2b5b3013d2ea"
+      "fingerprint": "56068354d14b2310f61020e7069343aabaff25a48583850bb1f2bc1e5fd07a3c"
     },
     {
       "entityType": "craft",
@@ -56915,7 +56915,7 @@
         "item:renaissance_art_pigment_shell"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "bd61df222b5c258c5039068b4d28c23cab0cfebf40fd9c2465c6f03fe95f9d49"
+      "fingerprint": "1a6f0febfb3ffc4f08caa5bdb0e7ea59e688e514eac4bd5c6cab9358675d8e89"
     },
     {
       "entityType": "craft",
@@ -56928,7 +56928,7 @@
         "item:renaissance_furniture_apothecary_perfumer_poison_cupboard"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2ffb81553c321c757ff9c4d2a96d01156d1311ccf9278ceebbf2430eff4978cd"
+      "fingerprint": "c24f6016aedcb22b1dbb0f3fa912abf4398f430b5088d9e9004a2ff81683df67"
     },
     {
       "entityType": "craft",
@@ -56941,7 +56941,7 @@
         "item:renaissance_furniture_iba_helmet_cuirass_stand_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "26de574f40a639021090959c8da75e469fb3d4f2db0e8b6bac730576415b0aaa"
+      "fingerprint": "a123cad556655d641466383718565bb44058f7eb2a7ab54492337a9c7b03ef3a"
     },
     {
       "entityType": "craft",
@@ -56954,7 +56954,7 @@
         "item:renaissance_furniture_cef_crossbow_rack_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b6f332262f145fc646bc0e582b8b1d209f241b973f295132e7da099a556cf6b9"
+      "fingerprint": "0b64692cb1acac56516bc7562419dc56477d97ef098731642df040e563402292"
     },
     {
       "entityType": "craft",
@@ -56967,7 +56967,7 @@
         "item:renaissance_personal_japanese_ryukyuan_tiered_medicine_case"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8b56e68db61c10b9e7971d2ebabde5867efbff18017e273589b05e058695042a"
+      "fingerprint": "3440ab01bd8a1c07a5305ca20be71817bd21022f985de585ba1b154d054a8bb8"
     },
     {
       "entityType": "craft",
@@ -56980,7 +56980,7 @@
         "item:renaissance_art_wax_model"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7f506dac090e694a010ec631cb86177d2bd99c2ee92fed3d5fd87ce628749e49"
+      "fingerprint": "f42526e4fbf93459788959b38aa6fc6d4b6a1801fe8de373adf754d28d38e1c6"
     },
     {
       "entityType": "craft",
@@ -56993,7 +56993,7 @@
         "item:renaissance_furniture_pip_freestanding_weapon_rack_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "524d6418b43e831a1c239b099a89029ba9306d8c4e49705fd8e45372ad46466b"
+      "fingerprint": "cb8263de9b3acd6c0541e98d04752ad906e5dfff314ea8bc62617e1c94384cf9"
     },
     {
       "entityType": "craft",
@@ -57006,7 +57006,7 @@
         "item:renaissance_furniture_car_stepped_display_shelves_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "9552ca39034ebd85795474de8aa961051f86c2ef276c344be0b6f0fae2628beb"
+      "fingerprint": "778e30f4a5302b7f562e6a70391e697c8c566cbc2d21b5dbcd4725f4356f59f3"
     },
     {
       "entityType": "craft",
@@ -57019,7 +57019,7 @@
         "item:renaissance_furniture_aca_coin_drawer_cabinet_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "92f30412a17410034b746ac95a59221f0ca71e2056198afc533573f690306359"
+      "fingerprint": "7f3595a4c9b0a9cfb28519c3d7b434221d5cbbda6a2e0f7f7df7a668be7efdd3"
     },
     {
       "entityType": "craft",
@@ -57032,7 +57032,7 @@
         "item:renaissance_furniture_cef_lock_fitted_armoire_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1cb5eaa64980f490e83ad376d5848d0e56edabd7d7f22905273ca0b99afd45e3"
+      "fingerprint": "47448e8132bb4c4e2d7c3bc9a8eef601b5cc5735ff97c4ba242c010021564149"
     },
     {
       "entityType": "craft",
@@ -57045,7 +57045,7 @@
         "item:renaissance_furniture_rse_side_table_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "00b814bc349b6c2351133e86b68133d9638337360fda3d09223a605f0e07e197"
+      "fingerprint": "17fa2db2027b518470c016bbdb41be350379fd03392a469c3a7c9e11691cc5b4"
     },
     {
       "entityType": "craft",
@@ -57058,7 +57058,7 @@
         "item:renaissance_furniture_and_harness_stand_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "adaa12dd13e36cd7e5ce66c97e6205b7b89bcdae44847dc3786243326afdb102"
+      "fingerprint": "0702de8f8496d56d5936a9466a748a0e13a3e306d402c074eaf87c3c7782b4c1"
     },
     {
       "entityType": "craft",
@@ -57071,7 +57071,7 @@
         "item:renaissance_furniture_pip_offering_stand_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "06c74974686fcf7bbd2caa03675f409bdc41af8a9beb78189d41cbb853c9713d"
+      "fingerprint": "1afbcf78868e188742f44e72c3e855eeb09230fe0fb84b3b958fffa9729c7394"
     },
     {
       "entityType": "craft",
@@ -57084,7 +57084,7 @@
         "item:renaissance_domestic_apothecary_perfumer_ointment_pot"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3b01357ee7c5a2d5f54c8cbd3263c40b5b68054d6c53e5932a1c22c5842fed4d"
+      "fingerprint": "211d06c7920469e6fa1d198f5606b827d59efa9dc8b5ddacb6b6c60904a94d51"
     },
     {
       "entityType": "craft",
@@ -57097,7 +57097,7 @@
         "item:renaissance_domestic_shipboard_purser_shipboard_pitcher"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "cb75d4e71f37270c88616f2117ede36b90d7e16bc810417d46fe7121a8551819"
+      "fingerprint": "a14e93f5992eb2880fb589e6efb92de4dd9251efe6621b0cb28977ab19aa1131"
     },
     {
       "entityType": "craft",
@@ -57110,7 +57110,7 @@
         "item:renaissance_domestic_warehouse_dock_vinegar_flask"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "f977116fcf059b42cbfe961ee8d7f721f00f5543ec161b2d60628f630fd63309"
+      "fingerprint": "342d33c111fb29809df9b3f8f27c791cc5a268c6b2a7775fcfdc6b231d263079"
     },
     {
       "entityType": "craft",
@@ -57123,7 +57123,7 @@
         "item:renaissance_furniture_iba_campaign_weapon_rack_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b279fd1ecafb432426997b71dca36d01e68a0a564dddd74b969f25a6fabaa197"
+      "fingerprint": "8b935de95ac912a65428b299aece6a13011cc59565ec75040ccfeb61d7814915"
     },
     {
       "entityType": "craft",
@@ -57136,7 +57136,7 @@
         "item:renaissance_furniture_mes_offering_stand_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ddbc743ff264d7709c9b8fbf9fc847efe083c100f2cf5b75014496d187999b3a"
+      "fingerprint": "6da659eb2f697f6eb560cf73a1ed1ea4758f2a3da6cd19de6d006415443c7a30"
     },
     {
       "entityType": "craft",
@@ -57149,7 +57149,7 @@
         "item:renaissance_furniture_and_lattice_display_cabinet_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "02e1c16a10a536ac14770a0771f9d5803cd52200072588127a75a135a8542ef5"
+      "fingerprint": "a934ae58d821f4d2a51208ffc4029cb2b5226b1cba336f8a00236e7dbc8cd265"
     },
     {
       "entityType": "craft",
@@ -57162,7 +57162,7 @@
         "item:renaissance_personal_mesoamerican_market_codex_satchel"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a73d2f2cb16d8d16f9079ad835675451e131667765aad5d91c738f43ba622e5e"
+      "fingerprint": "7eb8d67f690d41ee495d183261d545e1a36d2e07d4ae8e2ebd45c56ae73054b4"
     },
     {
       "entityType": "craft",
@@ -57175,7 +57175,7 @@
         "item:renaissance_container_cen_liquid_medium_storage_jar_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "29801a00093c6cdf7269dec5966bcb19ae27bf17299911166827063a17f75ce3"
+      "fingerprint": "493aa3d570bd9f0eb114e17c160c6ef0d5416f750ab6ed251a9ea5944bee3872"
     },
     {
       "entityType": "craft",
@@ -57188,7 +57188,7 @@
         "item:renaissance_container_ott_trade_large_transport_jar_04"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2ed97caf60fa9a37e2268b8aa3287fd2ee2974660f1fed0bb02a18686782db55"
+      "fingerprint": "5d63cd92b5e0341c4fd6d63a37e990c53d370ec684e92e76f4282fc7ad6f7a15"
     },
     {
       "entityType": "craft",
@@ -57201,7 +57201,7 @@
         "item:renaissance_domestic_shipboard_purser_oil_flask"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c1e5a942d11502b3a06b1e50b6cb45e571bf5c649a7a0966385ecc6261b581fa"
+      "fingerprint": "1652dd414cdb8f08cb8aa9fa95db02ee706e11145bb92dcc6327b53ec7a97408"
     },
     {
       "entityType": "craft",
@@ -57214,7 +57214,7 @@
         "item:renaissance_trade_urban_kitchen_oil_transport_jar"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e6e3447547325305953acd2d257bff86e92095e668bea669d00f2d5147a88700"
+      "fingerprint": "42b33fc1f6ce948e13746793109f18ec54210a51bc46cf39add156dc9624d348"
     },
     {
       "entityType": "craft",
@@ -57227,7 +57227,7 @@
         "item:renaissance_personal_civic_guild_tally_satchel"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "bced73733ea22793eee3c5766946448eb482e6036a30ce396436ef0304c34a25"
+      "fingerprint": "2869f880517b5ae4a6e0eb3ac98760389368435cd12f1bb93b1c6bb1bc701945"
     },
     {
       "entityType": "craft",
@@ -57240,7 +57240,7 @@
         "item:renaissance_andean_straight_sleevelesstunic"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "449a8790bac5200fe87b39dbcd8571913d8097efda53d78609f9af484785f5b7"
+      "fingerprint": "31474c32e53ae8b711adf0581eee89121cbb4db3ea4ee310780ae4c7ce00c231"
     },
     {
       "entityType": "craft",
@@ -57253,7 +57253,7 @@
         "item:renaissance_military_takouba_straight_blade"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "573fc9d6c4f69f60212f52eef51b987f740ab894faac374c746fe5619af35eef"
+      "fingerprint": "1b594fbd093bf75331e2694b5275d10d1b90490af637d580bbdb878da0110288"
     },
     {
       "entityType": "craft",
@@ -57266,7 +57266,7 @@
         "item:renaissance_domestic_tavern_inn_pewter_tankard"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "0da5201cb09aafe48671374a7ea860856f542347f6775a92f91b31f5730c0ce8"
+      "fingerprint": "5de0b92397908882be2026709f18d39d02d814329b6d04bd8405faae0da7be13"
     },
     {
       "entityType": "craft",
@@ -57279,7 +57279,7 @@
         "item:renaissance_furniture_aca_compact_garment_cabinet_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "fa7aef2b880743c8626f87522438d0a2ae82b790c91e467fd81aa0ab20fe00d1"
+      "fingerprint": "f241e140e0faab79cae99caa6b7440ca102eb4e13c0b9c57da313a20e1f55fc5"
     },
     {
       "entityType": "craft",
@@ -57292,7 +57292,7 @@
         "item:renaissance_furniture_cef_lock_fitted_weapon_cabinet_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "62ba6d323ef6ddc49ee0ee01edd2d3e63c6e27fc1e4f52f46d42975bbdd05d37"
+      "fingerprint": "885d7a4fc8091c21cc885194393adbdb4f92432c34d70d73d5c94d48fa67a7b3"
     },
     {
       "entityType": "craft",
@@ -57305,7 +57305,7 @@
         "item:renaissance_military_rapier_swept_hilt"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d53a3cfc424de3f73ef3c251e0e6964b712dc2fa066afed8772ca864faf60374"
+      "fingerprint": "ccd7c28e866ffc2a4fb8a6997fb714bbfd585a3bfa2952e85b196a6cb184aef8"
     },
     {
       "entityType": "craft",
@@ -57318,7 +57318,7 @@
         "item:renaissance_furniture_nac_side_table_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "df3e1e71e91d8d8db881c8da7e01038d1eae854f671d85b9a9d5513f132d20e9"
+      "fingerprint": "20f5d4e853ccc9bbc766fb26dcea95d10e8785e2dc13aab1b989c891410f8ac9"
     },
     {
       "entityType": "craft",
@@ -57331,7 +57331,7 @@
         "item:renaissance_furniture_mar_lock_fitted_wardrobe_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "54293b3cbbdfe29b6ce99c47cb21b242b44f3664e4454c52b0cc6c000c1e6a0d"
+      "fingerprint": "97e3ad448f0d8b921c2d783dbdd3b0ab0059de9db23987661c8ba3ba1299c945"
     },
     {
       "entityType": "craft",
@@ -57344,7 +57344,7 @@
         "item:renaissance_furniture_east_asian_literati_garment_cabinet"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7d1f98d54e0d40c4a703731d647dfa6767c16159b71bde7fbc2cbb9758d58329"
+      "fingerprint": "0ee860442bf2d7d44a51ecdd6c40bae92462967f00e719816f1261779a4d15b8"
     },
     {
       "entityType": "craft",
@@ -57357,7 +57357,7 @@
         "item:renaissance_furniture_nac_open_display_shelves_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "5e89933f4c54ea5b7afdee313f8151529e88a6051ce7907bfa95853112da51d2"
+      "fingerprint": "2d2b842a74b41e0a7f8a583588ac37955489130084b3323b92fb58d0a60f98d3"
     },
     {
       "entityType": "craft",
@@ -57370,7 +57370,7 @@
         "item:renaissance_trade_mesoamerican_market_feather_merchants_basket"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3fbb385b080c1a4572451e1fe6cecf1878cad1049412a5237cb016864cfc0d61"
+      "fingerprint": "d9cd754955baba2c3c464b2323e95682efef00477b7e501e17f2a08840d452ed"
     },
     {
       "entityType": "craft",
@@ -57383,7 +57383,7 @@
         "item:renaissance_domestic_ottoman_bazaar_storage_jar"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e5e37f63cbcf077aa308865ed116dc8653dee7ce938e2c77b2b1c45b4e898495"
+      "fingerprint": "04be9d227424bb74032cb80d68b924b0223911f0b75b5b7421e118a9481eb973"
     },
     {
       "entityType": "craft",
@@ -57396,7 +57396,7 @@
         "item:renaissance_furniture_nac_hanging_cabinet_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "09496d28ac4c98b504faa7fa3ed5d3eb0236165c25eb739362513cbe98185de3"
+      "fingerprint": "9ddd3fd28305914bc3bddb024fa86b8bce8eb619fd6963aa99b1a3dc5b12b4e2"
     },
     {
       "entityType": "craft",
@@ -57409,7 +57409,7 @@
         "item:renaissance_furniture_rse_campaign_desk_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "daa0b7fc8e19b2c7552f6b721fec60c0701ab9c2c837581965d5d0f8623e9d1a"
+      "fingerprint": "0db7edddd8b0f3ce675a6835ea4048e1994e647a9d2f7280e57640ba181d4813"
     },
     {
       "entityType": "craft",
@@ -57422,7 +57422,7 @@
         "item:renaissance_furniture_sas_compact_garment_cabinet_04"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "baa467e9ced12f2b54badd64b75435ed134e8260e3f7434ec17a71dd0416bce7"
+      "fingerprint": "82b0a6696f81aa08cd36c0fd6c8d6491974d9d995e97cf7ebd1bc94f2aaa5ec2"
     },
     {
       "entityType": "craft",
@@ -57435,7 +57435,7 @@
         "item:renaissance_furniture_and_side_table_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2dc1d11dd03ddfea92a1079febfc6ccfc6f8c73c65bc2f398af309240c0eadba"
+      "fingerprint": "de650c98726acd0ac45459018f1c03e3c8912f7c704686d95eb846a84c81a17b"
     },
     {
       "entityType": "craft",
@@ -57448,7 +57448,7 @@
         "item:renaissance_furniture_elite_household_chamber_armoire"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a74c228ca36f38b6d318618775e685008fe8113af42cd3865b6648c7e4659b3d"
+      "fingerprint": "15d0ddd41b65591c72791354a2cbc51facff0c5b91b972343ac3f4440fdacd03"
     },
     {
       "entityType": "craft",
@@ -57461,7 +57461,7 @@
         "item:renaissance_furniture_mar_wall_cupboard_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "2c8a3161dee7d4a540fa1e41ece97408926a2d8d30832de3fe081d168b405d41"
+      "fingerprint": "96e4cacc45968d3608c388b8e9dde18b24878750a410aa25fece659eeb1ecd4a"
     },
     {
       "entityType": "craft",
@@ -57474,7 +57474,7 @@
         "item:renaissance_furniture_eal_archive_bookcase_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "bb2852971b132b6451408e5b711afe88a96d3ba71f4bef44bb837d068b6d89a8"
+      "fingerprint": "1c88580225438e50b46721693bf9ee3f4761d0a95dac8fe75e22b17ab18bf3b0"
     },
     {
       "entityType": "craft",
@@ -57487,7 +57487,7 @@
         "item:renaissance_furniture_mea_lamp_stand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ac8fed876e1e98509613723b46f7a4f425dee1bb262d4b8d8ef4924fb717b5e2"
+      "fingerprint": "0b3699ff205607a8dc8aa0fa5d8d974314f2c9363783e5715e6f5ec43db75dc8"
     },
     {
       "entityType": "craft",
@@ -57500,7 +57500,7 @@
         "item:renaissance_furniture_eal_sword_rack_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "e4da30c84fde0ecf84bd66702038a8cff23c970a0569d5f449feb23b155774e4"
+      "fingerprint": "3f6e9b9a0a8de32e32f993326dea3629e104b0c2b910007bb282fa2caff8bd64"
     },
     {
       "entityType": "craft",
@@ -57513,7 +57513,7 @@
         "item:renaissance_joseon_tall_horsehairhat"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "08467c9158b5b0959141b061d8397ffc4b8a33d13393f2601b86742edd9fa427"
+      "fingerprint": "5a5ba3a1d3d618d56066bd3f6e6ae0d37fbf126af9814c2738b33337fc98c52c"
     },
     {
       "entityType": "craft",
@@ -57526,7 +57526,7 @@
         "item:renaissance_furniture_sas_offering_stand_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "dc564244c401c79298bb6be47c5f440c0ad8e9c74ed3fcbc99449bc3891f4ed7"
+      "fingerprint": "4109fb0ff3af007ba464977c58cb25362401b36367437fc1c686f580bf60fd12"
     },
     {
       "entityType": "craft",
@@ -57539,7 +57539,7 @@
         "item:renaissance_domestic_warehouse_dock_dockside_mug"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a4e02434d1154863ac80141a25d198e14f4ce0c853b2a6137680486407e6944f"
+      "fingerprint": "b16535eb90da1ca3dacae8d4e126eaa3517b6302ce9ab5803467395802880e2f"
     },
     {
       "entityType": "craft",
@@ -57552,7 +57552,7 @@
         "item:renaissance_military_artillery_case_shot_three_pound"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3e59055eda3559d4d3ae5ed6f1d8e6c5ac92daa60c764f658a5ac7d549221a6c"
+      "fingerprint": "f350ed216d3822d8e1294d69806fb2afd0bafb96c31deec632f0be2234d5c87a"
     },
     {
       "entityType": "craft",
@@ -57565,7 +57565,7 @@
         "item:renaissance_military_field_gun_three_pounder"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c999eacac47484bed06630e0e7bba10e795060fdd6a7f24b09d39ed97a2a7e21"
+      "fingerprint": "95c62a25aae60b9465e35a71934e069ddda4328aea72d5e0f6e8d4ddca0d2b1d"
     },
     {
       "entityType": "craft",
@@ -57578,7 +57578,7 @@
         "item:renaissance_military_harness_three_quarter"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "75b4ea701156d658d905f4d088d01779830ee52fedf9dc06a69a069173a25da7"
+      "fingerprint": "e8b0ae83cb352436a50ee1e0315db694fa3afc30ec897e16c060efd58c428976"
     },
     {
       "entityType": "craft",
@@ -57591,7 +57591,7 @@
         "item:renaissance_furniture_apothecary_perfumer_bottle_display_shelves"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "9ef2f88b9daf67f2729631997c939480f216e057b8ba874b30e33c675473de76"
+      "fingerprint": "94decd3417023f33892c8e5ca2c84e40b690f6e5376c1b7e48686f4bdddab258"
     },
     {
       "entityType": "craft",
@@ -57604,7 +57604,7 @@
         "item:renaissance_furniture_pip_folding_display_stand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "f039551a5908994a6649b5997e480e444aef020682ffe2719f6a0eff6489b4ef"
+      "fingerprint": "13b2cec32500022687dd5d1600da4fb96271d6a0efbcdb43b0e82d6364b41463"
     },
     {
       "entityType": "craft",
@@ -57617,7 +57617,7 @@
         "item:renaissance_furniture_stp_armour_tree_04"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "cba2429f075c32448ea4fb23f8214fee09de91414da8d9f1880854dc63b32830"
+      "fingerprint": "ce11dab02a3f2d597940dc65678702ab4ef2bb9696b4d80564611c7197fe8227"
     },
     {
       "entityType": "craft",
@@ -57630,7 +57630,7 @@
         "item:renaissance_furniture_mea_chest_of_drawers_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "cd2e52cdf6213846f9a02c0d53679764849b19ba87fb9d5e53ba9ff152372e14"
+      "fingerprint": "5876f529942625a6dfe4eabe2d60ae1d41f09eca36de68164d7d081fc68a8b63"
     },
     {
       "entityType": "craft",
@@ -57643,7 +57643,7 @@
         "item:renaissance_furniture_col_slant_front_desk_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "030b41742c125a4a6402ce12e2cfdbe631a05e6e6f2686c8c267b5b6db5c1f4d"
+      "fingerprint": "5bf16da18976fc0d18eab72f4f979d6dcdd6fdb6ba9761b365875508d4540588"
     },
     {
       "entityType": "craft",
@@ -57656,7 +57656,7 @@
         "item:renaissance_furniture_wer_lamp_table_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3fd853a4458074717d8c1ffe8638900603d08b758582b5c814e5b2323ebf12d0"
+      "fingerprint": "75fd20312fa1ee44f00c565756b690bb37c89b991e9a2d4319eba827db683ed5"
     },
     {
       "entityType": "craft",
@@ -57669,7 +57669,7 @@
         "item:renaissance_furniture_iba_vessel_stand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "933f35fb3fa9d22d8b9ef44e8ca837439459b0295259004a7f6a99bae92ec9c6"
+      "fingerprint": "4c374b9efb61b0c40d7e07a9448c896da7b9d077f4d4234c5ed6dcfd77c4f3bf"
     },
     {
       "entityType": "craft",
@@ -57682,7 +57682,7 @@
         "item:renaissance_furniture_mea_end_table_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "23c1748941e6b977b3b36dbd073f31c94da6d18cc1fbb08187916831f3bf994a"
+      "fingerprint": "8d38a28ba4e66a9b3190d62bee7f5b64dc9a073f5ec22adebdbbb4087a694ac9"
     },
     {
       "entityType": "craft",
@@ -57695,7 +57695,7 @@
         "item:renaissance_domestic_apothecary_perfumer_medicine_cup"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "03c1e853d7a36d1c77e73a79a92b090f2649cc32b69b8c7b217e928ca1c47fd5"
+      "fingerprint": "485d674f4bab60112d6cf9d7b49eeb33b12347f7e59bcbc9e5b7bf7679017d67"
     },
     {
       "entityType": "craft",
@@ -57708,7 +57708,7 @@
         "item:renaissance_military_gorget_two_piece"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "f1476980afd7154cae2de6db5faaa117937df12cbf68f171b172ccaf87b5a7b4"
+      "fingerprint": "aa9d69ae495cfa84bb2114c41f6f1c15841c37392aee338516023b008f3ff0ee"
     },
     {
       "entityType": "craft",
@@ -57721,7 +57721,7 @@
         "item:renaissance_container_col_domestic_condiment_box_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "8bce25cb9c0d5f753e6ffdb1e1135dd076e4efdde26251642d9e29abba355d29"
+      "fingerprint": "9cf6c6eb179bdb174987024e01cea61e67c2f1aadeb6fad5c87147c36e49e098"
     },
     {
       "entityType": "craft",
@@ -57734,7 +57734,7 @@
         "item:renaissance_container_ott_trade_large_trade_cask_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "79ce3a2d9b8dc8b510d34dd9f87294dda54cfec1d62b42228a160fb09e7aa0af"
+      "fingerprint": "bb7c7dd21733405d3b4d68193e42cacff8b451e1d4e9cc6eaeedd48476076d44"
     },
     {
       "entityType": "craft",
@@ -57747,7 +57747,7 @@
         "item:renaissance_container_eal_trade_liquid_transport_rundlet_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "70a094c2e92de9e69db93a3a01873f538c1d40e327aecc07a127be243d4bedbf"
+      "fingerprint": "f4bd3a05bd6927a858c5e8fc964a471f8b94bc88d6b78bb4087e2f276ecda362"
     },
     {
       "entityType": "craft",
@@ -57760,7 +57760,7 @@
         "item:renaissance_trade_western_counting_house_merchant_till_chest"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "94f1075b2c50bcf1868ae684c79f3ef0541f70b4a5b14d69ed00a6ea915525e6"
+      "fingerprint": "5555fb89693450e25aed4f2f44805a7c3332ebc49a7b76e7962d6cf0416f6692"
     },
     {
       "entityType": "craft",
@@ -57773,7 +57773,7 @@
         "item:renaissance_military_kris_wavy_blade"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "57887dbcd3b77681f805b33cea4238f426b6de3391ec9be849dcb2d8d371d2c3"
+      "fingerprint": "d22777e1a9a7ac66ad182e77c5b4b271dbdcfc00d70a38c794369918a0f9285c"
     },
     {
       "entityType": "craft",
@@ -57786,7 +57786,7 @@
         "item:renaissance_personal_shipboard_purser_stewards_provision_bag"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "a13c6375e3a5e315e74b7169460ec397ea2ba42d8c8cd691534529d5f1ebfa31"
+      "fingerprint": "0c354fe249e68f1620a19ad034b2b960fd72b8a60105ae89716e18a89f05ce33"
     },
     {
       "entityType": "craft",
@@ -57799,7 +57799,7 @@
         "item:renaissance_personal_warehouse_dock_tallyman_satchel"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "afbedef0d55a6249647c3b821755a9e8d93112b26f02c957c12e257710869ee1"
+      "fingerprint": "c56090a1a9f2b96fdf37d61edf4e2363b27f8ff77acab30006a9d8ae0e2e5ea5"
     },
     {
       "entityType": "craft",
@@ -57812,7 +57812,7 @@
         "item:renaissance_military_wheellock_carbine"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "3b8650fbc2b46b56e9188501ee72515ddd0e1acb862110820e568a9bbf2ce740"
+      "fingerprint": "3b63dfa9f89f515dc5e41211a7c65b0e6707676e5e7c719ca90240dde36d5f1b"
     },
     {
       "entityType": "craft",
@@ -57825,7 +57825,7 @@
         "item:renaissance_military_wheellock_pistol"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "78473684d2390109ae3d7e589826dbea899ef96d214bb212a2a0a30dceb635ce"
+      "fingerprint": "11ee55ea6c7bb47ba17432f2f86164422a43e197823ae306d1eac75dc39bec5f"
     },
     {
       "entityType": "craft",
@@ -57838,7 +57838,7 @@
         "item:renaissance_art_plaster_cast"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "cdcd459c0a6f10e359a973e1ea837d9b011e68ed37b54bbd444a20b2f3f32643"
+      "fingerprint": "bf2634c6aee2a2bee17a727459b5ae0b378751cde7a24d2bdfbdad473dc31137"
     },
     {
       "entityType": "craft",
@@ -57851,7 +57851,7 @@
         "item:renaissance_container_ott_trade_segmented_packing_crate_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "b282d162d51beba021ba38ca02d2f5a381dd7daf4d592381aee9d2c0e58eb46e"
+      "fingerprint": "60251f4cc792e7531ddd3e395d84c3a5fad879494fe87120b023ed82760a8d29"
     },
     {
       "entityType": "craft",
@@ -57864,7 +57864,7 @@
         "item:renaissance_container_cen_trade_deep_trade_hamper_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "fd98d9c4f2e5e6d1d85f7a31b72b5fc13fdaef5263c0a614221194abcd94f194"
+      "fingerprint": "12d8c8ae85261bc7dc4800b1748c256a8e60dd8136a66a75c99563231c45ed23"
     },
     {
       "entityType": "craft",
@@ -57877,7 +57877,7 @@
         "item:renaissance_container_cef_trade_lidded_trade_basket_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "6fa05141f2ed005490bf30d2b8b777fd6b1985d55483e756d6547ffd1d9bd904"
+      "fingerprint": "9142e05ca5a31f0b48188ee91fc76c78666238a051f28d89442945029c93c565"
     },
     {
       "entityType": "craft",
@@ -57890,7 +57890,7 @@
         "item:renaissance_container_pip_trade_deep_trade_hamper_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1e121b32c9f8c67ab01fbe338ec093d9bf92f27148b0f96e6a4b13328e05209e"
+      "fingerprint": "746efb605d6f08968475b770d0088c22caed4a6a4beea0503d7d34b826756bd6"
     },
     {
       "entityType": "craft",
@@ -57903,7 +57903,7 @@
         "item:renaissance_container_wer_trade_segmented_packing_crate_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "da2bd8b7b29313ffdd8ca9c0af7d1b3e6713a8d7c3091a0931b75f3102600769"
+      "fingerprint": "b76e81430cb765bbab9200294be320d417dfc9fe12202aafc09c63be20b3642d"
     },
     {
       "entityType": "craft",
@@ -57916,7 +57916,7 @@
         "item:renaissance_container_iba_trade_lidded_trade_basket_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d8b323f99992ccdf59488f62a96b327e36e958fa88cd06eb18f7930fa2c3376d"
+      "fingerprint": "5ff73ab6f3f7472cd81b2afe916b0d410517360ca0a8e79a6c278f5c4efe3077"
     },
     {
       "entityType": "craft",
@@ -57929,7 +57929,7 @@
         "item:renaissance_domestic_civic_guild_pewter_charger"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "0b06d8822f7c27239ff8827ab6e5fdfe9f3e3a6990fc7a877d3969543016e62e"
+      "fingerprint": "9e105f547bfd1f2949ec646333f7c49dd57470f9cc6753f1330b66958280b613"
     },
     {
       "entityType": "craft",
@@ -57942,7 +57942,7 @@
         "item:renaissance_furniture_cef_saddle_harness_stand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "f5cd9f251951b8b3db77939ecb1716398d94636ae5cd6c46d3a1f0c88819ad64"
+      "fingerprint": "ff85e0b232c49bf68f71042245fe5ada1fe9a90b89c8084ababd02056ec961cf"
     },
     {
       "entityType": "craft",
@@ -57955,7 +57955,7 @@
         "item:renaissance_furniture_jpn_lock_fitted_drawer_chest_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "f462686f55f7da6ad62029344bef8ac23d810f72ca1d43ecf920b10e8f9a0965"
+      "fingerprint": "ae280077ca44a4febbfb9b061e70a492ecb495ecba3d54af8f0b3fe8bc6bc686"
     },
     {
       "entityType": "craft",
@@ -57968,7 +57968,7 @@
         "item:renaissance_furniture_col_corner_cupboard_02"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "86b29409843d55c09aba3c47cf4327e0d53d6b8ab1a6ecf56060865a719a3cb3"
+      "fingerprint": "d882fa223aa1a69d9034c3c7f23d2b9016534791d892b094d6313d26ba4d712a"
     },
     {
       "entityType": "craft",
@@ -57981,7 +57981,7 @@
         "item:renaissance_furniture_jpn_open_display_cabinet_03"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "1a8a08a6b935eb0aaa82d036d8f6cb976f59a00a5cd27f2b5a4d5fad2b8af5eb"
+      "fingerprint": "b40b34187ba47f41bcd36d7ed0d34173afd88b8ad3909f77bee46d04927b8efe"
     },
     {
       "entityType": "craft",
@@ -57994,7 +57994,7 @@
         "item:renaissance_container_wer_trade_lidded_trade_basket_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "32f583f1d3186c5597a881479d6bdf86be48e53dd848b1823693fcf3273d72ba"
+      "fingerprint": "1bacd7b20c93826ff3711f1617753fed08ee58d7623fb85cc6500ed600d5d0ae"
     },
     {
       "entityType": "craft",
@@ -58007,7 +58007,7 @@
         "item:renaissance_military_elbow_cops_winged"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7828f2cbc3e22b61e8c2798b32688a32a13b6fdbd82c815f251dbd8fc51797d0"
+      "fingerprint": "d7c8256fefdd102367ec067019ec73182235095b9180ef080f5b9f2f688bbab1"
     },
     {
       "entityType": "craft",
@@ -58020,7 +58020,7 @@
         "item:renaissance_andean_woven_earflapcap"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "7467132eb6ef57842607ec4a1ae75397001e2ecaa1f0f39c955a52a3bff652ee"
+      "fingerprint": "6eb219a0e14078d31599e11951b0c52711dba568f42e16fdb1b8b40354636b25"
     },
     {
       "entityType": "craft",
@@ -58033,7 +58033,7 @@
         "item:renaissance_personal_andean_storehouse_gourd_bottle_sling"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "02586ed08638d2bd35f1d111189e8d4eafc16aa7e5b89776d2bd347a04fc34a5"
+      "fingerprint": "9d0b0dbbd019aa15a5749984501663a762e59547fb56074700dfc7e44bca209d"
     },
     {
       "entityType": "craft",
@@ -58046,7 +58046,7 @@
         "item:renaissance_military_rattan_vest_siamese"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "d361f0ac3994be186f5f72231ff886f65507ee8e56e55ad01eb54c7f21bf4cb8"
+      "fingerprint": "8acc7783ddd8c33cce27b9a48f03dc1d33df4f07d3575792f853216322a6821d"
     },
     {
       "entityType": "craft",
@@ -58059,7 +58059,7 @@
         "item:renaissance_personal_sahel_redsea_indianocean_water_gourd_sling"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "0769a1484e94cbc3a21830a378d208b69766492ead71542734d4b10e7365e3ef"
+      "fingerprint": "023bae426c66ee4280bef46e3b6fd71dc2bbe6c4ec14981c30fc0062bf5f744f"
     },
     {
       "entityType": "craft",
@@ -58072,7 +58072,7 @@
         "item:renaissance_military_rattan_round_shield"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "03484696d25c9b305cb96c69afe9d431f1050fddb7ce0dd85bc695d1802c173c"
+      "fingerprint": "6abf95901c65f5daa94ab33a99167766b0104f37e4cf3a089928cb6ecd7e2bae"
     },
     {
       "entityType": "craft",
@@ -58085,7 +58085,7 @@
         "item:renaissance_furniture_nac_bow_rack_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "c85022545a413ab81427d2a253189de48fb32d5dc536a94745b1a2e5352b6e28"
+      "fingerprint": "a58d629715ec8994e5480fa64332652d155890f883a33e56aa5bfa4109596ea8"
     },
     {
       "entityType": "craft",
@@ -58098,7 +58098,7 @@
         "item:renaissance_furniture_and_shield_rack_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "9c78eee146829c866dc0181726051f326c535eade1bd2ea0b9d08ce3d0b4473c"
+      "fingerprint": "f637bd9a1c104cb7f7daedc34ac2061c296395e2a99d186e4f3b6975d2a3691f"
     },
     {
       "entityType": "craft",
@@ -58111,7 +58111,7 @@
         "item:renaissance_furniture_mes_offering_stand_01"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "07cfeb89252d2abd3eb33bf056aa884fbb0ccc644fe666fd691a4ca69ad61430"
+      "fingerprint": "0e678708e5538a25e5754bc109836f60682b295244ad59d06aa77183ab3ba648"
     },
     {
       "entityType": "craft",
@@ -58124,7 +58124,7 @@
         "item:renaissance_andean_wrapped_fulllengthdress"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "01de26c5429cdeccc68b3a31b896aba8689a242498520201249a0e4a1626e11b"
+      "fingerprint": "5cc078f6148b04285adf54940712406e7e44bb74b2b794fc2162426ce372ab01"
     },
     {
       "entityType": "craft",
@@ -58137,7 +58137,7 @@
         "item:renaissance_military_kilij_yelman"
       ],
       "ownershipPolicy": "stockAggregate",
-      "fingerprint": "337e00b3def1ea5359f9219cb647a031924dde979fc95bde3a4cd1dbae4110a7"
+      "fingerprint": "650950f1de9b43950ec1e702108fd121cedeb96195f06d50cf887133cf5e698b"
     },
     {
       "entityType": "craft",
@@ -175567,17 +175567,6 @@
     },
     {
       "entityType": "prog",
-      "stableKey": "CrApKRenFinIteCra69TCra115",
-      "module": "crafts",
-      "eraAdmissions": [
-        "renaissance"
-      ],
-      "dependencies": [],
-      "ownershipPolicy": "stockAggregate",
-      "fingerprint": "ede00d6aad9c9fcef34a723e9cf43a02349f49e4ee9c8d14506985dc5b206b83"
-    },
-    {
-      "entityType": "prog",
       "stableKey": "CrApKRenFinIteCra69TGla-1115",
       "module": "crafts",
       "eraAdmissions": [
@@ -175597,6 +175586,17 @@
       "dependencies": [],
       "ownershipPolicy": "stockAggregate",
       "fingerprint": "7d8dac06b07a3ddb4119b73dc865c4ba1c0bfdbb504339b16c8a9a3607130403"
+    },
+    {
+      "entityType": "prog",
+      "stableKey": "CrApKRenFinIteCra69TLab-815",
+      "module": "crafts",
+      "eraAdmissions": [
+        "renaissance"
+      ],
+      "dependencies": [],
+      "ownershipPolicy": "stockAggregate",
+      "fingerprint": "2f9f37b90cb0516582d144a751b48a1d5753f2ffbdf77be6ea3ccf240f63e12c"
     },
     {
       "entityType": "prog",
@@ -179005,17 +179005,6 @@
     },
     {
       "entityType": "prog",
-      "stableKey": "CrUseKRenFinIteCra69TCra115",
-      "module": "crafts",
-      "eraAdmissions": [
-        "renaissance"
-      ],
-      "dependencies": [],
-      "ownershipPolicy": "stockAggregate",
-      "fingerprint": "25994a53334342c41ca1edcd15409bba75f7f415b0b1b9b0807c32154ce3d919"
-    },
-    {
-      "entityType": "prog",
       "stableKey": "CrUseKRenFinIteCra69TGla-1115",
       "module": "crafts",
       "eraAdmissions": [
@@ -179035,6 +179024,17 @@
       "dependencies": [],
       "ownershipPolicy": "stockAggregate",
       "fingerprint": "c186cdbc80aeb289903ac205cf0528374b8ccf3dae9c25b260ba2cc0cc90fcea"
+    },
+    {
+      "entityType": "prog",
+      "stableKey": "CrUseKRenFinIteCra69TLab-815",
+      "module": "crafts",
+      "eraAdmissions": [
+        "renaissance"
+      ],
+      "dependencies": [],
+      "ownershipPolicy": "stockAggregate",
+      "fingerprint": "41cc449f9285a5df2d6407864fc0bd3e29a83a2ce20e1820be505f43195bc059"
     },
     {
       "entityType": "prog",
@@ -182443,17 +182443,6 @@
     },
     {
       "entityType": "prog",
-      "stableKey": "CrWhyKRenFinIteCra69TCra115",
-      "module": "crafts",
-      "eraAdmissions": [
-        "renaissance"
-      ],
-      "dependencies": [],
-      "ownershipPolicy": "stockAggregate",
-      "fingerprint": "55b4e129de556bab437034a898048c1831f4e6830cbe9813b07277dca9d60122"
-    },
-    {
-      "entityType": "prog",
       "stableKey": "CrWhyKRenFinIteCra69TGla-1115",
       "module": "crafts",
       "eraAdmissions": [
@@ -182473,6 +182462,17 @@
       "dependencies": [],
       "ownershipPolicy": "stockAggregate",
       "fingerprint": "904ca4c869705e8e22e52e9555e5d63672b4eb5c5ee5231539e5c84872e297e9"
+    },
+    {
+      "entityType": "prog",
+      "stableKey": "CrWhyKRenFinIteCra69TLab-815",
+      "module": "crafts",
+      "eraAdmissions": [
+        "renaissance"
+      ],
+      "dependencies": [],
+      "ownershipPolicy": "stockAggregate",
+      "fingerprint": "b862604b3112a117cb939b163656fba9a79d4f1657ed8753c5138f6698722d70"
     },
     {
       "entityType": "prog",


### PR DESCRIPTION
## Summary
- Harden DatabaseSeeder setup, answer handling, rollback behavior, calendar defaults, and combat configuration.
- Expand Medieval, Renaissance, and Early Modern item, crafting, medical, military, food, and component coverage with maintained manifest updates.
- Reduce item-seeder complexity with O(1) indexes, deferred craft persistence, detached graphs, and controlled EF change detection.

## Validation
- DatabaseSeeder build: passed with 0 warnings and 0 errors.
- Focused DatabaseSeeder tests: 186 passed, 0 failed, 0 skipped.
- git diff --check: passed.
- Live demo_dbo Items run for medieval renaissance earlymodern: completed successfully in 255.6 seconds.

Fixes the reported long-running item-seeder behavior while preserving the requested 1703 Europe seeding configuration.