### PR TITLE
Clear clinches when a participant leaves combat

### DIFF
--- a/Design Documents/Combat/Combat_Strategy_Runtime.md
+++ b/Design Documents/Combat/Combat_Strategy_Runtime.md
@@ -139,6 +139,8 @@ Expected active no-move cases mirror `StandardMelee`.
 
 A melee strategy that tries to enter and fight in clinch range. It starts a clinch when upright, not cooling down, and able to clinch the target. Once clinching, it rolls between clinch weapon attacks and unarmed clinch attacks. It suppresses the base clinch-breaking behaviour because clinch is the desired state.
 
+Each pairwise clinch expires when either linked participant leaves combat, including departure caused by death or incapacitation. Other clinches in a multi-holder combat remain independent.
+
 If it discovers it has no viable clinch attacks but has viable normal melee attacks, it switches back to `StandardMelee`.
 
 ### GrappleForControl

--- a/MudSharpCore Unit Tests/ClinchEffectTests.cs
+++ b/MudSharpCore Unit Tests/ClinchEffectTests.cs
@@ -1,0 +1,78 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Character;
+using MudSharp.Combat;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Framework;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class ClinchEffectTests
+{
+	[TestMethod]
+	public void ClincherLeavesCombat_ExpiresEffect()
+	{
+		var (effect, clincher, target) = CreateFixture();
+
+		clincher.Raise(x => x.OnLeaveCombat += null!, clincher.Object);
+
+		clincher.Verify(x => x.RemoveEffect(effect, true), Times.Once);
+		target.Verify(x => x.RemoveEffect(It.IsAny<IEffect>(), It.IsAny<bool>()), Times.Never);
+	}
+
+	[TestMethod]
+	public void TargetLeavesCombat_ExpiresEffect()
+	{
+		var (effect, clincher, target) = CreateFixture();
+
+		target.Raise(x => x.OnLeaveCombat += null!, target.Object);
+
+		clincher.Verify(x => x.RemoveEffect(effect, true), Times.Once);
+	}
+
+	[TestMethod]
+	public void UnrelatedParticipantLeavesCombat_DoesNotExpireEffect()
+	{
+		var (effect, clincher, _) = CreateFixture();
+		var unrelated = new Mock<ICharacter>();
+
+		unrelated.Raise(x => x.OnLeaveCombat += null!, unrelated.Object);
+
+		clincher.Verify(x => x.RemoveEffect(effect, true), Times.Never);
+	}
+
+	[TestMethod]
+	public void OneTargetLeavesCombat_OtherHolderEffectRemains()
+	{
+		var combat = new Mock<ICombat>();
+		var holder = CreateCharacter(combat.Object);
+		var firstTarget = CreateCharacter(combat.Object);
+		var secondTarget = CreateCharacter(combat.Object);
+		var firstEffect = new ClinchEffect(holder.Object, firstTarget.Object);
+		var secondEffect = new ClinchEffect(holder.Object, secondTarget.Object);
+
+		firstTarget.Raise(x => x.OnLeaveCombat += null!, firstTarget.Object);
+
+		holder.Verify(x => x.RemoveEffect(firstEffect, true), Times.Once);
+		holder.Verify(x => x.RemoveEffect(secondEffect, true), Times.Never);
+	}
+
+	private static (ClinchEffect Effect, Mock<ICharacter> Clincher, Mock<ICharacter> Target) CreateFixture()
+	{
+		var combat = new Mock<ICombat>();
+		var clincher = CreateCharacter(combat.Object);
+		var target = CreateCharacter(combat.Object);
+		return (new ClinchEffect(clincher.Object, target.Object), clincher, target);
+	}
+
+	private static Mock<ICharacter> CreateCharacter(ICombat combat)
+	{
+		var character = new Mock<ICharacter>();
+		character.SetupGet(x => x.Combat).Returns(combat);
+		return character;
+	}
+}

--- a/MudSharpCore/Effects/Concrete/ClinchEffect.cs
+++ b/MudSharpCore/Effects/Concrete/ClinchEffect.cs
@@ -8,11 +8,25 @@ public class ClinchEffect : CombatEffectBase, IAffectProximity
     {
         Clincher = clincher;
         Target = target;
+		Clincher.OnLeaveCombat += Participant_OnLeaveCombat;
+		Target.OnLeaveCombat += Participant_OnLeaveCombat;
     }
 
     protected override string SpecificEffectType => "ClinchEffect";
     public ICharacter Clincher { get; set; }
     public ICharacter Target { get; set; }
+
+	private void Participant_OnLeaveCombat(IPerceivable participant)
+	{
+		ExpireEffect();
+	}
+
+	public override void RemovalEffect()
+	{
+		Clincher.OnLeaveCombat -= Participant_OnLeaveCombat;
+		Target.OnLeaveCombat -= Participant_OnLeaveCombat;
+		base.RemovalEffect();
+	}
 
     public override string Describe(IPerceiver voyeur)
     {


### PR DESCRIPTION
## Summary
- expire a pairwise `ClinchEffect` when either linked participant leaves combat
- unregister participant events when the effect is removed
- leave unrelated simultaneous clinches intact

## Why
`ClinchEffect` currently listens only for the whole combat ending. In a multi-combatant fight, a dead or departed holder can therefore leave another character clinched with a corpse until every remaining combat ends.

## Tests
- clincher departure expires the effect
- target departure expires the effect
- unrelated departure does nothing
- one holder's departure preserves a second holder's effect
- complete MudSharpCore suite: 2,116 passed