### PR TITLE
Let clinch strategies resist breakouts without defense

### DIFF
--- a/Design Documents/Combat/Combat_Strategy_Runtime.md
+++ b/Design Documents/Combat/Combat_Strategy_Runtime.md
@@ -52,6 +52,13 @@ Ranged cover is independently authored for attacks from the same level, above, a
 - clinch attempts, break-clinch attempts, grapples, and magic attack powers;
 - movement into melee by allowing the move unless a derived strategy overrides it.
 
+The racial `CanDefend` flag suppresses ordinary defensive reactions but does not bypass strategy-specific
+responses to an opponent's `BreakClinchMove`. A standard melee strategy still answers that move with a
+helpless defense, preserving the former uncontested escape behaviour, while a clinch strategy may contest
+the escape when its existing posture, stamina, mounting, consciousness, and blocking-effect checks allow it.
+The contest continues to use the normal `ResistBreakClinch` check, so a low or zero defensive trait makes the
+holder weak without being an absolute substitute for the standard strategy's helpless response.
+
 `RangeBaseStrategy` handles ranged defenses, receive-charge opportunities, and ranged-natural defenses. It delegates magic power attack defense to `StandardMeleeStrategy` so ranged-mode combatants still use ordinary ward/block/parry/dodge coverage against magic. Ranged strategies normally rely on the melee-range setter to switch them to their preferred melee strategy once melee range is established.
 
 `WardStrategy` extends melee defense by trying a ward defense before falling back to standard defense. Wards are available against start-clinch, weapon attacks, and magic attack powers when the defender is not ward-beaten, has stamina, the assailant is upright, and the defender has a usable warding weapon or unarmed ward attack.

--- a/MudSharpCore Unit Tests/CombatStrategyRuntimeTests.cs
+++ b/MudSharpCore Unit Tests/CombatStrategyRuntimeTests.cs
@@ -83,7 +83,7 @@ public class CombatStrategyRuntimeTests
 		return gameworld;
 	}
 
-	private static Mock<ICharacter> CreateDefendingCharacter(IFuturemud gameworld)
+	private static Mock<ICharacter> CreateDefendingCharacter(IFuturemud gameworld, bool canDefend = true)
 	{
 		Mock<IBody> body = new();
 		body.SetupGet(x => x.WieldedItems).Returns(Array.Empty<IGameItem>());
@@ -92,7 +92,7 @@ public class CombatStrategyRuntimeTests
 		race.SetupGet(x => x.CombatSettings).Returns(new RacialCombatSettings
 		{
 			CanAttack = true,
-			CanDefend = true,
+			CanDefend = canDefend,
 			CanUseWeapons = true
 		});
 
@@ -130,6 +130,46 @@ public class CombatStrategyRuntimeTests
 		ICombatMove response = StandardMeleeStrategy.Instance.ResponseToMove(move, defender.Object, attacker.Object);
 
 		Assert.IsInstanceOfType(response, typeof(DodgeMove));
+	}
+
+	[TestMethod]
+	public void StandardMelee_ResponseToWeaponAttack_CanDefendFalseRemainsHelpless()
+	{
+		Mock<IFuturemud> gameworld = CreateGameworld();
+		Mock<ICharacter> defender = CreateDefendingCharacter(gameworld.Object, false);
+		Mock<ICharacter> attacker = CreateDefendingCharacter(gameworld.Object);
+		Mock<IWeaponAttackMove> move = new();
+
+		ICombatMove response = StandardMeleeStrategy.Instance.ResponseToMove(move.Object, defender.Object,
+			attacker.Object);
+
+		Assert.IsInstanceOfType(response, typeof(HelplessDefenseMove));
+	}
+
+	[TestMethod]
+	public void StandardMelee_ResponseToBreakClinch_CanDefendFalseRetainsHelplessStrategyResponse()
+	{
+		Mock<IFuturemud> gameworld = CreateGameworld();
+		Mock<ICharacter> defender = CreateDefendingCharacter(gameworld.Object, false);
+		Mock<ICharacter> attacker = CreateDefendingCharacter(gameworld.Object);
+		BreakClinchMove move = new(attacker.Object, defender.Object);
+
+		ICombatMove response = StandardMeleeStrategy.Instance.ResponseToMove(move, defender.Object, attacker.Object);
+
+		Assert.IsInstanceOfType(response, typeof(HelplessDefenseMove));
+	}
+
+	[TestMethod]
+	public void Clinch_ResponseToBreakClinch_CanDefendFalseContestsEscape()
+	{
+		Mock<IFuturemud> gameworld = CreateGameworld();
+		Mock<ICharacter> defender = CreateDefendingCharacter(gameworld.Object, false);
+		Mock<ICharacter> attacker = CreateDefendingCharacter(gameworld.Object);
+		BreakClinchMove move = new(attacker.Object, defender.Object);
+
+		ICombatMove response = ClinchStrategy.Instance.ResponseToMove(move, defender.Object, attacker.Object);
+
+		Assert.IsInstanceOfType(response, typeof(StartClinchMove));
 	}
 
 	[TestMethod]

--- a/MudSharpCore/Combat/Strategies/StandardMeleeStrategy.cs
+++ b/MudSharpCore/Combat/Strategies/StandardMeleeStrategy.cs
@@ -404,7 +404,7 @@ public class StandardMeleeStrategy : StrategyBase
         IWeaponAttackMove moveAsWeaponAttack = move as IWeaponAttackMove;
         IRangedWeaponAttackMove moveAsRangedAttack = move as IRangedWeaponAttackMove;
 
-        if (!defenseCharacter.Race.CombatSettings.CanDefend)
+        if (!defenseCharacter.Race.CombatSettings.CanDefend && move is not BreakClinchMove)
         {
             return new HelplessDefenseMove { Assailant = defenseCharacter };
         }


### PR DESCRIPTION
## Summary

- allow strategy-specific clinch resistance even when a race cannot use ordinary combat defences
- retain the existing helpless response for all other moves when `CanDefend` is false
- document the distinction and add focused regression coverage

## Why

Dead Harbour standard zombies must not dodge, parry, or block ordinary attacks, so their candidate race uses `CanDefend = false`. Previously, `StandardMeleeStrategy.ResponseToMove` returned `HelplessDefenseMove` before dispatching any move, which also made a zombie automatically helpless when a victim tried to break its clinch.

A break-clinch response is the holder contesting control of an existing clinch, rather than selecting an ordinary dodge, parry, or block. The early return now excludes only `BreakClinchMove`, allowing the active strategy to decide how to respond.

## Compatibility

Existing behaviour remains available:

- ordinary attacks against a character with `CanDefend = false` still receive `HelplessDefenseMove`
- `StandardMeleeStrategy.ResponseToBreakClinch` still returns the helpless response
- strategies such as `ClinchStrategy` may return their existing resistance move
- `CanDefend = true` behaviour is unchanged

Setting a defensive trait to zero can make a resistance check weak, but it is not an exact replacement for the old automatic helpless response because break-clinch uses its own resistance check and modifiers. Strategy selection remains the explicit compatibility control.

## Validation

- focused `CombatStrategyRuntimeTests`: 3/3 passed
- complete `MudSharpCore Unit Tests` suite: 2089/2089 passed
- candidate runtime built and deployed as `2.3.0+39f0ffafc15d8df22b7d9ea379e030602d3a0b39`
- live test with `CanDefend = false`: no zombie dodge/desperate-dodge/dodge-fall output
- live clinch test: the holder resisted the first breakout attempt and lost the second, demonstrating that the contest is no longer bypassed

The change is intentionally limited to one production guard, focused tests, and one combat runtime note. It does not alter multi-holder breakout selection, failed-clinch cooldowns, AI, health handling, or content definitions.