### PR TITLE
Preserve capitalization across wrapped corpse descriptions

### DIFF
--- a/Design Documents/Health/Health_Adjacencies_and_Items.md
+++ b/Design Documents/Health/Health_Adjacencies_and_Items.md
@@ -87,6 +87,8 @@ Current runtime corpse model types:
 | `StandardCorpseModel` | Decaying corpse model with terrain-based decay and decay-state descriptions | Seeded in stock human and animal content |
 | `NonDecayingCorpseModel` | Static corpse description model with no decay progression | Runtime support present; not broadly stock seeded |
 
+`StandardCorpseModel` sentence-cases its own description template before inserting character descriptions. This preserves the intended lowercase continuation at visual line wraps already present in those inserted descriptions.
+
 ### Severed bodyparts
 Severed parts are part of the same conceptual system as corpses. Wounds can reference severed bodyparts, corpse models can describe severed remains, and cleanup or restoration flows may need to manage them explicitly.
 

--- a/MudSharpCore Unit Tests/Health/Corpses/StandardCorpseModelTests.cs
+++ b/MudSharpCore Unit Tests/Health/Corpses/StandardCorpseModelTests.cs
@@ -1,0 +1,67 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Body;
+using MudSharp.Character;
+using MudSharp.Form.Shape;
+using MudSharp.Framework;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.Health;
+using MudSharp.Health.Corpses;
+
+namespace MudSharp_Unit_Tests.Health.Corpses;
+
+[TestClass]
+public class StandardCorpseModelTests
+{
+	private sealed class TestCorpseModel : StandardCorpseModel
+	{
+		public TestCorpseModel(MudSharp.Models.CorpseModel model, IFuturemud gameworld)
+			: base(model, gameworld)
+		{
+		}
+	}
+
+	[TestMethod]
+	public void Describe_WrappedInsertedDescription_DoesNotCapitaliseVisualContinuation()
+	{
+		const string definition = """
+		                          <CorpseModel>
+		                            <Ranges>
+		                              <Range state="0" lower="0" upper="1" />
+		                            </Ranges>
+		                            <Terrains default="1" />
+		                            <Descriptions>
+		                              <ShortDescriptions><Description state="0">a corpse</Description></ShortDescriptions>
+		                              <FullDescriptions><Description state="0">the remains are:
+		                          @@desc</Description></FullDescriptions>
+		                              <ContentsDescriptions><Description state="0">contents</Description></ContentsDescriptions>
+		                              <PartDescriptions><Description state="0">part</Description></PartDescriptions>
+		                            </Descriptions>
+		                          </CorpseModel>
+		                          """;
+		var model = new TestCorpseModel(new MudSharp.Models.CorpseModel
+		{
+			Id = 1,
+			Name = "Test Corpse Model",
+			Description = "Test",
+			Definition = definition
+		}, new Mock<IFuturemud>().Object);
+		var character = new Mock<ICharacter>();
+		var body = new Mock<IBody>();
+		var voyeur = new Mock<IPerceiver>();
+		character.Setup(x => x.ApparentGender(voyeur.Object)).Returns(Gendering.Get(Gender.Indeterminate));
+		character.Setup(x => x.HowSeen(voyeur.Object, false, DescriptionType.Full, false,
+			PerceiveIgnoreFlags.None))
+			.Returns("The first sentence.\r\nordinary wrapped continuation remains lowercase.");
+		body.Setup(x => x.VisibleWounds(voyeur.Object, WoundExaminationType.Look))
+			.Returns(Array.Empty<IWound>());
+
+		var result = model.Describe(DescriptionType.Full, DecayState.Fresh, character.Object, body.Object,
+			voyeur.Object, 0.0);
+
+		StringAssert.StartsWith(result, "The remains are:");
+		StringAssert.Contains(result, "\r\nordinary wrapped continuation remains lowercase.");
+		Assert.IsFalse(result.Contains("\r\nOrdinary wrapped continuation"));
+	}
+}

--- a/MudSharpCore/Health/Corpses/StandardCorpseModel.cs
+++ b/MudSharpCore/Health/Corpses/StandardCorpseModel.cs
@@ -338,9 +338,9 @@ public class StandardCorpseModel : CorpseModel
         IBody originalBody, IPerceiver voyeur, double eatenPercentage)
     {
         return
-            ReplaceDescriptionVariables(DecayStringsDictionary[type][state], originalCharacter, originalBody, voyeur, state,
-                    eatenPercentage, originalBody.VisibleWounds(voyeur, WoundExaminationType.Look).ToList())
-                .ProperSentences();
+            ReplaceDescriptionVariables(DecayStringsDictionary[type][state].ProperSentences(), originalCharacter,
+                originalBody, voyeur, state, eatenPercentage,
+                originalBody.VisibleWounds(voyeur, WoundExaminationType.Look).ToList());
     }
 
     public override string DescribeSevered(DescriptionType type, DecayState state, ICharacter originalCharacter,


### PR DESCRIPTION
## Summary

- Sentence-case `StandardCorpseModel` templates before substituting already formatted character descriptions.
- Preserve lowercase continuation at visual line wraps in inserted descriptions.
- Document the ordering and add a focused regression test.

## Why

`StandardCorpseModel` previously called `ProperSentences` after replacing `@@desc`. Character descriptions can already contain visual line wrapping, so the final casing pass treated wrapped continuation lines as new sentences and capitalised ordinary words mid-sentence.

## Validation

- Focused `StandardCorpseModel` regression: 1 passed, 0 failed.
- Complete `MudSharpCore Unit Tests` suite: 2,087 passed, 0 failed.
- Deployed candidate `2.3.0+eabda08fa7537549848ec37184e4d48bb203308c`, SHA-256 `1a815ccfe32ee57e9b88f906be6ea9eb7a26ada1ebb5e9dc2844aba9aa764a7a`.
- Runtime corpse inspection preserved lowercase visual continuations such as “are identical” and “they did.”

An initial full-suite attempt used a redirected artifacts directory and caused 27 source-inspection tests to resolve `C:\DeadHarbour\Build` as the repository root. It was discarded as an invalid harness run. The suite was rerun with default project-local output and passed 2,087/2,087.
