### PR TITLE
Version update to 2.4.0

### DIFF
--- a/FutureMUD.Web/Content/PatchNotes/2026-08-07-engine-2-4-0.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-08-07-engine-2-4-0.md
@@ -1,0 +1,24 @@
+---
+title: FutureMUD Engine 2.4.0
+summary: Adds crew-served artillery, scheduled project labour, broader liquid-exposure scripting, and expanded historical game content.
+date: 2026-08-07
+tags: engine, release, upgrade
+---
+**Upgrade note:** Apply the normal database upgrades before starting Engine 2.4.0. This release keeps the .NET 10 and MySQL 8.0 requirements and the Windows x64, Linux x64 and Linux ARM64 package set.
+
+## Artillery And Black-Powder Weapons
+
+- Added crew-served artillery pieces, ammunition, removable chambers, mounts and artillery crew behaviour for local-cell ranged engagements.
+- Improved black-powder weapon loading, crossbow operation and weapon-carrier attachments, including physical loading and ready-state fixes.
+
+## Projects And Crafting
+
+- Added launchable, time-sliced project labour queues and contribution merits for project work.
+- Expanded Renaissance and Early Modern crafting, repair, food, household, jewellery, door and military catalogues, with stronger seeded-item manifest reconciliation.
+
+## FutureProg, Combat And Presentation
+
+- Expanded FutureProg liquid exposure for items and characters with dry-fraction handling, and made wound calls safe for bodyless items.
+- Improved clinch-breakout defence, belt capacity seeding, surface-residue descriptions and preservation of wrapped-corpse capitalization.
+
+See `/downloads` for release archives and checksums, `/getting-started` for installation requirements, and `/docs/commands` for the published Engine reference.

--- a/MudSharpCore/MudSharpCore.csproj
+++ b/MudSharpCore/MudSharpCore.csproj
@@ -10,9 +10,9 @@
 	<Product>FutureMUD</Product>
 	<ApplicationIcon>FM Logo.ico</ApplicationIcon>
 	<AssemblyName>MudSharp</AssemblyName>
-	<Version>2.3.0</Version>
-	<AssemblyVersion>2.3.0</AssemblyVersion>
-	<FileVersion>2.3.0</FileVersion>
+	<Version>2.4.0</Version>
+	<AssemblyVersion>2.4.0</AssemblyVersion>
+	<FileVersion>2.4.0</FileVersion>
   </PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
Prepares the FutureMUD Engine 2.4.0 minor release. Updates Version, AssemblyVersion and FileVersion, and adds the website patch note covering artillery, project queues, FutureProg liquid exposure, combat fixes and seeded content. Validation: Release engine build; MudSharpCore Unit Tests (2,111 passed); FutureMUD.Web.Tests (51 passed); representative win-x64 framework-dependent single-file publish; documentation export with all five metadata families populated.