### PR TITLE
Optimise startup lazy loading

### DIFF
--- a/Design Documents/Economy/Economy_System_Runtime.md
+++ b/Design Documents/Economy/Economy_System_Runtime.md
@@ -36,6 +36,7 @@ The economy system is loaded late in the boot sequence, after the world, future 
 - `LoadJobs()` runs after `LoadEconomy()`.
 - new character materialisation is explicitly blocked during boot until `LoadNPCs()` begins, so pre-NPC loaders must not force a fresh `TryGetCharacter(...)` from the database.
 - economy or other pre-NPC loaders that genuinely need character-dependent resolution must defer that work through `IPostCharacterLoadFinalisable.FinaliseLoading()`, which now runs immediately after `LoadNPCs()`.
+- bank accounts load their durable balance and owner references during `LoadEconomy()`, but transaction history remains demand-loaded by `Transactions`. Startup must not prewarm every open account's transaction history; account commands and transaction operations already call the same one-shot loader when history is actually required.
 
 ### Verified current scheduled runtime hooks
 - market populations receive an hourly heartbeat through the scheduler

--- a/MudSharpCore/Communication/Drawing.cs
+++ b/MudSharpCore/Communication/Drawing.cs
@@ -45,7 +45,6 @@ public class Drawing : LateInitialisingItem, IDrawing, ILazyLoadDuringIdleTime
         DrawingSkill = dbitem.DrawingSkill;
         DrawingSize = (DrawingSize)dbitem.DrawingSize;
         _authorId = dbitem.AuthorId;
-        Gameworld.SaveManager.AddLazyLoad(this);
     }
 
     public Drawing(Drawing rhs)

--- a/MudSharpCore/Communication/Language/CompositeWriting.cs
+++ b/MudSharpCore/Communication/Language/CompositeWriting.cs
@@ -56,7 +56,6 @@ public class CompositeWriting : LateInitialisingItem, IGraffitiWriting, ILazyLoa
         DrawingSkill = double.Parse(definition.Element("DrawingSkill").Value);
         ShortDescription = definition.Element("ShortDescription").Value;
         IdInitialised = true;
-        Gameworld.SaveManager.AddLazyLoad(this);
     }
 
     public CompositeWriting(CompositeWriting rhs)

--- a/MudSharpCore/Communication/Language/SimpleWriting.cs
+++ b/MudSharpCore/Communication/Language/SimpleWriting.cs
@@ -47,7 +47,6 @@ public class SimpleWriting : LateInitialisingItem, IWriting, ILazyLoadDuringIdle
         WritingColour = gameworld.Colours.Get(writing.WritingColour);
         ImplementType = (WritingImplementType)writing.ImplementType;
         IdInitialised = true;
-        Gameworld.SaveManager.AddLazyLoad(this);
     }
 
     public SimpleWriting(SimpleWriting rhs)

--- a/MudSharpCore/Community/ClanMembership.cs
+++ b/MudSharpCore/Community/ClanMembership.cs
@@ -49,7 +49,6 @@ public class ClanMembership : SaveableItem, IClanMembership, ILazyLoadDuringIdle
         }
 
         IsArchivedMembership = membership.ArchivedMembership;
-        Gameworld.SaveManager.AddLazyLoad(this);
     }
 
     public long MemberId { get; set; }

--- a/MudSharpCore/Economy/Banking/BankAccount.cs
+++ b/MudSharpCore/Economy/Banking/BankAccount.cs
@@ -54,10 +54,6 @@ public class BankAccount : SaveableItem, IBankAccount, ILazyLoadDuringIdleTime
         }
 
         _nominatedBenefactor = dbitem.NominatedBenefactorAccountId;
-        if (AccountStatus != BankAccountStatus.Closed)
-        {
-            Gameworld.SaveManager.AddLazyLoad(this);
-        }
 
         if (!string.IsNullOrEmpty(dbitem.AuthorisedBankPaymentItems))
         {

--- a/MudSharpCore/Framework/FuturemudLoaders.cs
+++ b/MudSharpCore/Framework/FuturemudLoaders.cs
@@ -2752,6 +2752,9 @@ For information on the syntax to use in emotes (such as those included in bracke
                                      .ToList();
         var activeStableMountIds = ActiveStablePrimaryMountIdentityIds(activeStableMounts,
             FMDB.Context.CharacterInstances.AsNoTracking());
+#if DEBUG
+        sw.Restart();
+#endif
         List<Npc> npcs = (from npc in FMDB.Context.Npcs
                                     .Include(x => x.NpcsArtificialIntelligences)
                                     .Include(x => x.Character)
@@ -2780,6 +2783,11 @@ For information on the syntax to use in emotes (such as those included in bracke
                           */
                           where !((CharacterState)npc.Character.State).HasFlag(CharacterState.Dead)
                           select npc).ToList();
+#if DEBUG
+        sw.Stop();
+        ConsoleUtilities.WriteLine($"#E...Queried {npcs.Count:N0} NPC records in #2{sw.ElapsedMilliseconds:N0}ms#0");
+        sw.Restart();
+#endif
         List<Npc> loadableNpcs = npcs
                                  .Where(x => ShouldLoadNpcAtBoot(x.CharacterId,
                                      (CharacterState)x.Character.State, activeStableMountIds))
@@ -2814,7 +2822,7 @@ For information on the syntax to use in emotes (such as those included in bracke
         }
 #if DEBUG
         sw.Stop();
-        ConsoleUtilities.WriteLine($"Duration: #2{sw.ElapsedMilliseconds}ms#0");
+        ConsoleUtilities.WriteLine($"#E...Materialised {loadableNpcs.Count:N0} NPCs in #2{sw.ElapsedMilliseconds:N0}ms#0");
 #endif
         int count = loadableNpcs.Count;
         ConsoleUtilities.WriteLine("Loaded #2{0}#0 NPC{1}.", count, count == 1 ? "" : "s");
@@ -3098,13 +3106,35 @@ For information on the syntax to use in emotes (such as those included in bracke
         int count = progs.Count;
         ConsoleUtilities.WriteLine("Loaded #2{0}#0 FutureProg{1}...Compiling...", count, count == 1 ? "" : "s");
 
+#if DEBUG
+        sw.Restart();
+        List<(IFutureProg Prog, long Milliseconds)> compilationTimes = new();
+#endif
         foreach (IFutureProg prog in _futureProgs)
         {
+#if DEBUG
+            Stopwatch compilationStopwatch = Stopwatch.StartNew();
+#endif
             if (!prog.Compile())
             {
                 ConsoleUtilities.WriteLine("#9FutureProg {0} ({2}) failed to compile: \n{1}#0", prog.Id, prog.CompileError, prog.FunctionName);
             }
+#if DEBUG
+            compilationStopwatch.Stop();
+            compilationTimes.Add((prog, compilationStopwatch.ElapsedMilliseconds));
+#endif
         }
+#if DEBUG
+        sw.Stop();
+        ConsoleUtilities.WriteLine($"#ECompiled {count:N0} FutureProgs in #2{sw.ElapsedMilliseconds:N0}ms#0.");
+        foreach ((IFutureProg prog, long milliseconds) in compilationTimes
+                     .OrderByDescending(x => x.Milliseconds)
+                     .Take(10))
+        {
+            ConsoleUtilities.WriteLine(
+                $"#E...Slow FutureProg #{prog.Id:N0} ({prog.FunctionName}) #2{milliseconds:N0}ms#0");
+        }
+#endif
     }
 
     void IFuturemudLoader.LoadScriptedEvents()

--- a/MudSharpCore/Framework/Save/SaveManager.cs
+++ b/MudSharpCore/Framework/Save/SaveManager.cs
@@ -18,6 +18,10 @@ public class SaveManager : ISaveManager
     protected readonly List<ISaveable> _saveStack = new();
     protected readonly List<ISaveable> _delayedSaveStack = new();
     protected Queue<ILazyLoadDuringIdleTime> _lazyLoaders = new();
+#if DEBUG
+    private readonly Dictionary<string, (int Count, TimeSpan Duration)> _lazyLoadProfile = new();
+    private Stopwatch _lazyLoadProfileStopwatch;
+#endif
 
     #region ISaveManager Members
 
@@ -341,11 +345,24 @@ public class SaveManager : ISaveManager
             return;
         }
 
+#if DEBUG
+        _lazyLoadProfileStopwatch ??= Stopwatch.StartNew();
+#endif
         Stopwatch sw = new();
         sw.Start();
         while (sw.Elapsed < maximumTime)
         {
-            _lazyLoaders.Dequeue().DoLoad();
+            ILazyLoadDuringIdleTime loader = _lazyLoaders.Dequeue();
+#if DEBUG
+            Stopwatch loaderStopwatch = Stopwatch.StartNew();
+#endif
+            loader.DoLoad();
+#if DEBUG
+            loaderStopwatch.Stop();
+            string loaderType = loader.GetType().Name;
+            _lazyLoadProfile.TryGetValue(loaderType, out (int Count, TimeSpan Duration) current);
+            _lazyLoadProfile[loaderType] = (current.Count + 1, current.Duration + loaderStopwatch.Elapsed);
+#endif
             if (!_lazyLoaders.Any())
             {
                 break;
@@ -353,6 +370,25 @@ public class SaveManager : ISaveManager
         }
 
         sw.Stop();
+#if DEBUG
+        if (_lazyLoaders.Any())
+        {
+            return;
+        }
+
+        _lazyLoadProfileStopwatch.Stop();
+        ConsoleUtilities.WriteLine(
+            $"#ECompleted { _lazyLoadProfile.Values.Sum(x => x.Count):N0} idle lazy loads in #2{_lazyLoadProfileStopwatch.ElapsedMilliseconds:N0}ms#0.");
+        foreach ((string type, (int count, TimeSpan duration)) in _lazyLoadProfile
+                     .OrderByDescending(x => x.Value.Duration)
+                     .Take(10))
+        {
+            ConsoleUtilities.WriteLine($"#E...Lazy {type}: {count:N0} items in #2{duration.TotalMilliseconds:N0}ms#0");
+        }
+
+        _lazyLoadProfile.Clear();
+        _lazyLoadProfileStopwatch = null;
+#endif
     }
 
     private bool _mudBootingMode;
@@ -372,6 +408,9 @@ public class SaveManager : ISaveManager
                 {
                     _lazyLoaders.Enqueue(item);
                 }
+#if DEBUG
+                ConsoleUtilities.WriteLine($"#EQueued {_lazyLoaders.Count:N0} idle lazy-load operations.#0");
+#endif
             }
         }
     }

--- a/MudSharpCore/GameItems/Components/CorpseGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/CorpseGameItemComponent.cs
@@ -136,7 +136,10 @@ public class CorpseGameItemComponent : GameItemComponent, ICorpse, ILazyLoadDuri
         _prototype = proto;
         _noSave = true;
         LoadFromXml(XElement.Parse(component.Definition));
-        Gameworld.SaveManager.AddLazyLoad(this);
+        if (RepresentsFinalCharacterDeath)
+        {
+            Gameworld.SaveManager.AddLazyLoad(this);
+        }
         _noSave = false;
         SetupDecayListener();
     }


### PR DESCRIPTION
## Summary
- keep document authors, clan members, and account transaction histories demand-loaded rather than prewarming them during idle time
- preserve final-death corpse linkage while avoiding unnecessary prewarming
- add Debug startup and lazy-load timing breakdowns

## Validation
- dotnet build MudSharpCore\\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`n- dotnet test 'MudSharpCore Unit Tests\\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 (2,112 passed)
- dotnet build MudSharpCore\\MudSharpCore.csproj -c Release --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`n- LabMUD Debug boot/login/look smoke: 27.622s boot; idle queue reduced from 4,097 / 42.620s to 853 / 18.448s