### PR TITLE
Retain last describers for every unit type

### DIFF
--- a/Design Documents/Health/Health_Core_Runtime.md
+++ b/Design Documents/Health/Health_Core_Runtime.md
@@ -83,6 +83,8 @@ The body runtime continuously tracks more than visible wounds:
 - internal bleeding and other hidden trauma
 - consequences of low circulation for prompts, health checks, and death
 
+Unit descriptions retain a smallest describer independently for every measurement type, so zero or sub-unit internal bleeding quantities remain explicit rather than leaving blanks in diagnostics.
+
 Surface-liquid persistence permits blood records whose source race or blood type is no longer available. Those optional references serialize as zero rather than aborting the owning body's save; this is important because a failed body save would also lose unrelated inventory, implant, and cannula state from the same transaction.
 
 Temperature imbalance now participates in this same layer. Mild and moderate stages remain mostly symptomatic, but severe and especially critical hypothermia or hyperthermia apply organ-function penalties through the effect system. That means thermal injury is reversible while exposure is corrected, but can still become fatal if a body is left in critical extremes for long enough.

--- a/MudSharpCore Unit Tests/UnitManagerDescriptionTests.cs
+++ b/MudSharpCore Unit Tests/UnitManagerDescriptionTests.cs
@@ -1,0 +1,51 @@
+#nullable enable
+
+using System.Globalization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Framework.Units;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class UnitManagerDescriptionTests
+{
+	[TestMethod]
+	public void RecalculateLastUnits_MultipleUnitTypes_RetainsFallbackForEachType()
+	{
+		var mass = CreateUnit("gram", UnitType.Mass);
+		var fluid = CreateUnit("millilitre", UnitType.FluidVolume);
+		var manager = new UnitManager([mass.Object, fluid.Object]);
+
+		Assert.IsTrue(mass.Object.LastDescriber);
+		Assert.IsTrue(fluid.Object.LastDescriber);
+		Assert.AreEqual("0 grams", manager.Describe(0.0, UnitType.Mass, "Metric", CultureInfo.InvariantCulture));
+		Assert.AreEqual("0 millilitres",
+			manager.Describe(0.0, UnitType.FluidVolume, "Metric", CultureInfo.InvariantCulture));
+	}
+
+	[TestMethod]
+	public void Describe_NonZeroValue_RemainsUnchanged()
+	{
+		var fluid = CreateUnit("millilitre", UnitType.FluidVolume);
+		var manager = new UnitManager([fluid.Object]);
+
+		Assert.AreEqual("2 millilitres",
+			manager.Describe(2.0, UnitType.FluidVolume, "Metric", CultureInfo.InvariantCulture));
+	}
+
+	private static Mock<IUnit> CreateUnit(string name, UnitType type)
+	{
+		var unit = new Mock<IUnit>();
+		unit.SetupGet(x => x.Name).Returns(name);
+		unit.SetupGet(x => x.Type).Returns(type);
+		unit.SetupGet(x => x.System).Returns("Metric");
+		unit.SetupGet(x => x.MultiplierFromBase).Returns(1.0);
+		unit.SetupGet(x => x.PreMultiplierOffsetFrombase).Returns(0.0);
+		unit.SetupGet(x => x.PostMultiplierOffsetFrombase).Returns(0.0);
+		unit.SetupGet(x => x.DescriberUnit).Returns(true);
+		unit.SetupGet(x => x.SpaceBetween).Returns(true);
+		unit.SetupProperty(x => x.LastDescriber);
+		return unit;
+	}
+}

--- a/MudSharpCore/Framework/Units/UnitManager.cs
+++ b/MudSharpCore/Framework/Units/UnitManager.cs
@@ -21,6 +21,12 @@ public class UnitManager : IUnitManager
         InitialiseUnitManager(game);
     }
 
+	internal UnitManager(IEnumerable<IUnit> units)
+	{
+		_units.AddRange(units);
+		RecalculateAllUnits();
+	}
+
     public IEnumerable<IUnit> Units => _units;
 
     public IEnumerable<string> Systems => _unitSystems.Keys;
@@ -59,14 +65,14 @@ public class UnitManager : IUnitManager
     {
         foreach (string system in _unitSystems.Keys)
         {
+			_unitSystems[system].Sort((u1, u2) => u2.MultiplierFromBase.CompareTo(u1.MultiplierFromBase));
+			foreach (IUnit unit in _unitSystems[system])
+			{
+				unit.LastDescriber = false;
+			}
+
             foreach (UnitType value in Enum.GetValues(typeof(UnitType)))
             {
-                _unitSystems[system].Sort((u1, u2) => u2.MultiplierFromBase.CompareTo(u1.MultiplierFromBase));
-                foreach (IUnit unit in _unitSystems[system])
-                {
-                    unit.LastDescriber = false;
-                }
-
                 IUnit last = _unitSystems[system].LastOrDefault(x => x.DescriberUnit && x.Type == value);
                 last?.LastDescriber = true;
             }


### PR DESCRIPTION
## Summary
- clear `LastDescriber` flags once per unit system
- assign the smallest describer independently for every `UnitType`
- preserve existing nonzero descriptions

## Why
`RecalculateLastUnits` currently clears every flag inside the loop for each measurement type. Later types erase earlier types' fallback units, so zero or sub-unit quantities can render as blank text, including internal-bleeding diagnostics.

## Tests
- mass and fluid volume simultaneously retain their fallback describers
- zero quantities render explicitly for both types
- nonzero fluid descriptions remain unchanged
- complete MudSharpCore suite: 2,114 passed