### PR TITLE
Sentence-case surface-liquid room descriptions

### DIFF
--- a/Design Documents/Building/Room_Building_Builder_Guide.md
+++ b/Design Documents/Building/Room_Building_Builder_Guide.md
@@ -341,7 +341,7 @@ Outdoors type:
 
 Changing terrain can also set default light multipliers based on the terrain's default outdoors type. If you need a special case, set terrain first and then adjust `cell set type`, `cell set lightmultiplier`, or `cell set lightlevel`.
 
-Rain, ordinary liquid overflow, and pouring liquid onto the ground no longer create saved puddle items by default. Outdoor rooms lazily resolve weather exposure when they are observed or interacted with, storing bounded per-layer virtual liquid state on the cell. If `PuddlesEnabled` is true, virtual puddles can appear in room descriptions; if it is false, overflow soaks exposed items and bodies but does not accumulate room-level puddles. Existing saved puddle items remain load-compatible, but the room folds them into its virtual surface state and removes the legacy items before presenting room contents so old and new puddles cannot be shown together.
+Rain, ordinary liquid overflow, and pouring liquid onto the ground no longer create saved puddle items by default. Outdoor rooms lazily resolve weather exposure when they are observed or interacted with, storing bounded per-layer virtual liquid state on the cell. If `PuddlesEnabled` is true, virtual puddles can appear as complete sentence-cased lines in room descriptions; if it is false, overflow soaks exposed items and bodies but does not accumulate room-level puddles. Existing saved puddle items remain load-compatible, but the room folds them into its virtual surface state and removes the legacy items before presenting room contents so old and new puddles cannot be shown together.
 
 ## Exits
 

--- a/MudSharpCore Unit Tests/CellSurfaceLiquidDescriptionTests.cs
+++ b/MudSharpCore Unit Tests/CellSurfaceLiquidDescriptionTests.cs
@@ -1,0 +1,16 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Construction;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class CellSurfaceLiquidDescriptionTests
+{
+	[TestMethod]
+	public void DescribeSurfaceLiquidRoomLine_LowercaseNounPhrase_SentenceCasesLine()
+	{
+		Assert.AreEqual(
+			"A small puddle of a mixture of blood and water is here.",
+			Cell.DescribeSurfaceLiquidRoomLine("small puddle", "a mixture of blood and water"));
+	}
+}

--- a/MudSharpCore/Construction/Cell.SurfaceLiquid.cs
+++ b/MudSharpCore/Construction/Cell.SurfaceLiquid.cs
@@ -67,7 +67,8 @@ public partial class Cell
 		{
 			if (state.LiquidVolume >= Gameworld.GetStaticDouble("SplashLiquidQuantity"))
 			{
-				var text = $"{PuddleDescription(state.LiquidVolume).A_An()} of {state.ContaminatingLiquid.LiquidDescription} is here.";
+				var text = DescribeSurfaceLiquidRoomLine(PuddleDescription(state.LiquidVolume),
+					state.ContaminatingLiquid.LiquidDescription);
 				sb.AppendLine(colour ? text.Colour(state.ContaminatingLiquid.LiquidColour) : text);
 			}
 
@@ -83,6 +84,11 @@ public partial class Cell
 		}
 
 		return sb.ToString().TrimEnd();
+	}
+
+	internal static string DescribeSurfaceLiquidRoomLine(string amountDescription, string liquidDescription)
+	{
+		return $"{amountDescription.A_An()} of {liquidDescription} is here.".Proper();
 	}
 
 	public void ResolveRoomWeatherExposure(IPerceiver? voyeur)


### PR DESCRIPTION
## Summary
- sentence-case the completed virtual surface-liquid room line
- preserve lower-case liquid noun phrases inside the sentence
- leave liquid state, colour and persistence unchanged

## Why
Virtual puddle descriptions begin with generated lower-case noun phrases and are inserted as complete room-list sentences, producing output such as `a small puddle ... is here.`.

## Tests
- a lower-case puddle/liquid noun phrase becomes a correctly capitalised complete sentence
- complete MudSharpCore suite: 2,113 passed