### PR TITLE
Guard blank snapshot migration history

### DIFF
--- a/DatabaseSeeder Unit Tests/BlankDatabaseSnapshotTests.cs
+++ b/DatabaseSeeder Unit Tests/BlankDatabaseSnapshotTests.cs
@@ -27,6 +27,16 @@ public class BlankDatabaseSnapshotTests
     }
 
 	[TestMethod]
+	public void CommittedBlankSnapshot_RecordsLatestMigrationInHistory()
+	{
+		string assetDirectory = GetDatabaseSeederProjectDirectory();
+		string snapshot = File.ReadAllText(BlankDatabaseSnapshotManifest.GetSnapshotPath(assetDirectory));
+		string latestMigrationId = GetLatestMigrationIdFromSource();
+
+		StringAssert.Contains(snapshot, $"VALUES('{latestMigrationId}',");
+	}
+
+	[TestMethod]
 	public void CommittedBlankSnapshot_AppendedDeltasUseDumpTableCasing()
 	{
 		var snapshotPath = BlankDatabaseSnapshotManifest.GetSnapshotPath(GetDatabaseSeederProjectDirectory());


### PR DESCRIPTION
Adds a DatabaseSeeder regression test that verifies BlankDatabaseSnapshot.sql records the latest EF migration in __efmigrationshistory, preventing manifest-only snapshot drift. Validation: scripts/test-unit.ps1 passed 3,341 tests; DatabaseSeeder Unit Tests passed 670 tests; dotnet ef migrations has-pending-model-changes reported no changes; git diff --check passed. A full live snapshot refresh was attempted but local MySQL SSPI/TLS credentials were unavailable; committed snapshot contents were verified current.