### PR TITLE
Reduce unnecessary saves during startup

### DIFF
--- a/MudSharpCore/Accounts/Account.cs
+++ b/MudSharpCore/Accounts/Account.cs
@@ -43,7 +43,7 @@ public sealed class Account : SaveableItem, IAccount
         _name = account.Name.Proper();
         _id = account.Id;
         ControllingContext = null;
-        ActLawfully = account.ActLawfully;
+        _actLawfully = account.ActLawfully;
         Authority = authority;
         ActiveCharactersAllowed = account.ActiveCharactersAllowed;
         LastIP = account.LastLoginIp;
@@ -51,23 +51,24 @@ public sealed class Account : SaveableItem, IAccount
         LastLoginTime = account.LastLoginTime ?? DateTime.MinValue;
         CreationDate = account.CreationDate;
         EmailAddress = account.Email;
-        UseMSP = account.UseMsp;
-        UseMCCP = account.UseMccp;
-        UseUnicode = account.UseUnicode;
-        LineFormatLength = account.FormatLength;
-        InnerLineFormatLength = account.InnerFormatLength;
-        PageLength = account.PageLength;
-        TimeZone = TZConvert.GetTimeZoneInfo(account.TimeZoneId);
-        Culture = System.Globalization.CultureInfo.GetCultureInfo(account.CultureName);
-        UnitPreference = account.UnitPreference;
+        _useMsp = account.UseMsp;
+        _useMccp = account.UseMccp;
+        _useUnicode = account.UseUnicode;
+        _lineFormatLength = account.FormatLength;
+        _innerLineFormatLength = account.InnerFormatLength;
+        _pageLength = account.PageLength;
+        _timeZone = TZConvert.GetTimeZoneInfo(account.TimeZoneId);
+        _culture = System.Globalization.CultureInfo.GetCultureInfo(account.CultureName);
+        _unitPreference = account.UnitPreference;
         IsRegistered = account.IsRegistered;
         AccountStatus = (AccountStatus)account.AccessStatus;
-        PromptType = (PromptType)account.PromptType;
-        TabRoomDescriptions = account.TabRoomDescriptions;
-        CodedRoomDescriptionAdditionsOnNewLine = account.CodedRoomDescriptionAdditionsOnNewLine;
-        AppendNewlinesBetweenMultipleEchoesPerPrompt = account.AppendNewlinesBetweenMultipleEchoesPerPrompt;
-        CharacterNameOverlaySetting = (CharacterNameOverlaySetting)account.CharacterNameOverlaySetting;
-        HintsEnabled = account.HintsEnabled;
+        _promptType = (PromptType)account.PromptType;
+        _tabRoomDescriptions = account.TabRoomDescriptions;
+        _codedRoomDescriptionAdditionsOnNewLine = account.CodedRoomDescriptionAdditionsOnNewLine;
+        _appendNewlinesBetweenMultipleEchoesPerPrompt = account.AppendNewlinesBetweenMultipleEchoesPerPrompt;
+        _characterNameOverlaySetting = (CharacterNameOverlaySetting)account.CharacterNameOverlaySetting;
+        _hintsEnabled = account.HintsEnabled;
+        _autoReacquireTargets = account.AutoReacquireTargets;
 
         foreach (IChargenResource resource in Gameworld.ChargenResources)
         {

--- a/MudSharpCore/Body/Implementations/Body.cs
+++ b/MudSharpCore/Body/Implementations/Body.cs
@@ -818,7 +818,13 @@ public partial class Body : PerceiverItem, IBody
             {
                 gitem.FinaliseLoadTimeTasks();
                 _prosthetics.Add(prosthetic);
+                var prostheticWasChanged = prosthetic.Changed;
                 prosthetic.InstallProsthetic(this);
+                prosthetic.Changed = prostheticWasChanged;
+                if (!prostheticWasChanged)
+                {
+                    Gameworld.SaveManager.Abort(prosthetic);
+                }
             }
         }
 

--- a/MudSharpCore/Body/Implementations/BodyInventory.cs
+++ b/MudSharpCore/Body/Implementations/BodyInventory.cs
@@ -7,6 +7,7 @@ using MudSharp.Database;
 using MudSharp.Economy.Currency;
 using MudSharp.Effects.Concrete;
 using MudSharp.Events;
+using MudSharp.Framework.Save;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Inventory;
 using MudSharp.GameItems.Inventory.Size;
@@ -228,6 +229,12 @@ public partial class Body
             }
 
             loadedItems.Add(gitem);
+            var originalSaveStates = gitem.Components
+                                         .Cast<ISaveable>()
+                                         .Append(gitem)
+                                         .Distinct()
+                                         .Select(x => (Item: x, WasChanged: x.Changed))
+                                         .ToList();
 
             gitem.Get(this);
             if (item.WearProfile.HasValue)
@@ -248,6 +255,17 @@ public partial class Body
                     gitem.Get(null);
                     gitem.RoomLayer = RoomLayer;
                     gitem.InsertAtSource(Actor);
+                }
+                else
+                {
+                    foreach (var (saveable, wasChanged) in originalSaveStates)
+                    {
+                        saveable.Changed = wasChanged;
+                        if (!wasChanged)
+                        {
+                            Gameworld.SaveManager.Abort(saveable);
+                        }
+                    }
                 }
             }
             else

--- a/MudSharpCore/Character/Character.cs
+++ b/MudSharpCore/Character/Character.cs
@@ -85,7 +85,7 @@ public partial class Character : PerceiverItem, ICharacter, ICharacterIdentity, 
         Gameworld = gameworld;
         LoadFromDatabase(character);
         CommandTree = Gameworld.RetrieveAppropriateCommandTree(this);
-        LoginDateTime = character.LastLoginTime ?? DateTime.MinValue;
+        _loginDateTime = character.LastLoginTime ?? DateTime.MinValue;
         LastMinutesUpdate = LoginDateTime;
         _dbTotalMinutesPlayed = character.TotalMinutesPlayed;
         LoadEffects(XElement.Parse(character.EffectData.IfNullOrWhiteSpace("<Effects/>")));

--- a/MudSharpCore/Climate/WeatherController.cs
+++ b/MudSharpCore/Climate/WeatherController.cs
@@ -24,7 +24,7 @@ public class WeatherController : SaveableItem, IWeatherController
         OppositeHemisphere = controller.OppositeHemisphere;
         CurrentTemperatureFluctuation = controller.CurrentTemperatureFluctuation;
         ConsecutiveUnchangedPeriods = controller.ConsecutiveUnchangedPeriods;
-        MinuteCounter = controller.MinutesCounter;
+        _minuteCounter = controller.MinutesCounter;
         CurrentSeason = gameworld.Seasons.Get(controller.CurrentSeasonId);
         CurrentWeatherEvent = gameworld.WeatherEvents.Get(controller.CurrentWeatherEventId);
         HighestRecentPrecipitationLevel = (PrecipitationLevel)controller.HighestRecentPrecipitationLevel;

--- a/MudSharpCore/Community/Clan.cs
+++ b/MudSharpCore/Community/Clan.cs
@@ -29,7 +29,7 @@ public partial class Clan : SaveableItem, IClan
         Alias = clan.Alias;
         FullName = clan.FullName;
         Description = clan.Description;
-        Calendar = Gameworld.Calendars.Get(clan.CalendarId);
+        _calendar = Gameworld.Calendars.Get(clan.CalendarId);
         ShowClanMembersInWho = clan.ShowClanMembersInWho;
         ShowFamousMembersInNotables = clan.ShowFamousMembersInNotables;
         Sphere = clan.Sphere;

--- a/MudSharpCore/Construction/Area.cs
+++ b/MudSharpCore/Construction/Area.cs
@@ -50,7 +50,7 @@ public class Area : Location, IEditableArea
         _id = area.Id;
         IdInitialised = true;
         _name = area.Name;
-        WeatherController = Gameworld.WeatherControllers.Get(area.WeatherControllerId ?? 0L);
+        _weatherController = Gameworld.WeatherControllers.Get(area.WeatherControllerId ?? 0L);
         foreach (AreasRooms dbroom in area.AreasRooms)
         {
             IRoom room = Gameworld.Rooms.Get(dbroom.RoomId);

--- a/MudSharpCore/Economy/EconomicZone.cs
+++ b/MudSharpCore/Economy/EconomicZone.cs
@@ -190,7 +190,7 @@ public class EconomicZone : SaveableItem, IEconomicZone
         }
 
         OutstandingTaxesOwed = zone.OutstandingTaxesOwed;
-        TotalRevenueHeld = zone.TotalRevenueHeld;
+        _totalRevenueHeld = zone.TotalRevenueHeld;
         PreviousFinancialPeriodsToKeep = zone.PreviousFinancialPeriodsToKeep;
         ZoneForTimePurposes = gameworld.Zones.Get(zone.ZoneForTimePurposesId);
         PermitTaxableLosses = zone.PermitTaxableLosses;

--- a/MudSharpCore/Economy/Employment/ActiveJobBase.cs
+++ b/MudSharpCore/Economy/Employment/ActiveJobBase.cs
@@ -161,7 +161,7 @@ public abstract class ActiveJobBase : SaveableItem, IActiveJob, ILazyLoadDuringI
     public bool IsJobComplete { get; protected set; }
     public bool AlreadyHadClanPosition { get; }
     public double FullTimeEquivalentRatio => Listing.FullTimeEquivalentRatio;
-    private double _currentPerformance;
+    protected double _currentPerformance;
 
     public double CurrentPerformance
     {

--- a/MudSharpCore/Economy/Employment/ActiveOngoingJob.cs
+++ b/MudSharpCore/Economy/Employment/ActiveOngoingJob.cs
@@ -16,7 +16,7 @@ public class ActiveOngoingJob : ActiveJobBase
     public ActiveOngoingJob(ActiveJob dbitem, IJobListing listing, IFuturemud gameworld) : base(dbitem, listing,
         gameworld)
     {
-        CurrentPerformance = dbitem.CurrentPerformance;
+        _currentPerformance = dbitem.CurrentPerformance;
     }
 
     public ActiveOngoingJob(IJobListing listing, ICharacter character, MudDateTime commenced, MudDateTime? ending,

--- a/MudSharpCore/Economy/Employment/JobListingBase.cs
+++ b/MudSharpCore/Economy/Employment/JobListingBase.cs
@@ -42,8 +42,8 @@ public abstract class JobListingBase : SaveableItem, IJobListing
             RequiredProject?.CurrentPhase?.LabourRequirements.FirstOrDefault(x =>
                 x.Id == (dbitem.RequiredProjectLabourId ?? 0L));
         BankAccount = Gameworld.BankAccounts.Get(dbitem.BankAccountId ?? 0L);
-        IsArchived = dbitem.IsArchived;
-        IsReadyToBePosted = dbitem.IsReadyToBePosted;
+        _isArchived = dbitem.IsArchived;
+        _isReadyToBePosted = dbitem.IsReadyToBePosted;
         FullTimeEquivalentRatio = dbitem.FullTimeEquivalentRatio;
         foreach (XElement money in XElement.Parse(dbitem.MoneyPaidIn).Elements("Money"))
         {

--- a/MudSharpCore/Economy/Shops/Shop.cs
+++ b/MudSharpCore/Economy/Shops/Shop.cs
@@ -105,7 +105,7 @@ public abstract partial class Shop : SaveableItem, IShop
         _expectedCashBalance = shop.ExpectedCashBalance;
         MinimumFloatToBuyItems = shop.MinimumFloatToBuyItems;
         IsTrading = shop.IsTrading;
-        Currency = gameworld.Currencies.Get(shop.CurrencyId);
+        _currency = gameworld.Currencies.Get(shop.CurrencyId);
         MarketForPricingPurposes = gameworld.Markets.Get(shop.MarketId ?? 0);
         AutoPayTaxes = shop.AutopayTaxes;
         _canShopProg = gameworld.FutureProgs.Get(shop.CanShopProgId ?? 0);

--- a/MudSharpCore/FutureProg/ProgSchedule.cs
+++ b/MudSharpCore/FutureProg/ProgSchedule.cs
@@ -26,7 +26,7 @@ public class ProgSchedule : SaveableItem, IProgSchedule
             dbitem.ReferenceTime = string.Empty;
             dbitem.FutureProgId = prog.Id;
             FMDB.Context.SaveChanges();
-            LoadFromDB(dbitem);
+            LoadFromDB(dbitem, advanceReferenceTime: true);
         }
     }
 
@@ -88,7 +88,7 @@ public class ProgSchedule : SaveableItem, IProgSchedule
         _listener = null;
     }
 
-    private void LoadFromDB(MudSharp.Models.ProgSchedule schedule)
+    private void LoadFromDB(MudSharp.Models.ProgSchedule schedule, bool advanceReferenceTime = false)
     {
         _id = schedule.Id;
         _name = schedule.Name;
@@ -103,9 +103,8 @@ public class ProgSchedule : SaveableItem, IProgSchedule
         Prog = Gameworld.FutureProgs.Get(schedule.FutureProgId);
         var reference = MudDateTime.FromStoredStringOrFallback(schedule.ReferenceDate, Gameworld,
             StoredMudDateTimeFallback.CurrentDateTime, "ProgSchedule", schedule.Id, schedule.Name, "ReferenceDate");
-        NextReferenceTime = Interval.GetNextDateTime(reference);
+        NextReferenceTime = advanceReferenceTime ? Interval.GetNextDateTime(reference) : reference;
         _listener = Interval.CreateListenerFromInterval(NextReferenceTime, SchedulePayload, null, $"Prog Schedule #{Id} {Name.ColourName()}");
-        Changed = true;
     }
 
     public void SchedulePayload(object[] parameters)

--- a/MudSharpCore/GameItems/Components/CannulaGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/CannulaGameItemComponent.cs
@@ -162,7 +162,7 @@ public class CannulaGameItemComponent : GameItemComponent, ICannula
                     continue;
                 }
 
-                Connect(null, connectable);
+                RestorePersistedConnection(connectable, () => Connect(null, connectable));
                 break;
             }
         }
@@ -196,13 +196,12 @@ public class CannulaGameItemComponent : GameItemComponent, ICannula
                     continue;
                 }
 
-                Connect(null, connectable);
+                RestorePersistedConnection(connectable, () => Connect(null, connectable));
                 break;
             }
         }
 
         _pendingDependentLoadTimeConnections.Clear();
-        Changed = true;
     }
 
     public override bool AffectsLocationOnDestruction => true;

--- a/MudSharpCore/GameItems/Components/CompressorGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/CompressorGameItemComponent.cs
@@ -429,7 +429,7 @@ public class CompressorGameItemComponent : PoweredMachineBaseGameItemComponent, 
                     continue;
                 }
 
-                Connect(null, connectable);
+                RestorePersistedConnection(connectable, () => Connect(null, connectable));
                 break;
             }
         }
@@ -463,12 +463,11 @@ public class CompressorGameItemComponent : PoweredMachineBaseGameItemComponent, 
                     continue;
                 }
 
-                Connect(null, connectable);
+                RestorePersistedConnection(connectable, () => Connect(null, connectable));
                 break;
             }
         }
 
         _pendingDependentLoadTimeConnections.Clear();
-        Changed = true;
     }
 }

--- a/MudSharpCore/GameItems/Components/ConnectableGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/ConnectableGameItemComponent.cs
@@ -372,7 +372,7 @@ public class ConnectableGameItemComponent : GameItemComponent, IConnectable
                     continue;
                 }
 
-                Connect(null, connectable);
+                RestorePersistedConnection(connectable, () => Connect(null, connectable));
                 break;
             }
         }
@@ -406,13 +406,12 @@ public class ConnectableGameItemComponent : GameItemComponent, IConnectable
                     continue;
                 }
 
-                Connect(null, connectable);
+                RestorePersistedConnection(connectable, () => Connect(null, connectable));
                 break;
             }
         }
 
         _pendingDependentLoadTimeConnections.Clear();
-        Changed = true;
     }
 
     #endregion

--- a/MudSharpCore/GameItems/Components/DripGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/DripGameItemComponent.cs
@@ -121,7 +121,7 @@ public class DripGameItemComponent : GameItemComponent, IDrip, ISelectable
                     continue;
                 }
 
-                Connect(null, connectable);
+                RestorePersistedConnection(connectable, () => Connect(null, connectable));
                 break;
             }
         }
@@ -155,13 +155,12 @@ public class DripGameItemComponent : GameItemComponent, IDrip, ISelectable
                     continue;
                 }
 
-                Connect(null, connectable);
+                RestorePersistedConnection(connectable, () => Connect(null, connectable));
                 break;
             }
         }
 
         _pendingDependentLoadTimeConnections.Clear();
-        Changed = true;
     }
 
     public override bool HandleDieOrMorph(IGameItem newItem, ICell location)

--- a/MudSharpCore/GameItems/Components/ExternalOrganGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/ExternalOrganGameItemComponent.cs
@@ -97,7 +97,7 @@ public class ExternalOrganGameItemComponent : GameItemComponent, IExternalBloodO
                     continue;
                 }
 
-                Connect(null, connectable);
+                RestorePersistedConnection(connectable, () => Connect(null, connectable));
                 break;
             }
         }
@@ -131,13 +131,12 @@ public class ExternalOrganGameItemComponent : GameItemComponent, IExternalBloodO
                     continue;
                 }
 
-                Connect(null, connectable);
+                RestorePersistedConnection(connectable, () => Connect(null, connectable));
                 break;
             }
         }
 
         _pendingDependentLoadTimeConnections.Clear();
-        Changed = true;
     }
 
     public override IGameItemComponent Copy(IGameItem newParent, bool temporary = false)

--- a/MudSharpCore/GameItems/Components/IVBagGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/IVBagGameItemComponent.cs
@@ -461,7 +461,7 @@ public class IVBagGameItemComponent : GameItemComponent, ILiquidContainer, ISwit
                     continue;
                 }
 
-                Connect(null, connectable);
+                RestorePersistedConnection(connectable, () => Connect(null, connectable));
                 break;
             }
         }
@@ -495,13 +495,12 @@ public class IVBagGameItemComponent : GameItemComponent, ILiquidContainer, ISwit
                     continue;
                 }
 
-                Connect(null, connectable);
+                RestorePersistedConnection(connectable, () => Connect(null, connectable));
                 break;
             }
         }
 
         _pendingDependentLoadTimeConnections.Clear();
-        Changed = true;
     }
 
     #region IOpenable Members

--- a/MudSharpCore/GameItems/Components/PowerSocketGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/PowerSocketGameItemComponent.cs
@@ -231,7 +231,7 @@ public class PowerSocketGameItemComponent : GameItemComponent, IConnectable, IPr
                     continue;
                 }
 
-                Connect(null, connectable);
+                RestorePersistedConnection(connectable, () => Connect(null, connectable));
                 break;
             }
         }
@@ -265,13 +265,12 @@ public class PowerSocketGameItemComponent : GameItemComponent, IConnectable, IPr
                     continue;
                 }
 
-                Connect(null, connectable);
+                RestorePersistedConnection(connectable, () => Connect(null, connectable));
                 break;
             }
         }
 
         _pendingDependentLoadTimeConnections.Clear();
-        Changed = true;
         _connectedPowerSource = Parent.Components.Except(this).OfType<IProducePower>()
                                       .First(x => x.PrimaryLoadTimePowerProducer);
         _connectedPowerSource.BeginDrawdown(this);

--- a/MudSharpCore/GameItems/GameItemComponent.cs
+++ b/MudSharpCore/GameItems/GameItemComponent.cs
@@ -66,6 +66,39 @@ public abstract class GameItemComponent : LateInitialisingItem, IGameItemCompone
 
     public override string FrameworkItemType => "GameItemComponent";
 
+    /// <summary>
+    /// Replays a connection recorded in component XML without turning the replay itself into a save.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A normal connection updates both components and their parent items. During load those updates merely
+    /// reconstruct the already-persisted graph, so retaining their <see cref="ISaveable.Changed"/> state causes an
+    /// otherwise unnecessary first-save spike after boot.
+    /// </para>
+    /// <para>
+    /// Any change that pre-dated the replay is retained. This is important for genuine repair paths that have
+    /// already deliberately marked an item for saving.
+    /// </para>
+    /// </remarks>
+    protected void RestorePersistedConnection(IConnectable other, Action restoreAction)
+    {
+        var affectedItems = new ISaveable[] { this, other, Parent, other.Parent }
+            .Distinct()
+            .Select(x => (Item: x, WasChanged: x.Changed))
+            .ToList();
+
+        restoreAction();
+
+        foreach (var (item, wasChanged) in affectedItems)
+        {
+            item.Changed = wasChanged;
+            if (!wasChanged)
+            {
+                Gameworld.SaveManager.Abort(item);
+            }
+        }
+    }
+
     public abstract IGameItemComponent Copy(IGameItem newParent, bool temporary = false);
 
     public virtual bool PreventsMerging(IGameItemComponent component)

--- a/MudSharpCore/NPC/AI/Groups/GroupAI.cs
+++ b/MudSharpCore/NPC/AI/Groups/GroupAI.cs
@@ -16,15 +16,15 @@ public class GroupAI : LateInitialisingItem, IGroupAI
         IdInitialised = true;
         _name = ai.Name;
         XElement root = XElement.Parse(ai.Definition);
-        CurrentAction = (GroupAction)int.Parse(root.Element("Action").Value);
-        Alertness = (GroupAlertness)int.Parse(root.Element("Alertness").Value);
+        _currentAction = (GroupAction)int.Parse(root.Element("Action").Value);
+        _alertness = (GroupAlertness)int.Parse(root.Element("Alertness").Value);
         foreach (var reference in LoadMemberReferences(root.Element("Members")))
         {
             _groupMemberReferences.Add(reference);
         }
 
         Template = Gameworld.GroupAITemplates.Get(ai.GroupAiTemplateId);
-        Data = Template.GroupAIType.LoadData(XElement.Parse(ai.Data), Gameworld);
+        _data = Template.GroupAIType.LoadData(XElement.Parse(ai.Data), Gameworld);
         Gameworld.HeartbeatManager.FuzzyTenSecondHeartbeat += TenSecondTick;
         Gameworld.HeartbeatManager.FuzzyMinuteHeartbeat += MinuteTick;
     }

--- a/MudSharpCore/RPG/Law/Crime.cs
+++ b/MudSharpCore/RPG/Law/Crime.cs
@@ -64,7 +64,7 @@ public class Crime : LateInitialisingItem, ICrime
             ? null
             : MudDateTime.FromStoredStringOrFallback(dbitem.TimeOfReport, Gameworld,
                 StoredMudDateTimeFallback.CurrentDateTime, "Crime", dbitem.Id, null, "TimeOfReport");
-        HasBeenConvicted = dbitem.ConvictionRecorded;
+        _hasBeenConvicted = dbitem.ConvictionRecorded;
         _isKnownCrime = dbitem.IsKnownCrime;
         _criminalIdentityIsKnown = dbitem.IsCriminalIdentityKnown;
         _bailPosted = dbitem.BailHasBeenPosted;
@@ -75,7 +75,7 @@ public class Crime : LateInitialisingItem, ICrime
         _fineRecorded = dbitem.FineRecorded;
         _custodialSentenceLength = TimeSpan.FromSeconds(dbitem.CustodialSentenceLength);
         _calculatedBail = dbitem.CalculatedBail;
-        HasBeenFinalised = dbitem.IsFinalised;
+        _hasBeenFinalised = dbitem.IsFinalised;
         _executionPunishment = dbitem.ExecutionPunishment;
         _fineHasBeenPaid = dbitem.FineHasBeenPaid;
         _sentenceHasBeenServed = dbitem.SentenceHasBeenServed;

--- a/MudSharpCore/Work/Projects/ConcreteTypes/ProjectPhase.cs
+++ b/MudSharpCore/Work/Projects/ConcreteTypes/ProjectPhase.cs
@@ -10,8 +10,8 @@ public class ProjectPhase : SaveableItem, IProjectPhase
         Gameworld = gameworld;
         _id = phase.Id;
         _name = "Phase";
-        Description = phase.Description;
-        PhaseNumber = phase.PhaseNumber;
+        _description = phase.Description;
+        _phaseNumber = phase.PhaseNumber;
         foreach (Models.ProjectLabourRequirement labour in phase.ProjectLabourRequirements)
         {
             _labourRequirements.Add(ProjectFactory.LoadLabour(labour, gameworld));


### PR DESCRIPTION
Restores persisted state directly into backing fields across boot-loaded types; preserves clean save state while replaying persisted item connections, wielded inventory, and prosthetics; and prevents schedule reloads from advancing reference time. Validation: MudSharpCore build passed; MudSharpCore Unit Tests passed (2,111 tests); git diff --check passed.