### PR TITLE
Allow sprawled characters to begin crawling

### DIFF
--- a/Design Documents/World/Position_State_System.md
+++ b/Design Documents/World/Position_State_System.md
@@ -49,7 +49,7 @@ Current registered IDs:
 | 5 | `PositionLyingDown` | lying down | restricted by default | low tier |
 | 6 | `PositionProne` | prone | free | low/crawling tier |
 | 7 | `PositionProstrate` | prostrate | free if not in/on a target | low/crawling tier |
-| 8 | `PositionSprawled` | sprawled | restricted by default | lowest tier |
+| 8 | `PositionSprawled` | sprawled | transitions to prone when movement begins | lowest tier |
 | 9 | `PositionStandingAttention` | standing at attention | free | standing tier |
 | 10 | `PositionStandingEasy` | standing at ease | free | standing tier |
 | 11 | `PositionLeaning` | leaning | free | standing tier |

--- a/MudSharpCore Unit Tests/PositionStateTests.cs
+++ b/MudSharpCore Unit Tests/PositionStateTests.cs
@@ -47,6 +47,14 @@ public class PositionStateTests
 			PositionFloatingInWater.Instance.Describe(voyeur.Object, null, PositionModifier.None, null, false));
 	}
 
+	[TestMethod]
+	public void SprawledMovement_TransitionsToExistingProneCrawlPath()
+	{
+		Assert.AreEqual(MovementAbility.Free, PositionSprawled.Instance.MoveRestrictions);
+		Assert.AreSame(PositionProne.Instance, PositionSprawled.Instance.TransitionOnMovement);
+		Assert.AreEqual("crawl|crawls", PositionSprawled.Instance.TransitionOnMovement.DescribePositionMovement);
+	}
+
 	private static Mock<IPerceivable> GetTarget(string description)
 	{
 		var target = new Mock<IPerceivable>();

--- a/MudSharpCore/Body/Position/PositionStates/PositionSprawled.cs
+++ b/MudSharpCore/Body/Position/PositionStates/PositionSprawled.cs
@@ -13,6 +13,8 @@ public class PositionSprawled : PositionState
 
     public static PositionSprawled Instance => _instance;
     public override string DescribeLocationMovementParticiple => "sprawled";
+	public override MovementAbility MoveRestrictions => MovementAbility.Free;
+	public override IPositionState TransitionOnMovement => PositionProne.Instance;
 
     public override string DefaultDescription()
     {


### PR DESCRIPTION
## Summary
- make `PositionSprawled` movement-capable
- transition an attempted move through the existing `PositionProne` crawl path
- retain existing prone speeds, crawl prose, stamina and usable-limb requirements

## Why
Sprawled characters currently receive a stand-first refusal. Characters that cannot stand can therefore become permanently unable to move even when they retain anatomy capable of crawling.

## Tests
- sprawled movement is free to begin
- movement transitions to prone
- the transition uses existing `crawl|crawls` prose
- complete MudSharpCore suite: 2,113 passed