### PR TITLE
Version update to 2.5.0

### DIFF
--- a/FutureMUD.Web/Content/PatchNotes/2026-08-09-engine-2-5-0.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-08-09-engine-2-5-0.md
@@ -1,0 +1,26 @@
+---
+title: FutureMUD Engine 2.5.0
+summary: Improves startup and scheduling performance, modernises outbound email, and delivers time, combat, and anatomy fixes.
+date: 2026-08-09
+tags: engine, release, upgrade
+---
+**Upgrade note:** Apply the normal database upgrades before starting Engine 2.5.0. This release keeps the .NET 10 and MySQL 8.0 requirements and the Windows x64, Linux x64 and Linux ARM64 package set.
+
+## Runtime Performance And Operations
+
+- Improved startup by avoiding unnecessary saves and deferring more data until it is actually needed.
+- Added stable scheduling, runtime performance monitoring, connection snapshots, and staff diagnostics to make game-loop behaviour more predictable and easier to investigate.
+- Modernised outbound email with explicit SMTP security and authentication options, environment-backed secrets, Gmail API/OAuth support, safer retry handling, and clearer operational diagnostics.
+
+## Time, Calendar And Scheduled Events
+
+- Corrected time and date arithmetic, intercalary-calendar handling, birthdays, timezone carry, recurring intervals, and related FutureProg functions.
+- Fixed timezone-aware scheduled listeners so future events do not recursively fire while the game is starting.
+
+## Gameplay And Builder Fixes
+
+- Added a bodypart-level builder setting for limb sever descriptions, so visible results can be tuned per anatomy while preserving the established defaults.
+- Prevented natural attacks from using bodyparts that have been severed, let sprawled characters begin crawling when their anatomy permits it, and cleared clinches when either participant leaves combat.
+- Fixed unit fallback descriptions and surface-liquid sentence capitalisation so generated text stays complete and readable.
+
+Use `/downloads` for the release archives and checksums, `/getting-started` for installation requirements, and `/docs/commands` for the published Engine reference.

--- a/MudSharpCore/MudSharpCore.csproj
+++ b/MudSharpCore/MudSharpCore.csproj
@@ -10,9 +10,9 @@
 	<Product>FutureMUD</Product>
 	<ApplicationIcon>FM Logo.ico</ApplicationIcon>
 	<AssemblyName>MudSharp</AssemblyName>
-	<Version>2.4.0</Version>
-	<AssemblyVersion>2.4.0</AssemblyVersion>
-	<FileVersion>2.4.0</FileVersion>
+	<Version>2.5.0</Version>
+	<AssemblyVersion>2.5.0</AssemblyVersion>
+	<FileVersion>2.5.0</FileVersion>
   </PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
## Summary
- Align MudSharpCore `Version`, `AssemblyVersion`, and `FileVersion` at 2.5.0.
- Add the public Engine 2.5.0 patch note for the website.

## Validation
- `dotnet test 'MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj' -c Release --no-restore -m:1 -p:NuGetAudit=false -p:NoWarn=NU1902%3BNU1510` (2,173 passed)
- `dotnet test 'FutureMUD.Web.Tests/FutureMUD.Web.Tests.csproj' -c Release --no-restore -m:1 -p:NuGetAudit=false -p:NoWarn=NU1902%3BNU1510` (51 passed)
- Published a framework-dependent, single-file, untrimmed Windows x64 package with native-library extraction and embedded symbols.
- Exported documentation catalogue with source revision `b869e2b9327423bf6e80dc64a54a26936abb198a`; all five metadata families were populated.
- `git diff --check`