### PR TITLE
Add configurable explosive trigger components

### DIFF
--- a/Design Documents/Items/Item_System_Component_Authoring.md
+++ b/Design Documents/Items/Item_System_Component_Authoring.md
@@ -139,6 +139,17 @@ Use `IGameItemComponentPrototypeRequirementProvider` when a component prototype 
 
 The seeded modern bayonet mount requires `IMeleeWeapon`; the underbarrel launcher mount requires `IRangedWeapon`; and the weapon-light mount requires both `IProduceLight` and `IProducePower`. `ImpactDetonator` has a fixed requirement for `IDetonatable`, because it is only a trigger policy and cannot supply an explosive payload itself.
 
+The other explosive trigger prototypes use the same fixed sibling requirement. Use `countdowndetonator`, `clockdetonator`, `signaldetonator`, or `pinpulldetonator` for the trigger and attach a `Bomb` component separately for the payload. `CountdownDetonator`, `ClockDetonator`, `SignalDetonator`, and `RadioDetonator` advertise the exclusive `IArmableExplosiveTriggerPrototype` role, so an item prototype can have only one authoritative `arm` / `disarm` target. `PinPullDetonator` advertises its separate exclusive pin-pull role.
+
+The principal builder settings are:
+
+- `CountdownDetonator`: `default`, `minimum`, `maximum`, `playerdelay`, `disarmable`, `armemote`, and `disarmemote`.
+- `ClockDetonator`: `calendar`, `clock`, `timezone`, `disarmable`, `armemote`, and `disarmemote`. The selected clock must drive a calendar.
+- `SignalDetonator`: `source <component> [<endpoint>]`, `threshold`, `mode <above|below>`, `activation <edge|level>`, `power`, `watts`, `disarmable`, and the arm/disarm emotes. Edge is the safe default because an already-active input does not detonate merely because the item was armed or repowered.
+- `PinPullDetonator`: `delay` and `emote`. Its deadline cannot be cancelled once started.
+
+Do not introduce a second physical-only detonator API for future traps. A tripwire, pressure plate, opening trigger, or similar component should expose an `ISignalSourceComponent` numeric endpoint: a momentary mechanism emits a pulse suitable for edge activation, while a maintained mechanism exposes a level. The signal detonator remains deliberately agnostic about the source's physical or electronic implementation.
+
 ### Opt-in condition maintenance
 Use `IConditionDegradingComponent` when a component should optionally consume `IGameItem.Condition` as it is used. The interface extends `IAffectQuality`, and the matching `IConditionDegradingComponentPrototype` marker is aggregate, so a component can contribute a maintenance quality penalty without becoming the item's only quality-affecting component.
 

--- a/Design Documents/Items/Item_System_Content_Workflows.md
+++ b/Design Documents/Items/Item_System_Content_Workflows.md
@@ -69,6 +69,15 @@ Signal-automation examples now include:
 - `comp edit new relayswitch`
 - `comp edit new alarmsiren`
 
+Explosive-trigger examples include:
+
+- `comp edit new countdowndetonator`
+- `comp edit new clockdetonator`
+- `comp edit new signaldetonator`
+- `comp edit new pinpulldetonator`
+
+Each of these must be attached to an item prototype with a sibling `Bomb` component before the item can be submitted. Countdown, clock, signal, and radio detonators are mutually exclusive armable roles; the pin-pull role is separate.
+
 Power, telecom, and modern medical examples also include:
 - `comp edit new electricgridoutlet`
 - `comp edit new gridpowersupply`
@@ -178,6 +187,14 @@ These matter because many component features only make sense in combination with
 - morph and destroyed settings affect component replacement behaviour
 - registers and on-load progs can feed variable-style components
 - skinnability affects how content can be customised by players
+
+### Explosive trigger runtime workflow
+
+Use `arm <item> [<duration|in-game datetime>] [(<emote>)]` for countdown, clock, signal, and radio triggers. A countdown uses its authored default when no duration is supplied and accepts a player duration only when enabled; a clock trigger requires an exact future in-game date and time interpreted in the component's authored timezone; a signal or radio trigger takes no trigger argument. Use `disarm <item> [(<emote>)]` only when the component profile permits it. Existing `switch <radio detonator> on|off` aliases remain available for compatibility.
+
+Use `pullpin <item> [(<emote>)]` (or `pinpull`) for a pin-pull trigger. This begins its authored fixed delay and cannot be reversed. Countdown and pin-pull deadlines continue against UTC while unloaded or during server downtime and fire on the next load if overdue. Clock triggers follow their authored in-game calendar and clock instead.
+
+For a signal detonator, author a default source component and endpoint, then use the ordinary `electrical` inspection and binding workflow when a live item needs rewiring. A live binding to a specific source item remains tied to that item and becomes inactive when the source is disconnected or moved out of signal range; it never substitutes another item merely because the component prototype matches. Test both inactive and active starting states, source disconnection and reconnection, power loss and restoration when power is required, threshold direction, and the selected activation policy. Edge mode must require a fresh inactive-to-active transition after arming or repowering; level mode may detonate as soon as an active level is observed. A microcontroller can provide arbitrary electronic logic now, and later mechanical trap sources can use the same endpoint contract.
 - unique names give builders, scripts, and content references a stable lookup key that is not the item noun
 - builder comments preserve design intent, associations, and maintenance notes without changing runtime behaviour
 

--- a/Design Documents/Items/Item_System_Overview.md
+++ b/Design Documents/Items/Item_System_Overview.md
@@ -40,6 +40,7 @@ Component-prototype markers protect this composition in both directions: exclusi
 - The fastest way to add a new item capability is usually to add a new component prototype and component pair, not a new `GameItem` subclass.
 - Telecommunications items follow the same composition model: a wired telephone handset, a telecommunications outlet, a telecommunications feeder, a cell tower, a cellular handset, and an implant telephone are all ordinary item capabilities expressed through components and public interfaces.
 - Computer and signal automation work should follow the same pattern. Shared interfaces such as `IComputerHost`, `IComputerFileSystem`, `ISignalSource`, and `ISignalSink` belong in `FutureMUDLibrary`, while concrete behaviour should be delivered through distinct item component families rather than one generic "automation item" component.
+- Explosive triggers follow the same composition rule. `Bomb` remains the `IDetonatable` payload, while impact, fuse, radio, countdown, clock, signal, and pin-pull components supply independent trigger policies. Every trigger component requires a sibling explosive payload rather than implementing blast behaviour itself.
 - Riding and hitching gear also follow the composition model. `RidingGear` and `HitchGear` components give ordinary wearable or holdable items semantic roles such as saddle, bridle, reins, yoke, rope, chain, or tow bar, and the riding/vehicle systems query those interfaces rather than special item classes.
 - Ritual foci follow the same composition model. `OfferingReceiver` owns item-offering and consumptive liquid-libation policy and history summary, while independent capabilities such as the oil-lamp shrine's lighting remain ordinary sibling components such as `Lantern`.
 - Not every thematic item needs a mechanical family. The stock wooden measuring rod is intentionally a holdable static prop; builders can use descriptions and FutureProgs without introducing a dimension system solely to support it.
@@ -119,6 +120,19 @@ Computer-network visibility is now intentionally scoped rather than globally fla
 This keeps `Directory` and related tools from flooding players with every private sensor on the broader linked-grid graph, supports isolated exchange-local operational networks, and leaves space for future authorised tunnelling or hacking flows without changing the underlying addressing model.
 
 Those verbs currently use staged delayed actions, inventory plans for tool handling, configurable static-string echoes, and dedicated checks rather than instant state changes.
+
+## Explosive Triggers
+
+The explosive system now has four additional component families:
+
+- `CountdownDetonator` arms for a relative real-time duration. Builders set the default, minimum, maximum, whether players may choose the duration, and whether the trigger can be disarmed.
+- `ClockDetonator` arms for an exact future in-game date and time interpreted through an authored calendar, feed clock, and timezone.
+- `SignalDetonator` listens to a local numeric `ISignalSourceComponent` endpoint. It supports above/below threshold tests, edge or level activation, live `electrical bind` reconfiguration, and optional electrical power consumption.
+- `PinPullDetonator` starts a fixed irreversible countdown when its pin is pulled.
+
+`IArmableExplosiveTrigger` supplies the common `arm` and `disarm` interaction shared by countdown, clock, signal, and radio detonators. `IPinPullExplosiveTrigger` stays separate because pulling a pin is deliberately irreversible. Only one armable trigger component may be attached to an item prototype, while a pin-pull trigger remains a distinct capability.
+
+The signal contract does not encode whether a source is electronic or mechanical. Microcontrollers and current electronic sources can drive a `SignalDetonator` today; future pressure plates, tripwires, opening sensors, or other trap components can use the same numeric pulse or maintained-level contract without changing the detonator.
 
 ## Thermal Sources
 Room temperature now includes three layers:

--- a/Design Documents/Items/Item_System_Presentation_and_Integration.md
+++ b/Design Documents/Items/Item_System_Presentation_and_Integration.md
@@ -51,6 +51,10 @@ Examples include:
 - stable tickets showing the lodged mount, stable, lodger, and current outstanding fees when the ticket still points at an active stay
 - effects such as glow adding descriptive layers through adjacent systems
 
+Explosive trigger components decorate their parent item rather than replacing its authored descriptions. Armed countdown and pin-pull triggers add a conspicuous armed marker to the short description and report the localised remaining duration in the full description. Clock triggers report their exact target through the authored calendar, clock, and timezone. Signal and radio triggers report their armed state without exposing hidden controller logic to an ordinary look. `evaluate` presents the stable authored trigger facts, including permitted delay range, clock basis, signal threshold/activation mode/power requirement, fixed pin delay, and whether disarming is possible.
+
+The commands that change this state accept optional parenthesised player emotes and emit an explicit action echo. New trigger profiles let builders author that echo. `pullpin` must always communicate that its countdown is irreversible; `disarm` must fail clearly when the trigger profile forbids it.
+
 ### Decoration ordering
 Decoration ordering matters:
 - non-negative priorities are applied before colour processing

--- a/Design Documents/Items/Item_System_Runtime_Model.md
+++ b/Design Documents/Items/Item_System_Runtime_Model.md
@@ -125,6 +125,14 @@ Component protos also advertise their runtime capability contracts through marke
 
 Prototype composition is checked in both directions. `IGameItemComponentPrototypeRequirementProvider` declares the inverse relationship: a component can require one or more runtime capabilities from other siblings. Requirements are advisory while a builder is assembling an item, but unresolved requirements make `CanSubmit()` false and therefore block both submission and review approval.
 
+### Explosive trigger composition and persistence
+
+Explosive payload and trigger policy are separate capabilities. `Bomb` supplies `IDetonatable`; `CountdownDetonator`, `ClockDetonator`, `SignalDetonator`, `PinPullDetonator`, `RadioDetonator`, and `ImpactDetonator` only decide when that sibling payload should detonate. Their prototypes use `IGameItemComponentPrototypeRequirementProvider` to prevent approval without an `IDetonatable` sibling.
+
+Countdown and pin-pull components persist an absolute UTC deadline rather than a remaining duration. They subscribe to the second heartbeat only while loaded and active, compare inclusively, and detonate immediately on the next `Login()` when a persisted deadline expired while the item or server was offline. Builder submission and runtime arming both reject durations that cannot be represented as a future UTC `DateTime`. Clock detonators persist a `MudInstant`, subscribe to their authored clock, and likewise use an inclusive `current >= target` comparison so skipped or accelerated clock ticks cannot miss the event. Applying a component revision that changes the calendar or clock safely disarms an already-armed clock trigger because ticks from different clock systems are not interchangeable.
+
+Signal detonators are `IRuntimeConfigurableSignalSinkComponent` implementations. Edge mode establishes the current source state as a baseline when armed, connected, or repowered and fires only on the next inactive-to-active transition. Level mode fires whenever the armed, operational sink observes an active level. Optional power draw is active only while armed, and a signal observed while unpowered is not replayed later as a synthetic edge. Runtime source bindings, endpoint keys, thresholds, above/below mode, and armed state persist in component XML. A runtime binding with a source item id is strict: it never falls through to another nearby item with the same component prototype. Signal detonators re-resolve bindings when their parent or source moves or their physical connection topology changes, and reject events from sources that are no longer locally accessible.
+
 ## Composition Model
 ### Components define capabilities
 The item system is intentionally interface-first and component-driven.

--- a/FutureMUDLibrary/GameItems/Interfaces/IExplosiveTrigger.cs
+++ b/FutureMUDLibrary/GameItems/Interfaces/IExplosiveTrigger.cs
@@ -1,0 +1,31 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.PerceptionEngine;
+
+namespace MudSharp.GameItems.Interfaces;
+
+public enum ExplosiveSignalActivationMode
+{
+	Edge,
+	Level
+}
+
+public interface IArmableExplosiveTrigger : IGameItemComponent
+{
+	bool Armed { get; }
+	bool CanArm(ICharacter actor, string argument);
+	string WhyCannotArm(ICharacter actor, string argument);
+	bool Arm(ICharacter actor, string argument, IEmote? playerEmote = null);
+	bool CanDisarm(ICharacter actor);
+	string WhyCannotDisarm(ICharacter actor);
+	bool Disarm(ICharacter actor, IEmote? playerEmote = null);
+}
+
+public interface IPinPullExplosiveTrigger : IGameItemComponent
+{
+	bool PinPulled { get; }
+	bool CanPullPin(ICharacter actor);
+	string WhyCannotPullPin(ICharacter actor);
+	bool PullPin(ICharacter actor, IEmote? playerEmote = null);
+}

--- a/FutureMUDLibrary/GameItems/Prototypes/GameItemComponentPrototypeInterfaces.cs
+++ b/FutureMUDLibrary/GameItems/Prototypes/GameItemComponentPrototypeInterfaces.cs
@@ -205,6 +205,14 @@ public interface IImpactDetonatorPrototype : IExclusiveGameItemComponentPrototyp
 {
 }
 
+public interface IArmableExplosiveTriggerPrototype : IExclusiveGameItemComponentPrototype<IArmableExplosiveTrigger>
+{
+}
+
+public interface IPinPullExplosiveTriggerPrototype : IExclusiveGameItemComponentPrototype<IPinPullExplosiveTrigger>
+{
+}
+
 public interface IDicePrototype : IExclusiveGameItemComponentPrototype<IDice>
 {
 }

--- a/MudSharpCore Unit Tests/ExplosiveTriggerTests.cs
+++ b/MudSharpCore Unit Tests/ExplosiveTriggerTests.cs
@@ -1,0 +1,452 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Character;
+using MudSharp.Computers;
+using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.Framework.Scheduling;
+using MudSharp.Framework.Save;
+using MudSharp.Form.Shape;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Components;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.GameItems.Prototypes;
+using MudSharp.PerceptionEngine;
+using MudSharp.TimeAndDate;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class ExplosiveTriggerTests
+{
+	[TestMethod]
+	public void GameItemComponentManager_RegistersAllExplosiveTriggerTypes()
+	{
+		var manager = new GameItemComponentManager();
+
+		CollectionAssert.IsSubsetOf(
+			new[] { "countdowndetonator", "clockdetonator", "signaldetonator", "pinpulldetonator" },
+			manager.PrimaryTypes.ToList());
+		CollectionAssert.IsSubsetOf(
+			new[] { "CountdownDetonator", "ClockDetonator", "SignalDetonator", "PinPullDetonator" },
+			manager.TypeHelpInfo.Select(x => x.Name).ToList());
+	}
+
+	[TestMethod]
+	public void ExplosiveDeadlineScheduler_UsesInclusiveDeadlineComparison()
+	{
+		var deadline = new DateTime(638900000000000000L, DateTimeKind.Utc);
+
+		Assert.IsFalse(ExplosiveDeadlineScheduler.IsDue(deadline, deadline.AddTicks(-1)));
+		Assert.IsTrue(ExplosiveDeadlineScheduler.IsDue(deadline, deadline));
+		Assert.IsTrue(ExplosiveDeadlineScheduler.IsDue(deadline, deadline.AddSeconds(10)));
+	}
+
+	[TestMethod]
+	public void ExplosiveDeadlineScheduler_RejectsUnrepresentableDeadlines()
+	{
+		var now = DateTime.UtcNow;
+
+		Assert.IsTrue(ExplosiveDeadlineScheduler.TryGetDeadline(now, TimeSpan.FromHours(24), out var deadline));
+		Assert.AreEqual(now.AddHours(24), deadline);
+		Assert.IsFalse(ExplosiveDeadlineScheduler.TryGetDeadline(now, TimeSpan.MaxValue, out _));
+	}
+
+	[TestMethod]
+	public void ClockDetonatorScheduleEvaluator_DetonatesAfterSkippedWorldTicks()
+	{
+		var target = new MudInstant(1000L);
+
+		Assert.IsFalse(ClockDetonatorScheduleEvaluator.IsDue(target, new MudInstant(999L)));
+		Assert.IsTrue(ClockDetonatorScheduleEvaluator.IsDue(target, new MudInstant(1000L)));
+		Assert.IsTrue(ClockDetonatorScheduleEvaluator.IsDue(target, new MudInstant(1500L)));
+		Assert.IsTrue(ClockDetonatorScheduleEvaluator.CanRetainArmedTarget(1L, 2L, 1L, 2L));
+		Assert.IsFalse(ClockDetonatorScheduleEvaluator.CanRetainArmedTarget(1L, 2L, 3L, 2L));
+		Assert.IsFalse(ClockDetonatorScheduleEvaluator.CanRetainArmedTarget(1L, 2L, 1L, 4L));
+	}
+
+	[TestMethod]
+	public void CountdownDetonator_ValidatesPlayerDelayAndPersistsArmedDeadline()
+	{
+		var gameworld = CreateGameworld();
+		var detonatable = new Mock<IDetonatable>();
+		var item = CreateExplosiveItem(gameworld.Object, detonatable.Object);
+		var trigger = new CountdownDetonatorGameItemComponent(CreateCountdownPrototype(gameworld.Object), item.Object,
+			true);
+		var actor = CreateActor();
+
+		Assert.IsFalse(trigger.CanArm(actor.Object, "00:00:00.500"));
+		Assert.IsTrue(trigger.CanArm(actor.Object, "00:00:05"));
+		Assert.IsTrue(trigger.Arm(actor.Object, "00:00:05", Mock.Of<IEmote>()));
+		Assert.IsTrue(trigger.Armed);
+
+		var definition = SaveDefinition(trigger);
+		StringAssert.Contains(definition, "DetonationDeadlineUtcTicks");
+		Assert.IsTrue(long.Parse(XElement.Parse(definition).Element("DetonationDeadlineUtcTicks")!.Value) > 0L);
+	}
+
+	[TestMethod]
+	public void CountdownDetonator_ExpiredPersistedDeadlineDetonatesOnLogin()
+	{
+		var gameworld = CreateGameworld();
+		var detonatable = new Mock<IDetonatable>();
+		var item = CreateExplosiveItem(gameworld.Object, detonatable.Object);
+		var component = new MudSharp.Models.GameItemComponent
+		{
+			Definition = new XElement("Definition",
+				new XElement("DetonationDeadlineUtcTicks", DateTime.UtcNow.AddSeconds(-1).Ticks)).ToString()
+		};
+		var trigger = new CountdownDetonatorGameItemComponent(component,
+			CreateCountdownPrototype(gameworld.Object), item.Object);
+
+		trigger.Login();
+
+		detonatable.Verify(x => x.Detonate(), Times.Once);
+		Assert.IsFalse(trigger.Armed);
+	}
+
+	[TestMethod]
+	public void SignalDetonator_EdgeMode_IgnoresInitialHighThenFiresOnRisingEdge()
+	{
+		var (trigger, detonatable, actor) = CreateSignalDetonator(ExplosiveSignalActivationMode.Edge, false);
+		var source = Mock.Of<ISignalSource>();
+
+		Assert.IsTrue(trigger.Arm(actor.Object, string.Empty, Mock.Of<IEmote>()));
+		trigger.ReceiveSignal(new ComputerSignal(1.0, null, null), source);
+		detonatable.Verify(x => x.Detonate(), Times.Never);
+
+		trigger.ReceiveSignal(default, source);
+		trigger.ReceiveSignal(new ComputerSignal(1.0, null, null), source);
+		detonatable.Verify(x => x.Detonate(), Times.Once);
+	}
+
+	[TestMethod]
+	public void SignalDetonator_LevelMode_FiresWheneverArmedInputIsActive()
+	{
+		var (trigger, detonatable, actor) = CreateSignalDetonator(ExplosiveSignalActivationMode.Level, false);
+
+		Assert.IsTrue(trigger.Arm(actor.Object, string.Empty, Mock.Of<IEmote>()));
+		trigger.ReceiveSignal(new ComputerSignal(1.0, null, null), Mock.Of<ISignalSource>());
+
+		detonatable.Verify(x => x.Detonate(), Times.Once);
+		Assert.IsFalse(trigger.Armed);
+	}
+
+	[TestMethod]
+	public void SignalDetonator_PoweredEdgeMode_DoesNotReplaySignalReceivedWhileUnpowered()
+	{
+		var (trigger, detonatable, actor) = CreateSignalDetonator(ExplosiveSignalActivationMode.Edge, true);
+		var source = Mock.Of<ISignalSource>();
+
+		Assert.IsTrue(trigger.Arm(actor.Object, string.Empty, Mock.Of<IEmote>()));
+		trigger.ReceiveSignal(new ComputerSignal(1.0, null, null), source);
+		trigger.OnPowerCutIn();
+		detonatable.Verify(x => x.Detonate(), Times.Never);
+
+		trigger.ReceiveSignal(default, source);
+		trigger.ReceiveSignal(new ComputerSignal(1.0, null, null), source);
+		detonatable.Verify(x => x.Detonate(), Times.Once);
+	}
+
+	[TestMethod]
+	public void SignalDetonator_DisarmPreventsLaterSignalDetonation()
+	{
+		var (trigger, detonatable, actor) = CreateSignalDetonator(ExplosiveSignalActivationMode.Level, false);
+
+		Assert.IsTrue(trigger.Arm(actor.Object, string.Empty, Mock.Of<IEmote>()));
+		Assert.IsTrue(trigger.Disarm(actor.Object, Mock.Of<IEmote>()));
+		trigger.ReceiveSignal(new ComputerSignal(1.0, null, null), Mock.Of<ISignalSource>());
+
+		detonatable.Verify(x => x.Detonate(), Times.Never);
+	}
+
+	[TestMethod]
+	public void SignalDetonator_DisconnectedExplicitSourceCannotTriggerOrSubstituteAndReconnectsWhenAccessible()
+	{
+		var gameworld = CreateGameworld();
+		var detonatable = new Mock<IDetonatable>();
+		var item = CreateExplosiveItem(gameworld.Object, detonatable.Object);
+		var sourceItem = CreateSignalSourceItem(gameworld.Object, 8101L, 9101L, out var source);
+		var replacementItem = CreateSignalSourceItem(gameworld.Object, 8102L, 9102L, out var replacement);
+		var connectedItems = new List<IGameItem> { sourceItem.Object };
+		var sourceConnections = new List<IGameItem> { item.Object };
+		item.Setup(x => x.AttachedAndConnectedItems).Returns(connectedItems);
+		sourceItem.Setup(x => x.AttachedAndConnectedItems).Returns(sourceConnections);
+		replacementItem.Setup(x => x.AttachedAndConnectedItems).Returns(Array.Empty<IGameItem>());
+		gameworld.Setup(x => x.TryGetItem(8101L, true)).Returns(sourceItem.Object);
+		gameworld.Setup(x => x.TryGetItem(8102L, true)).Returns(replacementItem.Object);
+
+		var trigger = new SignalDetonatorGameItemComponent(
+			CreateSignalPrototype(gameworld.Object, ExplosiveSignalActivationMode.Edge, false), item.Object, true);
+		var binding = SignalComponentUtilities.CreateBinding(source.Object, "signal");
+		Assert.AreEqual(8101L, binding.SourceItemId);
+		Assert.AreEqual(9101L, binding.SourceComponentId);
+		Assert.AreEqual("signal", binding.SourceEndpointKey);
+		Assert.IsTrue(SignalComponentUtilities.ItemsAreSignalAccessible(item.Object, sourceItem.Object));
+		Assert.AreSame(source.Object, SignalComponentUtilities.FindSignalSource(item.Object, binding));
+		Assert.IsTrue(trigger.ConfigureSignalBinding(source.Object, "signal", out _));
+		Assert.IsTrue(trigger.Arm(CreateActor().Object, string.Empty, Mock.Of<IEmote>()));
+		Assert.IsNotNull(trigger.UpstreamSource);
+
+		connectedItems.Clear();
+		connectedItems.Add(replacementItem.Object);
+		sourceConnections.Clear();
+		replacementItem.Setup(x => x.AttachedAndConnectedItems).Returns(() => new[] { item.Object });
+		source.Raise(x => x.SignalChanged += null, source.Object, new ComputerSignal(1.0, null, null));
+
+		Assert.IsNull(trigger.UpstreamSource);
+		replacement.Raise(x => x.SignalChanged += null, replacement.Object,
+			new ComputerSignal(1.0, null, null));
+		detonatable.Verify(x => x.Detonate(), Times.Never);
+
+		connectedItems.Clear();
+		connectedItems.Add(sourceItem.Object);
+		sourceConnections.Add(item.Object);
+		sourceItem.Raise(x => x.OnLocationChanged += null!, sourceItem.Object, Mock.Of<ICellExit>());
+
+		Assert.AreSame(source.Object, trigger.UpstreamSource);
+		source.Raise(x => x.SignalChanged += null, source.Object, new ComputerSignal(1.0, null, null));
+		detonatable.Verify(x => x.Detonate(), Times.Once);
+	}
+
+	[TestMethod]
+	public void ExplosiveTriggerDescriptions_ReportOperationalFacts()
+	{
+		var gameworld = CreateGameworld();
+		var item = CreateExplosiveItem(gameworld.Object, Mock.Of<IDetonatable>());
+		var voyeur = CreateActor();
+		var radio = new RadioDetonatorGameItemComponent(CreateRadioPrototype(gameworld.Object), item.Object, true)
+		{
+			SwitchedOn = true
+		};
+		var countdown = new CountdownDetonatorGameItemComponent(CreateCountdownPrototype(gameworld.Object), item.Object,
+			true);
+		var signal = new SignalDetonatorGameItemComponent(
+			CreateSignalPrototype(gameworld.Object, ExplosiveSignalActivationMode.Edge, false), item.Object, true);
+
+		var radioFull = radio.Decorate(voyeur.Object, string.Empty, "a bomb", DescriptionType.Full, true,
+			PerceiveIgnoreFlags.None);
+		StringAssert.Contains(radioFull, "armed");
+		StringAssert.Contains(radioFull, "unpowered");
+		Assert.IsFalse(radioFull.Contains("currently disarmed", StringComparison.Ordinal));
+		StringAssert.Contains(countdown.Decorate(voyeur.Object, string.Empty, "a bomb", DescriptionType.Evaluate,
+			true, PerceiveIgnoreFlags.None), "permitted range");
+		var signalEvaluation = signal.Decorate(voyeur.Object, string.Empty, "a bomb", DescriptionType.Evaluate, true,
+			PerceiveIgnoreFlags.None);
+		StringAssert.Contains(signalEvaluation, "at or above");
+		StringAssert.Contains(signalEvaluation, "does not require electrical power");
+		StringAssert.Contains(signalEvaluation, "can be disarmed");
+	}
+
+	[TestMethod]
+	public void TriggerPrototypes_RejectUnrepresentableRealTimeDelays()
+	{
+		var gameworld = CreateGameworld();
+		var unsafeSeconds = TimeSpan.FromDays(4_000_000).TotalSeconds;
+		var countdown = CreatePrototype<CountdownDetonatorGameItemComponentProto>(gameworld.Object, 7201L,
+			new XElement("Definition",
+				new XElement("DefaultDelaySeconds", 10.0),
+				new XElement("MinimumDelaySeconds", 1.0),
+				new XElement("MaximumDelaySeconds", unsafeSeconds),
+				new XElement("PlayersCanSetDelay", true),
+				new XElement("CanBeDisarmed", true),
+				new XElement("ArmEmote", new XCData("@ arm|arms $1")),
+				new XElement("DisarmEmote", new XCData("@ disarm|disarms $1"))));
+		var pinPull = CreatePrototype<PinPullDetonatorGameItemComponentProto>(gameworld.Object, 7202L,
+			new XElement("Definition",
+				new XElement("DelaySeconds", unsafeSeconds),
+				new XElement("PullPinEmote", new XCData("@ pull|pulls the pin from $1"))));
+
+		Assert.IsFalse(countdown.CanSubmit());
+		Assert.IsFalse(pinPull.CanSubmit());
+		StringAssert.Contains(countdown.WhyCannotSubmit(), "too long");
+		StringAssert.Contains(pinPull.WhyCannotSubmit(), "too long");
+	}
+
+	[TestMethod]
+	public void TriggerPrototypes_RequireDetonatableSibling()
+	{
+		var gameworld = CreateGameworld();
+		var prototypes = new IGameItemComponentPrototypeRequirementProvider[]
+		{
+			CreateCountdownPrototype(gameworld.Object),
+			CreatePinPullPrototype(gameworld.Object),
+			CreateSignalPrototype(gameworld.Object, ExplosiveSignalActivationMode.Edge, false),
+			CreateRadioPrototype(gameworld.Object)
+		};
+
+		foreach (var prototype in prototypes)
+		{
+			CollectionAssert.AreEqual(new[] { typeof(IDetonatable) },
+				prototype.RequiredSiblingComponents.Select(x => x.Capability).ToArray());
+		}
+	}
+
+	[TestMethod]
+	public void TriggerPrototypeMarkers_ClassifyArmableAndPinPullRoles()
+	{
+		Assert.IsTrue(typeof(IArmableExplosiveTriggerPrototype)
+			.IsAssignableFrom(typeof(CountdownDetonatorGameItemComponentProto)));
+		Assert.IsTrue(typeof(IArmableExplosiveTriggerPrototype)
+			.IsAssignableFrom(typeof(ClockDetonatorGameItemComponentProto)));
+		Assert.IsTrue(typeof(IArmableExplosiveTriggerPrototype)
+			.IsAssignableFrom(typeof(SignalDetonatorGameItemComponentProto)));
+		Assert.IsTrue(typeof(IArmableExplosiveTriggerPrototype)
+			.IsAssignableFrom(typeof(RadioDetonatorGameItemComponentProto)));
+		Assert.IsTrue(typeof(IPinPullExplosiveTriggerPrototype)
+			.IsAssignableFrom(typeof(PinPullDetonatorGameItemComponentProto)));
+		Assert.IsTrue(typeof(IGameItemComponentPrototypeRequirementProvider)
+			.IsAssignableFrom(typeof(ClockDetonatorGameItemComponentProto)));
+	}
+
+	private static (SignalDetonatorGameItemComponent Trigger, Mock<IDetonatable> Detonatable,
+		Mock<ICharacter> Actor) CreateSignalDetonator(ExplosiveSignalActivationMode mode, bool requiresPower)
+	{
+		var gameworld = CreateGameworld();
+		var detonatable = new Mock<IDetonatable>();
+		var item = CreateExplosiveItem(gameworld.Object, detonatable.Object);
+		var trigger = new SignalDetonatorGameItemComponent(
+			CreateSignalPrototype(gameworld.Object, mode, requiresPower), item.Object, true);
+		return (trigger, detonatable, CreateActor());
+	}
+
+	private static Mock<IFuturemud> CreateGameworld()
+	{
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.HeartbeatManager).Returns(Mock.Of<IHeartbeatManager>());
+		gameworld.SetupGet(x => x.SaveManager).Returns(Mock.Of<ISaveManager>());
+		return gameworld;
+	}
+
+	private static Mock<IGameItem> CreateExplosiveItem(IFuturemud gameworld, IDetonatable detonatable)
+	{
+		var item = new Mock<IGameItem>();
+		item.SetupGet(x => x.Id).Returns(100L);
+		item.SetupGet(x => x.Name).Returns("test bomb");
+		item.SetupGet(x => x.Gameworld).Returns(gameworld);
+		item.Setup(x => x.IsItemType<IDetonatable>()).Returns(true);
+		item.Setup(x => x.GetItemType<IDetonatable>()).Returns(detonatable);
+		item.Setup(x => x.GetItemTypes<IProducePower>()).Returns(Array.Empty<IProducePower>());
+		item.SetupGet(x => x.AttachedAndConnectedItems).Returns(Array.Empty<IGameItem>());
+		item.SetupGet(x => x.TrueLocations).Returns(Array.Empty<ICell>());
+		item.Setup(x => x.HowSeen(It.IsAny<IPerceiver>(), It.IsAny<bool>(), It.IsAny<DescriptionType>(),
+			It.IsAny<bool>(), It.IsAny<PerceiveIgnoreFlags>())).Returns("a test bomb");
+		return item;
+	}
+
+	private static Mock<IGameItem> CreateSignalSourceItem(IFuturemud gameworld, long itemId, long componentId,
+		out Mock<ISignalSourceComponent> source)
+	{
+		var item = new Mock<IGameItem>();
+		item.SetupGet(x => x.Id).Returns(itemId);
+		item.SetupGet(x => x.Name).Returns($"source {itemId}");
+		item.SetupGet(x => x.Gameworld).Returns(gameworld);
+		item.SetupGet(x => x.TrueLocations).Returns(Array.Empty<ICell>());
+		var localSource = new Mock<ISignalSourceComponent>();
+		localSource.SetupGet(x => x.Id).Returns(componentId);
+		localSource.SetupGet(x => x.Parent).Returns(item.Object);
+		localSource.SetupGet(x => x.LocalSignalSourceIdentifier).Returns(42L);
+		localSource.SetupGet(x => x.CurrentSignal).Returns(default(ComputerSignal));
+		localSource.As<IFrameworkItem>().SetupGet(x => x.Name).Returns("controller");
+		localSource.As<ISignalSource>().SetupGet(x => x.Name).Returns("controller");
+		localSource.As<ISignalSource>().SetupGet(x => x.EndpointKey).Returns("signal");
+		item.Setup(x => x.GetItemTypes<ISignalSourceComponent>()).Returns(() => new[] { localSource.Object });
+		source = localSource;
+		return item;
+	}
+
+	private static Mock<ICharacter> CreateActor()
+	{
+		var actor = new Mock<ICharacter>();
+		actor.SetupGet(x => x.OutputHandler).Returns(Mock.Of<IOutputHandler>());
+		return actor;
+	}
+
+	private static string SaveDefinition(IGameItemComponent component)
+	{
+		return (string)component.GetType()
+			.GetMethod("SaveToXml", BindingFlags.Instance | BindingFlags.NonPublic)!
+			.Invoke(component, null)!;
+	}
+
+	private static CountdownDetonatorGameItemComponentProto CreateCountdownPrototype(IFuturemud gameworld)
+	{
+		return CreatePrototype<CountdownDetonatorGameItemComponentProto>(gameworld, 7001L,
+			new XElement("Definition",
+				new XElement("DefaultDelaySeconds", 10.0),
+				new XElement("MinimumDelaySeconds", 1.0),
+				new XElement("MaximumDelaySeconds", 86400.0),
+				new XElement("PlayersCanSetDelay", true),
+				new XElement("CanBeDisarmed", true),
+				new XElement("ArmEmote", new XCData("@ arm|arms $1")),
+				new XElement("DisarmEmote", new XCData("@ disarm|disarms $1"))));
+	}
+
+	private static PinPullDetonatorGameItemComponentProto CreatePinPullPrototype(IFuturemud gameworld)
+	{
+		return CreatePrototype<PinPullDetonatorGameItemComponentProto>(gameworld, 7002L,
+			new XElement("Definition",
+				new XElement("DelaySeconds", 5.0),
+				new XElement("PullPinEmote", new XCData("@ pull|pulls the pin from $1"))));
+	}
+
+	private static SignalDetonatorGameItemComponentProto CreateSignalPrototype(IFuturemud gameworld,
+		ExplosiveSignalActivationMode mode, bool requiresPower)
+	{
+		return CreatePrototype<SignalDetonatorGameItemComponentProto>(gameworld, 7003L,
+			new XElement("Definition",
+				new XElement("SourceComponentId", 42L),
+				new XElement("SourceComponentName", new XCData("controller")),
+				new XElement("SourceEndpointKey", new XCData("signal")),
+				new XElement("ActivationThreshold", 0.5),
+				new XElement("ActiveWhenAboveThreshold", true),
+				new XElement("ActivationMode", mode),
+				new XElement("RequiresPower", requiresPower),
+				new XElement("PowerConsumptionInWatts", 0.1),
+				new XElement("CanBeDisarmed", true),
+				new XElement("ArmEmote", new XCData("@ arm|arms $1")),
+				new XElement("DisarmEmote", new XCData("@ disarm|disarms $1"))));
+	}
+
+	private static RadioDetonatorGameItemComponentProto CreateRadioPrototype(IFuturemud gameworld)
+	{
+		return CreatePrototype<RadioDetonatorGameItemComponentProto>(gameworld, 7004L,
+			new XElement("Definition",
+				new XElement("PowerConsumptionInWatts", 0.1),
+				new XElement("OnPowerOnEmote", new XCData("@ light|lights")),
+				new XElement("OnPowerOffEmote", new XCData("@ darken|darkens"))));
+	}
+
+	private static T CreatePrototype<T>(IFuturemud gameworld, long id, XElement definition)
+		where T : IGameItemComponentProto
+	{
+		return (T)typeof(T)
+			.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, null,
+				[typeof(MudSharp.Models.GameItemComponentProto), typeof(IFuturemud)], null)!
+			.Invoke([
+				new MudSharp.Models.GameItemComponentProto
+				{
+					Id = id,
+					Name = typeof(T).Name,
+					Description = "Test",
+					RevisionNumber = 1,
+					Definition = definition.ToString(),
+					EditableItem = new MudSharp.Models.EditableItem
+					{
+						RevisionStatus = (int)RevisionStatus.Current,
+						RevisionNumber = 1
+					}
+				},
+				gameworld
+			]);
+	}
+}

--- a/MudSharpCore/Commands/Modules/ManipulationModule.cs
+++ b/MudSharpCore/Commands/Modules/ManipulationModule.cs
@@ -7218,6 +7218,193 @@ The syntax is:
         selectable.Select(actor, argumentText, emote);
     }
 
+	[PlayerCommand("Arm", "arm")]
+	[RequiredCharacterState(CharacterState.Able)]
+	[HelpInfo("arm", @"The #3arm#0 command arms an explosive trigger. Countdown triggers accept a duration, clock triggers accept an exact in-game date and time, and signal triggers need no additional argument.
+
+The syntax is:
+
+	#3arm <item> [<duration|in-game datetime>] [(<emote>)]#0", AutoHelp.HelpArgOrNoArg)]
+	protected static void Arm(ICharacter actor, string command)
+	{
+		var ss = new StringStack(command.RemoveFirstWord());
+		if (ss.IsFinished)
+		{
+			actor.Send("What explosive item do you want to arm?");
+			return;
+		}
+
+		var target = actor.TargetItem(ss.PopSpeech());
+		if (target is null)
+		{
+			actor.Send("You do not see any such explosive item to arm.");
+			return;
+		}
+
+		var trigger = target.GetItemType<IArmableExplosiveTrigger>();
+		if (trigger is null)
+		{
+			actor.Send($"{target.HowSeen(actor, true)} does not have an armable explosive trigger.");
+			return;
+		}
+
+		var (truth, error) = actor.CanManipulateItem(target);
+		if (!truth)
+		{
+			actor.Send(error);
+			return;
+		}
+
+		var match = ArgumentsAndEmoteRegex.Match(ss.SafeRemainingArgument ?? string.Empty);
+		var argument = match.Success ? match.Groups["arguments"].Value.Trim() : ss.SafeRemainingArgument;
+		PlayerEmote? emote = null;
+		if (match.Success && match.Groups["emote"].Success)
+		{
+			emote = new PlayerEmote(match.Groups["emote"].Value, actor);
+			if (!emote.Valid)
+			{
+				actor.Send(emote.ErrorMessage);
+				return;
+			}
+		}
+
+		if (!trigger.CanArm(actor, argument))
+		{
+			actor.Send(trigger.WhyCannotArm(actor, argument));
+			return;
+		}
+
+		trigger.Arm(actor, argument, emote);
+	}
+
+	[PlayerCommand("Disarm", "disarm")]
+	[RequiredCharacterState(CharacterState.Able)]
+	[HelpInfo("disarm", @"The #3disarm#0 command stops an armed explosive trigger when its design permits disarming.
+
+The syntax is:
+
+	#3disarm <item> [(<emote>)]#0", AutoHelp.HelpArgOrNoArg)]
+	protected static void Disarm(ICharacter actor, string command)
+	{
+		var ss = new StringStack(command.RemoveFirstWord());
+		if (ss.IsFinished)
+		{
+			actor.Send("What explosive item do you want to disarm?");
+			return;
+		}
+
+		var target = actor.TargetItem(ss.PopSpeech());
+		if (target is null)
+		{
+			actor.Send("You do not see any such explosive item to disarm.");
+			return;
+		}
+
+		var trigger = target.GetItemType<IArmableExplosiveTrigger>();
+		if (trigger is null)
+		{
+			actor.Send($"{target.HowSeen(actor, true)} does not have an armable explosive trigger.");
+			return;
+		}
+
+		var (truth, error) = actor.CanManipulateItem(target);
+		if (!truth)
+		{
+			actor.Send(error);
+			return;
+		}
+
+		PlayerEmote? emote = null;
+		var emoteText = ss.PopParentheses();
+		if (!string.IsNullOrWhiteSpace(emoteText))
+		{
+			emote = new PlayerEmote(emoteText, actor);
+			if (!emote.Valid)
+			{
+				actor.Send(emote.ErrorMessage);
+				return;
+			}
+		}
+
+		if (!ss.IsFinished)
+		{
+			actor.Send("The disarm command takes only an item and an optional parenthesised emote.");
+			return;
+		}
+
+		if (!trigger.CanDisarm(actor))
+		{
+			actor.Send(trigger.WhyCannotDisarm(actor));
+			return;
+		}
+
+		trigger.Disarm(actor, emote);
+	}
+
+	[PlayerCommand("PullPin", "pullpin", "pinpull")]
+	[RequiredCharacterState(CharacterState.Able)]
+	[HelpInfo("pullpin", @"The #3pullpin#0 command irreversibly starts the countdown on a pin-pull explosive trigger.
+
+The syntax is:
+
+	#3pullpin <item> [(<emote>)]#0", AutoHelp.HelpArgOrNoArg)]
+	protected static void PullPin(ICharacter actor, string command)
+	{
+		var ss = new StringStack(command.RemoveFirstWord());
+		if (ss.IsFinished)
+		{
+			actor.Send("What explosive item do you want to pull the pin from?");
+			return;
+		}
+
+		var target = actor.TargetItem(ss.PopSpeech());
+		if (target is null)
+		{
+			actor.Send("You do not see any such explosive item here.");
+			return;
+		}
+
+		var trigger = target.GetItemType<IPinPullExplosiveTrigger>();
+		if (trigger is null)
+		{
+			actor.Send($"{target.HowSeen(actor, true)} does not have a pin-pull explosive trigger.");
+			return;
+		}
+
+		var (truth, error) = actor.CanManipulateItem(target);
+		if (!truth)
+		{
+			actor.Send(error);
+			return;
+		}
+
+		PlayerEmote? emote = null;
+		var emoteText = ss.PopParentheses();
+		if (!string.IsNullOrWhiteSpace(emoteText))
+		{
+			emote = new PlayerEmote(emoteText, actor);
+			if (!emote.Valid)
+			{
+				actor.Send(emote.ErrorMessage);
+				return;
+			}
+		}
+
+		if (!ss.IsFinished)
+		{
+			actor.Send("The pullpin command takes only an item and an optional parenthesised emote.");
+			return;
+		}
+
+		if (!trigger.CanPullPin(actor))
+		{
+			actor.Send(trigger.WhyCannotPullPin(actor));
+			return;
+		}
+
+		trigger.PullPin(actor, emote);
+	}
+
     [PlayerCommand("Insert", "insert")]
     [RequiredCharacterState(CharacterState.Able)]
     [HelpInfo("insert", @"The #3insert#0 command places a held insertable item into a nearby compatible receptacle. If there is exactly one suitable nearby receptacle, you may omit it. You can attach a parenthesised emote.

--- a/MudSharpCore/GameItems/Components/ClockDetonatorGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/ClockDetonatorGameItemComponent.cs
@@ -1,0 +1,308 @@
+#nullable enable
+
+using MudSharp.GameItems.Prototypes;
+using MudSharp.TimeAndDate;
+using MudSharp.TimeAndDate.Date;
+using MudSharp.TimeAndDate.Time;
+
+namespace MudSharp.GameItems.Components;
+
+internal static class ClockDetonatorScheduleEvaluator
+{
+	internal static bool IsDue(MudInstant target, MudInstant current)
+	{
+		return current >= target;
+	}
+
+	internal static bool CanRetainArmedTarget(long oldCalendarId, long oldClockId, long newCalendarId,
+		long newClockId)
+	{
+		return oldCalendarId == newCalendarId && oldClockId == newClockId;
+	}
+}
+
+public class ClockDetonatorGameItemComponent : GameItemComponent, IArmableExplosiveTrigger
+{
+	private ClockDetonatorGameItemComponentProto _prototype;
+	private MudInstant? _targetInstant;
+	private bool _clockSubscribed;
+	private bool _runtimeActive;
+
+	public ClockDetonatorGameItemComponent(ClockDetonatorGameItemComponentProto proto, IGameItem parent,
+		bool temporary = false)
+		: base(parent, proto, temporary)
+	{
+		_prototype = proto;
+	}
+
+	public ClockDetonatorGameItemComponent(MudSharp.Models.GameItemComponent component,
+		ClockDetonatorGameItemComponentProto proto, IGameItem parent)
+		: base(component, parent)
+	{
+		_prototype = proto;
+		_noSave = true;
+		LoadFromXml(XElement.Parse(component.Definition));
+		_noSave = false;
+	}
+
+	public ClockDetonatorGameItemComponent(ClockDetonatorGameItemComponent rhs, IGameItem newParent,
+		bool temporary = false)
+		: base(rhs, newParent, temporary)
+	{
+		_prototype = rhs._prototype;
+		_targetInstant = rhs._targetInstant;
+	}
+
+	public override IGameItemComponentProto Prototype => _prototype;
+	public bool Armed => _targetInstant is { IsNever: false };
+
+	protected override void UpdateComponentNewPrototype(IGameItemComponentProto newProto)
+	{
+		RemoveClockSubscription();
+		var newClockPrototype = (ClockDetonatorGameItemComponentProto)newProto;
+		if (Armed && !ClockDetonatorScheduleEvaluator.CanRetainArmedTarget(
+			    _prototype.Calendar.Id, _prototype.Clock.Id, newClockPrototype.Calendar.Id,
+			    newClockPrototype.Clock.Id))
+		{
+			// The stored MudInstant was authored against the old clock. Raw ticks from different
+			// clocks are not safely comparable, so an incompatible component update fails safe.
+			_targetInstant = null;
+			Changed = true;
+		}
+
+		_prototype = newClockPrototype;
+		if (_runtimeActive && Armed)
+		{
+			EnsureClockSubscription();
+			CheckTargetTime();
+		}
+	}
+
+	public override IGameItemComponent Copy(IGameItem newParent, bool temporary = false)
+	{
+		return new ClockDetonatorGameItemComponent(this, newParent, temporary);
+	}
+
+	private void LoadFromXml(XElement root)
+	{
+		if (MudInstant.TryParse(root.Element("TargetInstant")?.Value, out var instant) && !instant.IsNever)
+		{
+			_targetInstant = instant;
+		}
+	}
+
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition",
+			new XElement("TargetInstant", _targetInstant?.GetStorageString() ?? MudInstant.Never.GetStorageString()))
+			.ToString();
+	}
+
+	public override void Login()
+	{
+		_runtimeActive = true;
+		base.Login();
+		if (!Armed)
+		{
+			return;
+		}
+
+		EnsureClockSubscription();
+		CheckTargetTime();
+	}
+
+	public override void Quit()
+	{
+		_runtimeActive = false;
+		RemoveClockSubscription();
+		base.Quit();
+	}
+
+	public override void Delete()
+	{
+		_runtimeActive = false;
+		RemoveClockSubscription();
+		base.Delete();
+	}
+
+	public bool CanArm(ICharacter actor, string argument)
+	{
+		return !Armed && Parent.IsItemType<IDetonatable>() && TryParseTarget(actor, argument, out _, out _);
+	}
+
+	public string WhyCannotArm(ICharacter actor, string argument)
+	{
+		if (Armed)
+		{
+			return $"{Parent.HowSeen(actor, true)} is already armed for {DescribeTarget(actor)}.";
+		}
+
+		if (!Parent.IsItemType<IDetonatable>())
+		{
+			return $"{Parent.HowSeen(actor, true)} has no explosive payload to detonate.";
+		}
+
+		return TryParseTarget(actor, argument, out _, out var error)
+			? $"{Parent.HowSeen(actor, true)} cannot be armed at this time."
+			: error;
+	}
+
+	public bool Arm(ICharacter actor, string argument, IEmote? playerEmote = null)
+	{
+		if (!CanArm(actor, argument))
+		{
+			actor.Send(WhyCannotArm(actor, argument));
+			return false;
+		}
+
+		TryParseTarget(actor, argument, out var target, out _);
+		_targetInstant = target;
+		Changed = true;
+		actor.OutputHandler.Handle(
+			new MixedEmoteOutput(new Emote(_prototype.ArmEmote, actor, actor, Parent)).Append(playerEmote));
+		if (_runtimeActive)
+		{
+			EnsureClockSubscription();
+			CheckTargetTime();
+		}
+		return true;
+	}
+
+	public bool CanDisarm(ICharacter actor)
+	{
+		return Armed && _prototype.CanBeDisarmed;
+	}
+
+	public string WhyCannotDisarm(ICharacter actor)
+	{
+		if (!Armed)
+		{
+			return $"{Parent.HowSeen(actor, true)} is not armed.";
+		}
+
+		return _prototype.CanBeDisarmed
+			? $"{Parent.HowSeen(actor, true)} cannot be disarmed at this time."
+			: $"Once armed, {Parent.HowSeen(actor)} has an irreversible clock trigger.";
+	}
+
+	public bool Disarm(ICharacter actor, IEmote? playerEmote = null)
+	{
+		if (!CanDisarm(actor))
+		{
+			actor.Send(WhyCannotDisarm(actor));
+			return false;
+		}
+
+		actor.OutputHandler.Handle(
+			new MixedEmoteOutput(new Emote(_prototype.DisarmEmote, actor, actor, Parent)).Append(playerEmote));
+		_targetInstant = null;
+		Changed = true;
+		RemoveClockSubscription();
+		return true;
+	}
+
+	private bool TryParseTarget(ICharacter actor, string argument, out MudInstant instant, out string error)
+	{
+		instant = MudInstant.Never;
+		error = string.Empty;
+		if (string.IsNullOrWhiteSpace(argument))
+		{
+			error = "You must specify the exact in-game date and time at which this detonator should fire.";
+			return false;
+		}
+
+		var localTargetText = $"{argument} {_prototype.TimeZone.Alias}";
+		if (!MudDateTime.TryParse(localTargetText, _prototype.Calendar, _prototype.Clock, actor, out var dateTime,
+			    out error))
+		{
+			return false;
+		}
+
+		instant = MudInstant.FromMudDateTime(dateTime);
+		if (instant.IsNever || instant <= _prototype.Calendar.CurrentInstant)
+		{
+			error = "The detonation time must be in the future.";
+			return false;
+		}
+
+		return true;
+	}
+
+	private void EnsureClockSubscription()
+	{
+		if (_clockSubscribed || !Armed)
+		{
+			return;
+		}
+
+		_prototype.Clock.SecondsUpdated += CheckTargetTime;
+		_clockSubscribed = true;
+	}
+
+	private void RemoveClockSubscription()
+	{
+		if (!_clockSubscribed)
+		{
+			return;
+		}
+
+		_prototype.Clock.SecondsUpdated -= CheckTargetTime;
+		_clockSubscribed = false;
+	}
+
+	private void CheckTargetTime()
+	{
+		if (_targetInstant is not { } target ||
+		    !ClockDetonatorScheduleEvaluator.IsDue(target, _prototype.Calendar.CurrentInstant))
+		{
+			return;
+		}
+
+		_targetInstant = null;
+		Changed = true;
+		RemoveClockSubscription();
+		Parent.GetItemType<IDetonatable>()?.Detonate();
+	}
+
+	private string DescribeTarget(IFormatProvider voyeur)
+	{
+		if (_targetInstant is not { } target)
+		{
+			return "no target time";
+		}
+
+		var dateTime = target.ToMudDateTime(_prototype.Calendar, _prototype.Clock, _prototype.TimeZone);
+		return dateTime.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue();
+	}
+
+	public override bool DescriptionDecorator(DescriptionType type)
+	{
+		return type is DescriptionType.Short or DescriptionType.Full or DescriptionType.Evaluate;
+	}
+
+	public override string Decorate(IPerceiver voyeur, string name, string description, DescriptionType type,
+		bool colour, PerceiveIgnoreFlags flags)
+	{
+		if (type == DescriptionType.Short && Armed)
+		{
+			return $"{description} {"(armed)".Colour(Telnet.BoldRed)}";
+		}
+
+		if (type == DescriptionType.Full)
+		{
+			return Armed
+				? $"{description}\n\nIts clock detonator is armed for {DescribeTarget(voyeur)}."
+				: $"{description}\n\nIts clock detonator is currently disarmed.";
+		}
+
+		if (type == DescriptionType.Evaluate)
+		{
+			return
+				$"It has a clock detonator using {_prototype.Calendar.FullName.ColourName()}, {_prototype.Clock.Name.ColourName()}, and {_prototype.TimeZone.Alias.ColourValue()}. It {(_prototype.CanBeDisarmed ? "can" : "cannot")} be disarmed after arming.";
+		}
+
+		return description;
+	}
+
+	public override int DecorationPriority => int.MaxValue - 1;
+}

--- a/MudSharpCore/GameItems/Components/CountdownDetonatorGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/CountdownDetonatorGameItemComponent.cs
@@ -1,0 +1,204 @@
+#nullable enable
+
+using MudSharp.GameItems.Prototypes;
+
+namespace MudSharp.GameItems.Components;
+
+public class CountdownDetonatorGameItemComponent : DeadlineExplosiveTriggerGameItemComponent,
+	IArmableExplosiveTrigger
+{
+	private CountdownDetonatorGameItemComponentProto _prototype;
+
+	public CountdownDetonatorGameItemComponent(CountdownDetonatorGameItemComponentProto proto, IGameItem parent,
+		bool temporary = false)
+		: base(parent, proto, temporary)
+	{
+		_prototype = proto;
+	}
+
+	public CountdownDetonatorGameItemComponent(MudSharp.Models.GameItemComponent component,
+		CountdownDetonatorGameItemComponentProto proto, IGameItem parent)
+		: base(component, parent)
+	{
+		_prototype = proto;
+		_noSave = true;
+		LoadDeadline(XElement.Parse(component.Definition));
+		_noSave = false;
+	}
+
+	public CountdownDetonatorGameItemComponent(CountdownDetonatorGameItemComponent rhs, IGameItem newParent,
+		bool temporary = false)
+		: base(rhs, newParent, temporary)
+	{
+		_prototype = rhs._prototype;
+	}
+
+	public override IGameItemComponentProto Prototype => _prototype;
+	public bool Armed => HasActiveDeadline;
+
+	protected override void UpdateComponentNewPrototype(IGameItemComponentProto newProto)
+	{
+		_prototype = (CountdownDetonatorGameItemComponentProto)newProto;
+	}
+
+	public override IGameItemComponent Copy(IGameItem newParent, bool temporary = false)
+	{
+		return new CountdownDetonatorGameItemComponent(this, newParent, temporary);
+	}
+
+	protected override string SaveToXml()
+	{
+		var root = new XElement("Definition");
+		SaveDeadline(root);
+		return root.ToString();
+	}
+
+	public bool CanArm(ICharacter actor, string argument)
+	{
+		return !Armed &&
+		       Parent.IsItemType<IDetonatable>() &&
+		       TryResolveDelay(actor, argument, out _, out _);
+	}
+
+	public string WhyCannotArm(ICharacter actor, string argument)
+	{
+		if (Armed)
+		{
+			return $"{Parent.HowSeen(actor, true)} is already armed.";
+		}
+
+		if (!Parent.IsItemType<IDetonatable>())
+		{
+			return $"{Parent.HowSeen(actor, true)} has no explosive payload to detonate.";
+		}
+
+		return TryResolveDelay(actor, argument, out _, out var error)
+			? $"{Parent.HowSeen(actor, true)} cannot be armed at this time."
+			: error;
+	}
+
+	public bool Arm(ICharacter actor, string argument, IEmote? playerEmote = null)
+	{
+		if (!CanArm(actor, argument))
+		{
+			actor.Send(WhyCannotArm(actor, argument));
+			return false;
+		}
+
+		TryResolveDelay(actor, argument, out var delay, out _);
+		if (!ExplosiveDeadlineScheduler.TryGetDeadline(DateTime.UtcNow, delay, out var deadline))
+		{
+			actor.Send("That countdown is too long to schedule safely.");
+			return false;
+		}
+		actor.OutputHandler.Handle(
+			new MixedEmoteOutput(new Emote(_prototype.ArmEmote, actor, actor, Parent)).Append(playerEmote));
+		StartDeadline(deadline);
+		return true;
+	}
+
+	public bool CanDisarm(ICharacter actor)
+	{
+		return Armed && _prototype.CanBeDisarmed;
+	}
+
+	public string WhyCannotDisarm(ICharacter actor)
+	{
+		if (!Armed)
+		{
+			return $"{Parent.HowSeen(actor, true)} is not armed.";
+		}
+
+		return _prototype.CanBeDisarmed
+			? $"{Parent.HowSeen(actor, true)} cannot be disarmed at this time."
+			: $"Once armed, {Parent.HowSeen(actor)} has an irreversible countdown.";
+	}
+
+	public bool Disarm(ICharacter actor, IEmote? playerEmote = null)
+	{
+		if (!CanDisarm(actor))
+		{
+			actor.Send(WhyCannotDisarm(actor));
+			return false;
+		}
+
+		actor.OutputHandler.Handle(
+			new MixedEmoteOutput(new Emote(_prototype.DisarmEmote, actor, actor, Parent)).Append(playerEmote));
+		CancelDeadline();
+		return true;
+	}
+
+	private bool TryResolveDelay(ICharacter actor, string argument, out TimeSpan delay, out string error)
+	{
+		delay = _prototype.DefaultDelay;
+		error = string.Empty;
+		if (!string.IsNullOrWhiteSpace(argument))
+		{
+			if (!_prototype.PlayersCanSetDelay)
+			{
+				error = $"{Parent.HowSeen(actor, true)} has a fixed countdown of {_prototype.DefaultDelay.Describe(actor).ColourValue()}.";
+				return false;
+			}
+
+			if (!TimeSpan.TryParse(argument, actor, out delay))
+			{
+				error = "That is not a valid countdown duration.";
+				return false;
+			}
+		}
+
+		if (delay < _prototype.MinimumDelay || delay > _prototype.MaximumDelay)
+		{
+			error =
+				$"The countdown must be between {_prototype.MinimumDelay.Describe(actor).ColourValue()} and {_prototype.MaximumDelay.Describe(actor).ColourValue()}.";
+			return false;
+		}
+
+		if (!ExplosiveDeadlineScheduler.TryGetDeadline(DateTime.UtcNow, delay, out _))
+		{
+			error = "That countdown is too long to schedule safely.";
+			return false;
+		}
+
+		return true;
+	}
+
+	public override bool DescriptionDecorator(DescriptionType type)
+	{
+		return type is DescriptionType.Short or DescriptionType.Full or DescriptionType.Evaluate;
+	}
+
+	public override string Decorate(IPerceiver voyeur, string name, string description, DescriptionType type,
+		bool colour, PerceiveIgnoreFlags flags)
+	{
+		if (type == DescriptionType.Short && Armed)
+		{
+			return $"{description} {"(armed)".Colour(Telnet.BoldRed)}";
+		}
+
+		if (type == DescriptionType.Full)
+		{
+			return Armed
+				? $"{description}\n\nIts countdown detonator is armed with {DescribeRemaining(voyeur)} remaining."
+				: $"{description}\n\nIts countdown detonator is currently disarmed.";
+		}
+
+		if (type == DescriptionType.Evaluate)
+		{
+			return
+				$"It has a countdown detonator with a default delay of {_prototype.DefaultDelay.Describe(voyeur).ColourValue()} and a permitted range of {_prototype.MinimumDelay.Describe(voyeur).ColourValue()} to {_prototype.MaximumDelay.Describe(voyeur).ColourValue()}. Players {(_prototype.PlayersCanSetDelay ? "can" : "cannot")} choose the delay. It {(_prototype.CanBeDisarmed ? "can" : "cannot")} be disarmed after arming.";
+		}
+
+		return description;
+	}
+
+	private string DescribeRemaining(IPerceiver voyeur)
+	{
+		var remaining = RemainingDuration();
+		return remaining > TimeSpan.Zero
+			? remaining.Describe(voyeur).Colour(Telnet.BoldRed)
+			: "less than a second".Colour(Telnet.BoldRed);
+	}
+
+	public override int DecorationPriority => int.MaxValue - 1;
+}

--- a/MudSharpCore/GameItems/Components/DeadlineExplosiveTriggerGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/DeadlineExplosiveTriggerGameItemComponent.cs
@@ -1,0 +1,153 @@
+#nullable enable
+
+namespace MudSharp.GameItems.Components;
+
+internal static class ExplosiveDeadlineScheduler
+{
+	internal static bool IsDue(DateTime deadlineUtc, DateTime nowUtc)
+	{
+		return nowUtc >= deadlineUtc;
+	}
+
+	internal static bool TryGetDeadline(DateTime nowUtc, TimeSpan delay, out DateTime deadlineUtc)
+	{
+		deadlineUtc = default;
+		if (delay <= TimeSpan.Zero)
+		{
+			return false;
+		}
+
+		var utcNow = nowUtc.Kind == DateTimeKind.Utc ? nowUtc : nowUtc.ToUniversalTime();
+		if (delay.Ticks > DateTime.MaxValue.Ticks - utcNow.Ticks)
+		{
+			return false;
+		}
+
+		deadlineUtc = new DateTime(utcNow.Ticks + delay.Ticks, DateTimeKind.Utc);
+		return true;
+	}
+}
+
+public abstract class DeadlineExplosiveTriggerGameItemComponent : GameItemComponent
+{
+	private bool _heartbeatSubscribed;
+
+	protected DeadlineExplosiveTriggerGameItemComponent(IGameItem parent, IGameItemComponentProto proto,
+		bool temporary = false)
+		: base(parent, proto, temporary)
+	{
+	}
+
+	protected DeadlineExplosiveTriggerGameItemComponent(MudSharp.Models.GameItemComponent component,
+		IGameItem parent)
+		: base(component, parent)
+	{
+	}
+
+	protected DeadlineExplosiveTriggerGameItemComponent(DeadlineExplosiveTriggerGameItemComponent rhs,
+		IGameItem newParent, bool temporary = false)
+		: base(rhs, newParent, temporary)
+	{
+		DetonationDeadlineUtc = rhs.DetonationDeadlineUtc;
+	}
+
+	protected DateTime? DetonationDeadlineUtc { get; private set; }
+	protected bool HasActiveDeadline => DetonationDeadlineUtc is not null;
+
+	protected void LoadDeadline(XElement root)
+	{
+		if (long.TryParse(root.Element("DetonationDeadlineUtcTicks")?.Value, out var ticks) && ticks > 0 &&
+		    ticks <= DateTime.MaxValue.Ticks)
+		{
+			DetonationDeadlineUtc = new DateTime(ticks, DateTimeKind.Utc);
+		}
+	}
+
+	protected void SaveDeadline(XElement root)
+	{
+		root.Add(new XElement("DetonationDeadlineUtcTicks", DetonationDeadlineUtc?.Ticks ?? 0L));
+	}
+
+	protected void StartDeadline(DateTime deadlineUtc)
+	{
+		DetonationDeadlineUtc = deadlineUtc.Kind == DateTimeKind.Utc
+			? deadlineUtc
+			: deadlineUtc.ToUniversalTime();
+		Changed = true;
+		EnsureHeartbeatSubscription();
+		CheckDeadline();
+	}
+
+	protected void CancelDeadline()
+	{
+		DetonationDeadlineUtc = null;
+		Changed = true;
+		RemoveHeartbeatSubscription();
+	}
+
+	protected TimeSpan RemainingDuration(DateTime? now = null)
+	{
+		return DetonationDeadlineUtc is { } deadline
+			? deadline - (now ?? DateTime.UtcNow)
+			: TimeSpan.Zero;
+	}
+
+	public override void Login()
+	{
+		base.Login();
+		if (!HasActiveDeadline)
+		{
+			return;
+		}
+
+		EnsureHeartbeatSubscription();
+		CheckDeadline();
+	}
+
+	public override void Quit()
+	{
+		RemoveHeartbeatSubscription();
+		base.Quit();
+	}
+
+	public override void Delete()
+	{
+		RemoveHeartbeatSubscription();
+		base.Delete();
+	}
+
+	private void EnsureHeartbeatSubscription()
+	{
+		if (_heartbeatSubscribed || !HasActiveDeadline)
+		{
+			return;
+		}
+
+		Gameworld.HeartbeatManager.SecondHeartbeat += CheckDeadline;
+		_heartbeatSubscribed = true;
+	}
+
+	private void RemoveHeartbeatSubscription()
+	{
+		if (!_heartbeatSubscribed)
+		{
+			return;
+		}
+
+		Gameworld.HeartbeatManager.SecondHeartbeat -= CheckDeadline;
+		_heartbeatSubscribed = false;
+	}
+
+	private void CheckDeadline()
+	{
+		if (DetonationDeadlineUtc is not { } deadline || !ExplosiveDeadlineScheduler.IsDue(deadline, DateTime.UtcNow))
+		{
+			return;
+		}
+
+		DetonationDeadlineUtc = null;
+		Changed = true;
+		RemoveHeartbeatSubscription();
+		Parent.GetItemType<IDetonatable>()?.Detonate();
+	}
+}

--- a/MudSharpCore/GameItems/Components/LocalSignalSinkSubscription.cs
+++ b/MudSharpCore/GameItems/Components/LocalSignalSinkSubscription.cs
@@ -21,23 +21,23 @@ internal sealed class LocalSignalSinkSubscription
 
 	public ISignalSource? UpstreamSource => _source;
 
-	public void Reconnect(LocalSignalBinding binding)
+	public void Reconnect(LocalSignalBinding binding, bool strictSourceItemId = false)
 	{
 		Reconnect(binding.SourceItemId, binding.SourceItemName, binding.SourceComponentId, binding.SourceComponentName,
-			binding.SourceEndpointKey);
+			binding.SourceEndpointKey, strictSourceItemId);
 	}
 
 	public void Reconnect(long sourceIdentifier, string sourceComponentName, string? sourceEndpointKey)
 	{
-		Reconnect(0L, string.Empty, sourceIdentifier, sourceComponentName, sourceEndpointKey);
+		Reconnect(0L, string.Empty, sourceIdentifier, sourceComponentName, sourceEndpointKey, false);
 	}
 
 	public void Reconnect(long sourceItemId, string sourceItemName, long sourceIdentifier, string sourceComponentName,
-		string? sourceEndpointKey)
+		string? sourceEndpointKey, bool strictSourceItemId = false)
 	{
 		Detach();
 		_source = SignalComponentUtilities.FindSignalSource(_parent, sourceItemId, sourceItemName, sourceIdentifier, sourceComponentName,
-			sourceEndpointKey, _owner);
+			sourceEndpointKey, _owner, strictSourceItemId);
 		if (_source is null)
 		{
 			return;

--- a/MudSharpCore/GameItems/Components/PinPullDetonatorGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/PinPullDetonatorGameItemComponent.cs
@@ -1,0 +1,136 @@
+#nullable enable
+
+using MudSharp.GameItems.Prototypes;
+
+namespace MudSharp.GameItems.Components;
+
+public class PinPullDetonatorGameItemComponent : DeadlineExplosiveTriggerGameItemComponent,
+	IPinPullExplosiveTrigger
+{
+	private PinPullDetonatorGameItemComponentProto _prototype;
+
+	public PinPullDetonatorGameItemComponent(PinPullDetonatorGameItemComponentProto proto, IGameItem parent,
+		bool temporary = false)
+		: base(parent, proto, temporary)
+	{
+		_prototype = proto;
+	}
+
+	public PinPullDetonatorGameItemComponent(MudSharp.Models.GameItemComponent component,
+		PinPullDetonatorGameItemComponentProto proto, IGameItem parent)
+		: base(component, parent)
+	{
+		_prototype = proto;
+		_noSave = true;
+		LoadDeadline(XElement.Parse(component.Definition));
+		_noSave = false;
+	}
+
+	public PinPullDetonatorGameItemComponent(PinPullDetonatorGameItemComponent rhs, IGameItem newParent,
+		bool temporary = false)
+		: base(rhs, newParent, temporary)
+	{
+		_prototype = rhs._prototype;
+	}
+
+	public override IGameItemComponentProto Prototype => _prototype;
+	public bool PinPulled => HasActiveDeadline;
+
+	protected override void UpdateComponentNewPrototype(IGameItemComponentProto newProto)
+	{
+		_prototype = (PinPullDetonatorGameItemComponentProto)newProto;
+	}
+
+	public override IGameItemComponent Copy(IGameItem newParent, bool temporary = false)
+	{
+		return new PinPullDetonatorGameItemComponent(this, newParent, temporary);
+	}
+
+	protected override string SaveToXml()
+	{
+		var root = new XElement("Definition");
+		SaveDeadline(root);
+		return root.ToString();
+	}
+
+	public bool CanPullPin(ICharacter actor)
+	{
+		return !PinPulled && Parent.IsItemType<IDetonatable>() &&
+		       ExplosiveDeadlineScheduler.TryGetDeadline(DateTime.UtcNow, _prototype.Delay, out _);
+	}
+
+	public string WhyCannotPullPin(ICharacter actor)
+	{
+		if (PinPulled)
+		{
+			return $"The pin has already been pulled from {Parent.HowSeen(actor)}.";
+		}
+
+		if (!ExplosiveDeadlineScheduler.TryGetDeadline(DateTime.UtcNow, _prototype.Delay, out _))
+		{
+			return $"The configured delay on {Parent.HowSeen(actor)} is too long to schedule safely.";
+		}
+
+		return Parent.IsItemType<IDetonatable>()
+			? $"You cannot pull the pin from {Parent.HowSeen(actor)} at this time."
+			: $"{Parent.HowSeen(actor, true)} has no explosive payload to detonate.";
+	}
+
+	public bool PullPin(ICharacter actor, IEmote? playerEmote = null)
+	{
+		if (!CanPullPin(actor))
+		{
+			actor.Send(WhyCannotPullPin(actor));
+			return false;
+		}
+
+		if (!ExplosiveDeadlineScheduler.TryGetDeadline(DateTime.UtcNow, _prototype.Delay, out var deadline))
+		{
+			actor.Send($"The configured delay on {Parent.HowSeen(actor)} is too long to schedule safely.");
+			return false;
+		}
+
+		actor.OutputHandler.Handle(
+			new MixedEmoteOutput(new Emote(_prototype.PullPinEmote, actor, actor, Parent)).Append(playerEmote));
+		StartDeadline(deadline);
+		return true;
+	}
+
+	public override bool DescriptionDecorator(DescriptionType type)
+	{
+		return type is DescriptionType.Short or DescriptionType.Full or DescriptionType.Evaluate;
+	}
+
+	public override string Decorate(IPerceiver voyeur, string name, string description, DescriptionType type,
+		bool colour, PerceiveIgnoreFlags flags)
+	{
+		if (type == DescriptionType.Short && PinPulled)
+		{
+			return $"{description} {"(pin pulled)".Colour(Telnet.BoldRed)}";
+		}
+
+		if (type == DescriptionType.Full)
+		{
+			if (!PinPulled)
+			{
+				return $"{description}\n\nIts safety pin is still in place.";
+			}
+
+			var remaining = RemainingDuration();
+			var remainingText = remaining > TimeSpan.Zero
+				? remaining.Describe(voyeur).Colour(Telnet.BoldRed)
+				: "less than a second".Colour(Telnet.BoldRed);
+			return $"{description}\n\nIts safety pin has been pulled and detonation is irreversible, with {remainingText} remaining.";
+		}
+
+		if (type == DescriptionType.Evaluate)
+		{
+			return
+				$"It has a pin-pull detonator with an irreversible delay of {_prototype.Delay.Describe(voyeur).ColourValue()}.";
+		}
+
+		return description;
+	}
+
+	public override int DecorationPriority => int.MaxValue - 1;
+}

--- a/MudSharpCore/GameItems/Components/RadioDetonatorGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/RadioDetonatorGameItemComponent.cs
@@ -4,7 +4,7 @@ using MudSharp.GameItems.Prototypes;
 namespace MudSharp.GameItems.Components;
 
 public class RadioDetonatorGameItemComponent : GameItemComponent, IReceive, IConsumePower, IOnOff, ISelectable,
-    ISwitchable
+    ISwitchable, IArmableExplosiveTrigger
 {
     protected RadioDetonatorGameItemComponentProto _prototype;
     public override IGameItemComponentProto Prototype => _prototype;
@@ -129,6 +129,70 @@ public class RadioDetonatorGameItemComponent : GameItemComponent, IReceive, ICon
     #region IOnOff Implementation
 
     private bool _switchedOn;
+
+	public bool Armed => SwitchedOn;
+
+	public bool CanArm(ICharacter actor, string argument)
+	{
+		return !Armed && string.IsNullOrWhiteSpace(argument) && Parent.IsItemType<IDetonatable>();
+	}
+
+	public string WhyCannotArm(ICharacter actor, string argument)
+	{
+		if (Armed)
+		{
+			return $"{Parent.HowSeen(actor, true)} is already armed.";
+		}
+
+		if (!Parent.IsItemType<IDetonatable>())
+		{
+			return $"{Parent.HowSeen(actor, true)} has no explosive payload to detonate.";
+		}
+
+		return !string.IsNullOrWhiteSpace(argument)
+			? "A radio detonator does not take an arming duration or datetime."
+			: $"{Parent.HowSeen(actor, true)} cannot be armed at this time.";
+	}
+
+	public bool Arm(ICharacter actor, string argument, IEmote playerEmote = null)
+	{
+		if (!CanArm(actor, argument))
+		{
+			actor.Send(WhyCannotArm(actor, argument));
+			return false;
+		}
+
+		actor.OutputHandler.Handle(new MixedEmoteOutput(
+			new Emote("@ arm|arms $1's radio detonator.", actor, actor, Parent)).Append(playerEmote));
+		SwitchedOn = true;
+		return true;
+	}
+
+	public bool CanDisarm(ICharacter actor)
+	{
+		return Armed;
+	}
+
+	public string WhyCannotDisarm(ICharacter actor)
+	{
+		return Armed
+			? $"{Parent.HowSeen(actor, true)} cannot be disarmed at this time."
+			: $"{Parent.HowSeen(actor, true)} is not armed.";
+	}
+
+	public bool Disarm(ICharacter actor, IEmote playerEmote = null)
+	{
+		if (!CanDisarm(actor))
+		{
+			actor.Send(WhyCannotDisarm(actor));
+			return false;
+		}
+
+		actor.OutputHandler.Handle(new MixedEmoteOutput(
+			new Emote("@ disarm|disarms $1's radio detonator.", actor, actor, Parent)).Append(playerEmote));
+		SwitchedOn = false;
+		return true;
+	}
 
     public bool SwitchedOn
     {
@@ -271,12 +335,19 @@ public class RadioDetonatorGameItemComponent : GameItemComponent, IReceive, ICon
         switch (type)
         {
             case DescriptionType.Full:
+                var state = !SwitchedOn
+                    ? "disarmed".Colour(Telnet.Yellow)
+                    : _powered
+                        ? "armed and powered".Colour(Telnet.BoldRed)
+                        : $"{"armed".Colour(Telnet.BoldRed)} but {"unpowered".ColourError()}";
                 return
-                    $"{description}\n\nThis item has a radio detonator.\nIt is currently {(SwitchedOn && _powered ? "armed".Colour(Telnet.BoldRed) : "disarmed".Colour(Telnet.Yellow))}.\nYou can {"switch".ColourCommand()} to arm or disarm it (see {"help switch".FluentTagMXP("send", "href='help switch' hint='show the helpfile for the switch command'")}).\nYou can use {"select".ColourCommand()} to set the detonation code (see {"help select".FluentTagMXP("send", "href='help select' hint='show the helpfile for the select command'")}).";
+                    $"{description}\n\nThis item has a radio detonator.\nIt is currently {state}.\nYou can {"arm".ColourCommand()} or {"disarm".ColourCommand()} it; the existing {"switch".ColourCommand()} on/off controls are equivalent.\nYou can use {"select".ColourCommand()} to set the detonation code (see {"help select".FluentTagMXP("send", "href='help select' hint='show the helpfile for the select command'")}).";
             case DescriptionType.Short:
-                if (_switchedOn && _powered)
+                if (_switchedOn)
                 {
-                    return $"{description} {"(armed)".Colour(Telnet.BoldRed)}";
+                    return _powered
+                        ? $"{description} {"(armed)".Colour(Telnet.BoldRed)}"
+                        : $"{description} {"(armed, unpowered)".Colour(Telnet.BoldRed)}";
                 }
 
                 break;

--- a/MudSharpCore/GameItems/Components/SignalComponentUtilities.cs
+++ b/MudSharpCore/GameItems/Components/SignalComponentUtilities.cs
@@ -156,21 +156,28 @@ public static class SignalComponentUtilities
 			return true;
 		}
 
-		if (origin.AttachedAndConnectedItems.Contains(target) || target.AttachedAndConnectedItems.Contains(origin))
+		if (origin.AttachedAndConnectedItems.Any(x => SameRuntimeItem(x, target)) ||
+		    target.AttachedAndConnectedItems.Any(x => SameRuntimeItem(x, origin)))
 		{
 			return true;
 		}
 
 		var originCells = EnumerateSignalAccessibilityCells(origin).ToList();
 		var targetCells = EnumerateSignalAccessibilityCells(target).ToList();
-		return originCells.Intersect(targetCells).Any();
+		return originCells.Any(originCell => targetCells.Any(targetCell =>
+			ReferenceEquals(originCell, targetCell) || originCell.Id > 0 && originCell.Id == targetCell.Id));
+	}
+
+	private static bool SameRuntimeItem(IGameItem lhs, IGameItem rhs)
+	{
+		return ReferenceEquals(lhs, rhs) || lhs.Id > 0 && lhs.Id == rhs.Id;
 	}
 
 	public static ISignalSourceComponent? FindSignalSource(IGameItem parent, LocalSignalBinding binding,
-		IGameItemComponent? excludedComponent = null)
+		IGameItemComponent? excludedComponent = null, bool strictSourceItemId = false)
 	{
 		return FindSignalSource(parent, binding.SourceItemId, binding.SourceItemName, binding.SourceComponentId,
-			binding.SourceComponentName, binding.SourceEndpointKey, excludedComponent);
+			binding.SourceComponentName, binding.SourceEndpointKey, excludedComponent, strictSourceItemId);
 	}
 
 	public static ISignalSourceComponent? FindSignalSourceOnItem(IGameItem item, long sourceComponentId,
@@ -195,7 +202,7 @@ public static class SignalComponentUtilities
 
 	public static ISignalSourceComponent? FindSignalSource(IGameItem parent, long sourceItemId, string sourceItemName,
 		long sourceComponentId, string sourceComponentName, string? sourceEndpointKey = null,
-		IGameItemComponent? excludedComponent = null)
+		IGameItemComponent? excludedComponent = null, bool strictSourceItemId = false)
 	{
 		if (sourceComponentId <= 0 && string.IsNullOrWhiteSpace(sourceComponentName))
 		{
@@ -214,6 +221,13 @@ public static class SignalComponentUtilities
 				{
 					return itemMatch;
 				}
+			}
+
+			if (strictSourceItemId)
+			{
+				// Safety-sensitive live bindings can require the exact runtime item instead of silently
+				// substituting another nearby item merely because it has the same component prototype.
+				return null;
 			}
 		}
 

--- a/MudSharpCore/GameItems/Components/SignalDetonatorGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/SignalDetonatorGameItemComponent.cs
@@ -1,0 +1,530 @@
+#nullable enable
+
+using MudSharp.Computers;
+using MudSharp.Construction.Boundary;
+using MudSharp.Form.Shape;
+using MudSharp.GameItems.Prototypes;
+
+namespace MudSharp.GameItems.Components;
+
+public class SignalDetonatorGameItemComponent : GameItemComponent, IArmableExplosiveTrigger,
+	IRuntimeConfigurableSignalSinkComponent, IConsumePower
+{
+	private SignalDetonatorGameItemComponentProto _prototype;
+	private readonly LocalSignalSinkSubscription _binding;
+	private LocalSignalBinding? _runtimeBinding;
+	private double? _runtimeActivationThreshold;
+	private bool? _runtimeActiveWhenAboveThreshold;
+	private bool _armed;
+	private bool _powered;
+	private bool _runtimeActive;
+	private bool _hasSignalBaseline;
+	private bool _lastSignalActive;
+	private bool _suppressTrigger;
+	private bool _triggering;
+	private IProducePower? _powerSource;
+	private bool _topologySubscribed;
+	private IGameItem? _signalSourceParent;
+
+	public SignalDetonatorGameItemComponent(SignalDetonatorGameItemComponentProto proto, IGameItem parent,
+		bool temporary = false)
+		: base(parent, proto, temporary)
+	{
+		_prototype = proto;
+		_binding = new LocalSignalSinkSubscription(parent, this, HandleSourceChanged);
+	}
+
+	public SignalDetonatorGameItemComponent(MudSharp.Models.GameItemComponent component,
+		SignalDetonatorGameItemComponentProto proto, IGameItem parent)
+		: base(component, parent)
+	{
+		_prototype = proto;
+		_binding = new LocalSignalSinkSubscription(parent, this, HandleSourceChanged);
+		_noSave = true;
+		LoadFromXml(XElement.Parse(component.Definition));
+		_noSave = false;
+	}
+
+	public SignalDetonatorGameItemComponent(SignalDetonatorGameItemComponent rhs, IGameItem newParent,
+		bool temporary = false)
+		: base(rhs, newParent, temporary)
+	{
+		_prototype = rhs._prototype;
+		_binding = new LocalSignalSinkSubscription(newParent, this, HandleSourceChanged);
+		_runtimeBinding = rhs._runtimeBinding;
+		_runtimeActivationThreshold = rhs._runtimeActivationThreshold;
+		_runtimeActiveWhenAboveThreshold = rhs._runtimeActiveWhenAboveThreshold;
+		_armed = rhs._armed;
+		CurrentValue = rhs.CurrentValue;
+		_hasSignalBaseline = rhs._hasSignalBaseline;
+		_lastSignalActive = rhs._lastSignalActive;
+	}
+
+	public override IGameItemComponentProto Prototype => _prototype;
+	public bool Armed => _armed;
+	public long SourceComponentId => CurrentBinding.SourceComponentId;
+	public string SourceComponentName => CurrentBinding.SourceComponentName;
+	public string SourceEndpointKey => CurrentBinding.SourceEndpointKey;
+	public ISignalSource? UpstreamSource => _binding.UpstreamSource;
+	public double CurrentValue { get; private set; }
+	public LocalSignalBinding CurrentBinding => _runtimeBinding ?? new LocalSignalBinding(
+		0L, string.Empty, _prototype.SourceComponentId, _prototype.SourceComponentName, _prototype.SourceEndpointKey);
+	public double ActivationThreshold => _runtimeActivationThreshold ?? _prototype.ActivationThreshold;
+	public bool ActiveWhenAboveThreshold => _runtimeActiveWhenAboveThreshold ?? _prototype.ActiveWhenAboveThreshold;
+	public double PowerConsumptionInWatts => _prototype.RequiresPower && Armed ? _prototype.PowerConsumptionInWatts : 0.0;
+
+	protected override void UpdateComponentNewPrototype(IGameItemComponentProto newProto)
+	{
+		_prototype = (SignalDetonatorGameItemComponentProto)newProto;
+		ReconnectSource();
+		RefreshPowerDrawdown();
+	}
+
+	public override IGameItemComponent Copy(IGameItem newParent, bool temporary = false)
+	{
+		return new SignalDetonatorGameItemComponent(this, newParent, temporary);
+	}
+
+	private void LoadFromXml(XElement root)
+	{
+		_armed = bool.TryParse(root.Element("Armed")?.Value, out var armed) && armed;
+		if (double.TryParse(root.Element("CurrentValue")?.Value, out var currentValue) && double.IsFinite(currentValue))
+		{
+			CurrentValue = currentValue;
+		}
+		_hasSignalBaseline = bool.TryParse(root.Element("HasSignalBaseline")?.Value, out var hasBaseline) && hasBaseline;
+		_lastSignalActive = bool.TryParse(root.Element("LastSignalActive")?.Value, out var lastActive) && lastActive;
+		var runtimeSourceId = root.Element("RuntimeSourceComponentId");
+		if (runtimeSourceId is not null)
+		{
+			_runtimeBinding = new LocalSignalBinding(
+				long.TryParse(root.Element("RuntimeSourceItemId")?.Value, out var sourceItemId) ? sourceItemId : 0L,
+				root.Element("RuntimeSourceItemName")?.Value ?? string.Empty,
+				long.TryParse(runtimeSourceId.Value, out var sourceId) ? sourceId : 0L,
+				root.Element("RuntimeSourceComponentName")?.Value ?? string.Empty,
+				SignalComponentUtilities.NormaliseSignalEndpointKey(root.Element("RuntimeSourceEndpointKey")?.Value));
+		}
+		if (double.TryParse(root.Element("RuntimeActivationThreshold")?.Value, out var threshold) &&
+		    double.IsFinite(threshold))
+		{
+			_runtimeActivationThreshold = threshold;
+		}
+		if (bool.TryParse(root.Element("RuntimeActiveWhenAboveThreshold")?.Value, out var activeWhenAbove))
+		{
+			_runtimeActiveWhenAboveThreshold = activeWhenAbove;
+		}
+	}
+
+	protected override string SaveToXml()
+	{
+		var root = new XElement("Definition",
+			new XElement("Armed", Armed),
+			new XElement("CurrentValue", CurrentValue),
+			new XElement("HasSignalBaseline", _hasSignalBaseline),
+			new XElement("LastSignalActive", _lastSignalActive));
+		if (_runtimeBinding is not null)
+		{
+			root.Add(new XElement("RuntimeSourceItemId", _runtimeBinding.SourceItemId));
+			root.Add(new XElement("RuntimeSourceItemName", new XCData(_runtimeBinding.SourceItemName)));
+			root.Add(new XElement("RuntimeSourceComponentId", _runtimeBinding.SourceComponentId));
+			root.Add(new XElement("RuntimeSourceComponentName", new XCData(_runtimeBinding.SourceComponentName)));
+			root.Add(new XElement("RuntimeSourceEndpointKey", new XCData(_runtimeBinding.SourceEndpointKey)));
+		}
+		if (_runtimeActivationThreshold.HasValue)
+		{
+			root.Add(new XElement("RuntimeActivationThreshold", _runtimeActivationThreshold.Value));
+		}
+		if (_runtimeActiveWhenAboveThreshold.HasValue)
+		{
+			root.Add(new XElement("RuntimeActiveWhenAboveThreshold", _runtimeActiveWhenAboveThreshold.Value));
+		}
+		return root.ToString();
+	}
+
+	public override void FinaliseLoad()
+	{
+		// Signal subscriptions begin at login after the item graph is complete.
+	}
+
+	public override void Login()
+	{
+		_runtimeActive = true;
+		EnsureTopologySubscriptions();
+		base.Login();
+		ReconnectSource();
+		RefreshPowerDrawdown();
+		EvaluateCurrentSignalAfterStateChange();
+	}
+
+	public override void Quit()
+	{
+		_runtimeActive = false;
+		RemoveTopologySubscriptions();
+		RemoveSignalSourceLocationSubscription();
+		_binding.Detach();
+		EndPowerDrawdown();
+		base.Quit();
+	}
+
+	public override void Delete()
+	{
+		_runtimeActive = false;
+		RemoveTopologySubscriptions();
+		RemoveSignalSourceLocationSubscription();
+		_binding.Detach();
+		EndPowerDrawdown();
+		base.Delete();
+	}
+
+	public bool CanArm(ICharacter actor, string argument)
+	{
+		return !Armed && string.IsNullOrWhiteSpace(argument) && Parent.IsItemType<IDetonatable>();
+	}
+
+	public string WhyCannotArm(ICharacter actor, string argument)
+	{
+		if (Armed) return $"{Parent.HowSeen(actor, true)} is already armed.";
+		if (!Parent.IsItemType<IDetonatable>()) return $"{Parent.HowSeen(actor, true)} has no explosive payload to detonate.";
+		if (!string.IsNullOrWhiteSpace(argument)) return "This signal detonator does not take an arming duration or datetime.";
+		return $"{Parent.HowSeen(actor, true)} cannot be armed at this time.";
+	}
+
+	public bool Arm(ICharacter actor, string argument, IEmote? playerEmote = null)
+	{
+		if (!CanArm(actor, argument))
+		{
+			actor.Send(WhyCannotArm(actor, argument));
+			return false;
+		}
+
+		_armed = true;
+		Changed = true;
+		actor.OutputHandler.Handle(
+			new MixedEmoteOutput(new Emote(_prototype.ArmEmote, actor, actor, Parent)).Append(playerEmote));
+		RefreshPowerDrawdown();
+		EstablishSignalBaseline();
+		if (_prototype.ActivationMode == ExplosiveSignalActivationMode.Level)
+		{
+			EvaluateCurrentSignalAfterStateChange();
+		}
+		return true;
+	}
+
+	public bool CanDisarm(ICharacter actor)
+	{
+		return Armed && _prototype.CanBeDisarmed;
+	}
+
+	public string WhyCannotDisarm(ICharacter actor)
+	{
+		if (!Armed) return $"{Parent.HowSeen(actor, true)} is not armed.";
+		return _prototype.CanBeDisarmed
+			? $"{Parent.HowSeen(actor, true)} cannot be disarmed at this time."
+			: $"Once armed, {Parent.HowSeen(actor)} cannot be disarmed.";
+	}
+
+	public bool Disarm(ICharacter actor, IEmote? playerEmote = null)
+	{
+		if (!CanDisarm(actor))
+		{
+			actor.Send(WhyCannotDisarm(actor));
+			return false;
+		}
+
+		actor.OutputHandler.Handle(
+			new MixedEmoteOutput(new Emote(_prototype.DisarmEmote, actor, actor, Parent)).Append(playerEmote));
+		_armed = false;
+		Changed = true;
+		EndPowerDrawdown();
+		EstablishSignalBaseline();
+		return true;
+	}
+
+	public void ReconnectSource()
+	{
+		RemoveSignalSourceLocationSubscription();
+		_suppressTrigger = true;
+		_binding.Reconnect(CurrentBinding, strictSourceItemId: CurrentBinding.SourceItemId > 0);
+		_suppressTrigger = false;
+		EnsureSignalSourceTopologySubscription();
+		if (_binding.UpstreamSource is null)
+		{
+			CurrentValue = 0.0;
+			_hasSignalBaseline = false;
+			return;
+		}
+		EstablishSignalBaseline();
+		if (_prototype.ActivationMode == ExplosiveSignalActivationMode.Level)
+		{
+			EvaluateCurrentSignalAfterStateChange();
+		}
+	}
+
+	public void ReceiveSignal(ComputerSignal signal, ISignalSource source)
+	{
+		CurrentValue = signal.Value;
+		var active = SignalComponentUtilities.IsActiveSignal(CurrentValue, ActivationThreshold,
+			ActiveWhenAboveThreshold);
+		var shouldTrigger = Armed && IsOperational && !_suppressTrigger &&
+		                    (_prototype.ActivationMode == ExplosiveSignalActivationMode.Level
+			                    ? active
+			                    : _hasSignalBaseline && !_lastSignalActive && active);
+		_lastSignalActive = active;
+		_hasSignalBaseline = true;
+		Changed = true;
+		if (shouldTrigger)
+		{
+			TriggerDetonation();
+		}
+	}
+
+	private void HandleSourceChanged(ISignalSourceComponent source, ComputerSignal signal)
+	{
+		if (!_suppressTrigger && !SignalComponentUtilities.ItemsAreSignalAccessible(Parent, source.Parent))
+		{
+			ReconnectSource();
+			return;
+		}
+
+		ReceiveSignal(signal, source);
+	}
+
+	private bool IsOperational => !_prototype.RequiresPower || _powered;
+
+	private void EstablishSignalBaseline()
+	{
+		_lastSignalActive = SignalComponentUtilities.IsActiveSignal(CurrentValue, ActivationThreshold,
+			ActiveWhenAboveThreshold);
+		_hasSignalBaseline = _binding.UpstreamSource is not null;
+		Changed = true;
+	}
+
+	private void EvaluateCurrentSignalAfterStateChange()
+	{
+		if (!Armed || !IsOperational || _binding.UpstreamSource is null)
+		{
+			return;
+		}
+		if (_prototype.ActivationMode == ExplosiveSignalActivationMode.Level &&
+		    SignalComponentUtilities.IsActiveSignal(CurrentValue, ActivationThreshold, ActiveWhenAboveThreshold))
+		{
+			TriggerDetonation();
+		}
+	}
+
+	private void TriggerDetonation()
+	{
+		if (_triggering || !Armed)
+		{
+			return;
+		}
+		_triggering = true;
+		_armed = false;
+		Changed = true;
+		_binding.Detach();
+		EndPowerDrawdown();
+		Parent.GetItemType<IDetonatable>()?.Detonate();
+	}
+
+	public bool ConfigureSignalBinding(ISignalSourceComponent source, string? endpointKey, out string error)
+	{
+		_runtimeBinding = SignalComponentUtilities.CreateBinding(source, endpointKey);
+		Changed = true;
+		ReconnectSource();
+		error = string.Empty;
+		return true;
+	}
+
+	public void ClearSignalBinding()
+	{
+		_runtimeBinding = null;
+		Changed = true;
+		ReconnectSource();
+	}
+
+	public bool SetActivationThreshold(double threshold, out string error)
+	{
+		if (!double.IsFinite(threshold))
+		{
+			error = "That is not a valid numeric threshold.";
+			return false;
+		}
+		_runtimeActivationThreshold = threshold;
+		Changed = true;
+		EstablishSignalBaseline();
+		if (_prototype.ActivationMode == ExplosiveSignalActivationMode.Level)
+		{
+			EvaluateCurrentSignalAfterStateChange();
+		}
+		error = string.Empty;
+		return true;
+	}
+
+	public void SetActiveWhenAboveThreshold(bool activeWhenAboveThreshold)
+	{
+		_runtimeActiveWhenAboveThreshold = activeWhenAboveThreshold;
+		Changed = true;
+		EstablishSignalBaseline();
+		if (_prototype.ActivationMode == ExplosiveSignalActivationMode.Level)
+		{
+			EvaluateCurrentSignalAfterStateChange();
+		}
+	}
+
+	public void OnPowerCutIn()
+	{
+		_powered = true;
+		EstablishSignalBaseline();
+		if (_prototype.ActivationMode == ExplosiveSignalActivationMode.Level)
+		{
+			EvaluateCurrentSignalAfterStateChange();
+		}
+	}
+
+	public void OnPowerCutOut()
+	{
+		_powered = false;
+		EstablishSignalBaseline();
+	}
+
+	private void RefreshPowerDrawdown()
+	{
+		if (!_runtimeActive || !_prototype.RequiresPower || !Armed)
+		{
+			EndPowerDrawdown();
+			return;
+		}
+		var source = ResolvePowerSource();
+		if (!ReferenceEquals(source, _powerSource))
+		{
+			_powerSource?.EndDrawdown(this);
+			_powerSource = source;
+			_powered = false;
+		}
+		if (!_powered)
+		{
+			_powerSource?.BeginDrawdown(this);
+		}
+	}
+
+	private IProducePower? ResolvePowerSource()
+	{
+		return Parent.GetItemTypes<IProducePower>().FirstOrDefault() ??
+		       Parent.AttachedAndConnectedItems.SelectMany(x => x.GetItemTypes<IProducePower>()).FirstOrDefault();
+	}
+
+	private void EndPowerDrawdown()
+	{
+		_powerSource?.EndDrawdown(this);
+		_powerSource = null;
+		_powered = false;
+	}
+
+	private void EnsureTopologySubscriptions()
+	{
+		if (_topologySubscribed)
+		{
+			return;
+		}
+		Parent.OnConnected += ParentOnConnectionChanged;
+		Parent.OnDisconnected += ParentOnConnectionChanged;
+		Parent.OnLocationChanged += ParentOnLocationChanged;
+		_topologySubscribed = true;
+	}
+
+	private void RemoveTopologySubscriptions()
+	{
+		if (!_topologySubscribed)
+		{
+			return;
+		}
+		Parent.OnConnected -= ParentOnConnectionChanged;
+		Parent.OnDisconnected -= ParentOnConnectionChanged;
+		Parent.OnLocationChanged -= ParentOnLocationChanged;
+		_topologySubscribed = false;
+	}
+
+	private void ParentOnConnectionChanged(IConnectable other, ConnectorType type)
+	{
+		ReconnectSource();
+		RefreshPowerDrawdown();
+	}
+
+	private void ParentOnLocationChanged(ILocateable locatable, ICellExit exit)
+	{
+		ReconnectSource();
+	}
+
+	private void EnsureSignalSourceTopologySubscription()
+	{
+		var sourceParent = (_binding.UpstreamSource as IGameItemComponent)?.Parent;
+		if (sourceParent is null && CurrentBinding.SourceItemId > 0)
+		{
+			sourceParent = Gameworld.TryGetItem(CurrentBinding.SourceItemId, true);
+		}
+
+		if (sourceParent is null || ReferenceEquals(sourceParent, Parent))
+		{
+			return;
+		}
+
+		_signalSourceParent = sourceParent;
+		_signalSourceParent.OnLocationChanged += SignalSourceParentOnLocationChanged;
+		_signalSourceParent.OnConnected += SignalSourceParentOnConnectionChanged;
+		_signalSourceParent.OnDisconnected += SignalSourceParentOnConnectionChanged;
+	}
+
+	private void RemoveSignalSourceLocationSubscription()
+	{
+		if (_signalSourceParent is null)
+		{
+			return;
+		}
+
+		_signalSourceParent.OnLocationChanged -= SignalSourceParentOnLocationChanged;
+		_signalSourceParent.OnConnected -= SignalSourceParentOnConnectionChanged;
+		_signalSourceParent.OnDisconnected -= SignalSourceParentOnConnectionChanged;
+		_signalSourceParent = null;
+	}
+
+	private void SignalSourceParentOnLocationChanged(ILocateable locatable, ICellExit exit)
+	{
+		ReconnectSource();
+	}
+
+	private void SignalSourceParentOnConnectionChanged(IConnectable other, ConnectorType type)
+	{
+		ReconnectSource();
+	}
+
+	public override bool DescriptionDecorator(DescriptionType type)
+	{
+		return type is DescriptionType.Short or DescriptionType.Full or DescriptionType.Evaluate;
+	}
+
+	public override string Decorate(IPerceiver voyeur, string name, string description, DescriptionType type,
+		bool colour, PerceiveIgnoreFlags flags)
+	{
+		if (type == DescriptionType.Short && Armed)
+		{
+			return $"{description} {"(armed)".Colour(Telnet.BoldRed)}";
+		}
+		if (type == DescriptionType.Full)
+		{
+			return
+				$"{description}\n\nIts signal detonator is {(Armed ? "armed".Colour(Telnet.BoldRed) : "disarmed".Colour(Telnet.Yellow))}{(_prototype.RequiresPower ? $" and {(_powered ? "powered".ColourValue() : "unpowered".ColourError())}" : string.Empty)}.";
+		}
+		if (type == DescriptionType.Evaluate)
+		{
+			var thresholdMode = ActiveWhenAboveThreshold ? "at or above" : "below";
+			var powerText = _prototype.RequiresPower
+				? $" It requires {_prototype.PowerConsumptionInWatts.ToString("N3", voyeur).ColourValue()} watts while armed."
+				: " It does not require electrical power.";
+			return
+				$"It has a {_prototype.ActivationMode.DescribeEnum().ToLowerInvariant().ColourValue()} signal detonator driven by {SignalComponentUtilities.DescribeSignalComponent(CurrentBinding).ColourName()}, active {thresholdMode} {ActivationThreshold.ToString("N2", voyeur).ColourValue()}.{powerText} It {(_prototype.CanBeDisarmed ? "can" : "cannot")} be disarmed after arming.";
+		}
+		return description;
+	}
+
+	public override int DecorationPriority => int.MaxValue - 1;
+}

--- a/MudSharpCore/GameItems/Prototypes/ClockDetonatorGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/ClockDetonatorGameItemComponentProto.cs
@@ -1,0 +1,211 @@
+#nullable enable
+
+using MudSharp.Accounts;
+using MudSharp.Framework.Revision;
+using MudSharp.GameItems.Components;
+using MudSharp.TimeAndDate.Date;
+using MudSharp.TimeAndDate.Time;
+
+namespace MudSharp.GameItems.Prototypes;
+
+public class ClockDetonatorGameItemComponentProto : GameItemComponentProto,
+	IArmableExplosiveTriggerPrototype, IGameItemComponentPrototypeRequirementProvider
+{
+	private static readonly IReadOnlyCollection<GameItemComponentPrototypeRequirement> Requirements =
+	[
+		new(typeof(IDetonatable), "it needs an explosive payload to detonate at the selected world time")
+	];
+
+	protected ClockDetonatorGameItemComponentProto(IFuturemud gameworld, IAccount originator)
+		: base(gameworld, originator, "ClockDetonator")
+	{
+		var defaultClock = Gameworld.Clocks.Get(Gameworld.GetStaticLong("DefaultTimepieceClock"));
+		Calendar = Gameworld.Calendars.FirstOrDefault(x => x.FeedClock == defaultClock) ?? Gameworld.Calendars.First();
+		Clock = Calendar.FeedClock;
+		TimeZone = Clock.PrimaryTimezone;
+		CanBeDisarmed = true;
+		ArmEmote = "@ arm|arms the clock detonator on $1.";
+		DisarmEmote = "@ disarm|disarms the clock detonator on $1.";
+	}
+
+	protected ClockDetonatorGameItemComponentProto(MudSharp.Models.GameItemComponentProto proto, IFuturemud gameworld)
+		: base(proto, gameworld)
+	{
+	}
+
+	public override string TypeDescription => "ClockDetonator";
+	public IReadOnlyCollection<GameItemComponentPrototypeRequirement> RequiredSiblingComponents => Requirements;
+	public ICalendar Calendar { get; protected set; } = null!;
+	public IClock Clock { get; protected set; } = null!;
+	public IMudTimeZone TimeZone { get; protected set; } = null!;
+	public bool CanBeDisarmed { get; protected set; }
+	public string ArmEmote { get; protected set; } = string.Empty;
+	public string DisarmEmote { get; protected set; } = string.Empty;
+
+	protected override void LoadFromXml(XElement root)
+	{
+		Calendar = Gameworld.Calendars.Get(long.Parse(root.Element("Calendar")?.Value ?? "0")) ??
+		           Gameworld.Calendars.First();
+		Clock = Gameworld.Clocks.Get(long.Parse(root.Element("Clock")?.Value ?? "0")) ?? Calendar.FeedClock;
+		if (Clock != Calendar.FeedClock)
+		{
+			Clock = Calendar.FeedClock;
+		}
+		TimeZone = Clock.Timezones.Get(long.Parse(root.Element("TimeZone")?.Value ?? "0")) ??
+		           Clock.PrimaryTimezone;
+		CanBeDisarmed = bool.Parse(root.Element("CanBeDisarmed")?.Value ?? "true");
+		ArmEmote = root.Element("ArmEmote")?.Value ?? "@ arm|arms the clock detonator on $1.";
+		DisarmEmote = root.Element("DisarmEmote")?.Value ?? "@ disarm|disarms the clock detonator on $1.";
+	}
+
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition",
+			new XElement("Calendar", Calendar.Id),
+			new XElement("Clock", Clock.Id),
+			new XElement("TimeZone", TimeZone.Id),
+			new XElement("CanBeDisarmed", CanBeDisarmed),
+			new XElement("ArmEmote", new XCData(ArmEmote)),
+			new XElement("DisarmEmote", new XCData(DisarmEmote))).ToString();
+	}
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "calendar": return BuildingCommandCalendar(actor, command);
+			case "clock": return BuildingCommandClock(actor, command);
+			case "timezone":
+			case "tz": return BuildingCommandTimezone(actor, command);
+			case "disarmable":
+				CanBeDisarmed = !CanBeDisarmed;
+				Changed = true;
+				actor.Send($"This detonator is {(CanBeDisarmed ? "now" : "no longer")} disarmable once armed.");
+				return true;
+			case "armemote": return BuildingCommandEmote(actor, command, true);
+			case "disarmemote": return BuildingCommandEmote(actor, command, false);
+			default: return base.BuildingCommand(actor, command.GetUndo());
+		}
+	}
+
+	private bool BuildingCommandCalendar(ICharacter actor, StringStack command)
+	{
+		var calendar = command.IsFinished ? null : Gameworld.Calendars.GetByIdOrNames(command.SafeRemainingArgument);
+		if (calendar is null)
+		{
+			actor.Send("Which calendar should this clock detonator use?");
+			return false;
+		}
+
+		Calendar = calendar;
+		Clock = calendar.FeedClock;
+		TimeZone = Clock.PrimaryTimezone;
+		Changed = true;
+		actor.Send($"This detonator now uses {Calendar.FullName.ColourName()} and the {Clock.Name.ColourName()} clock.");
+		return true;
+	}
+
+	private bool BuildingCommandClock(ICharacter actor, StringStack command)
+	{
+		var clock = command.IsFinished ? null : Gameworld.Clocks.GetByIdOrNames(command.SafeRemainingArgument);
+		if (clock is null)
+		{
+			actor.Send("Which world clock should this detonator use?");
+			return false;
+		}
+
+		var calendar = Gameworld.Calendars.FirstOrDefault(x => x.FeedClock == clock);
+		if (calendar is null)
+		{
+			actor.Send("No calendar is driven by that clock, so it cannot be used for an exact datetime trigger.");
+			return false;
+		}
+
+		Clock = clock;
+		Calendar = calendar;
+		TimeZone = clock.PrimaryTimezone;
+		Changed = true;
+		actor.Send($"This detonator now uses the {Clock.Name.ColourName()} clock and {Calendar.FullName.ColourName()}.");
+		return true;
+	}
+
+	private bool BuildingCommandTimezone(ICharacter actor, StringStack command)
+	{
+		var timezone = command.IsFinished ? null : Clock.Timezones.GetByIdOrNames(command.SafeRemainingArgument);
+		if (timezone is null)
+		{
+			actor.Send($"Valid timezones are {Clock.Timezones.Select(x => x.Alias.ColourValue()).ListToString()}.");
+			return false;
+		}
+
+		TimeZone = timezone;
+		Changed = true;
+		actor.Send($"This detonator now interprets and displays target times in {TimeZone.Alias.ColourValue()}.");
+		return true;
+	}
+
+	private bool BuildingCommandEmote(ICharacter actor, StringStack command, bool arming)
+	{
+		if (command.IsFinished)
+		{
+			actor.Send("You must specify an emote using @ for the actor and $1 for the explosive item.");
+			return false;
+		}
+		var emote = new Emote(command.SafeRemainingArgument, actor, actor, new DummyPerceivable());
+		if (!emote.Valid)
+		{
+			actor.Send(emote.ErrorMessage);
+			return false;
+		}
+		if (arming) ArmEmote = command.SafeRemainingArgument;
+		else DisarmEmote = command.SafeRemainingArgument;
+		Changed = true;
+		actor.Send($"The {(arming ? "arming" : "disarming")} emote is now {command.SafeRemainingArgument.ColourCommand()}.");
+		return true;
+	}
+
+	private const string BuildingHelpText = @"You can use the following options with this component:
+	#3calendar <which>#0 - sets the world calendar and its feed clock
+	#3clock <which>#0 - selects a clock and its first compatible calendar
+	#3timezone <which>#0 - sets the timezone used for input and display
+	#3disarmable#0 - toggles whether an armed clock trigger can be stopped
+	#3armemote <emote>#0 - sets the arming emote
+	#3disarmemote <emote>#0 - sets the disarming emote";
+
+	public override string ShowBuildingHelp => $"{base.ShowBuildingHelp}\n{BuildingHelpText}";
+
+	public override string ComponentDescriptionOLC(ICharacter actor)
+	{
+		return
+			$"{"Clock Detonator Item Component".ColourName()} (#{Id.ToString("N0", actor)}r{RevisionNumber.ToString("N0", actor)}, {Name})\n\nCalendar: {Calendar.FullName.ColourName()} (#{Calendar.Id.ToString("N0", actor)})\nClock: {Clock.Name.ColourName()} (#{Clock.Id.ToString("N0", actor)})\nTimezone: {TimeZone.Alias.ColourValue()}\nDisarmable: {CanBeDisarmed.ToColouredString()}\nArm Emote: {ArmEmote.ColourCommand()}\nDisarm Emote: {DisarmEmote.ColourCommand()}";
+	}
+
+	public static void RegisterComponentInitialiser(GameItemComponentManager manager)
+	{
+		manager.AddBuilderLoader("clockdetonator", true,
+			(gameworld, account) => new ClockDetonatorGameItemComponentProto(gameworld, account));
+		manager.AddBuilderLoader("clock detonator", false,
+			(gameworld, account) => new ClockDetonatorGameItemComponentProto(gameworld, account));
+		manager.AddDatabaseLoader("ClockDetonator",
+			(proto, gameworld) => new ClockDetonatorGameItemComponentProto(proto, gameworld));
+		manager.AddTypeHelpInfo("ClockDetonator",
+			$"An {"[armable]".Colour(Telnet.Yellow)} exact in-game datetime trigger for an explosive payload",
+			BuildingHelpText);
+	}
+
+	public override IGameItemComponent CreateNew(IGameItem parent, ICharacter? loader = null, bool temporary = false)
+	{
+		return new ClockDetonatorGameItemComponent(this, parent, temporary);
+	}
+
+	public override IGameItemComponent LoadComponent(MudSharp.Models.GameItemComponent component, IGameItem parent)
+	{
+		return new ClockDetonatorGameItemComponent(component, this, parent);
+	}
+
+	public override IEditableRevisableItem CreateNewRevision(ICharacter initiator)
+	{
+		return CreateNewRevision(initiator,
+			(proto, gameworld) => new ClockDetonatorGameItemComponentProto(proto, gameworld));
+	}
+}

--- a/MudSharpCore/GameItems/Prototypes/CountdownDetonatorGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/CountdownDetonatorGameItemComponentProto.cs
@@ -1,0 +1,205 @@
+#nullable enable
+
+using MudSharp.Accounts;
+using MudSharp.Framework.Revision;
+using MudSharp.GameItems.Components;
+
+namespace MudSharp.GameItems.Prototypes;
+
+public class CountdownDetonatorGameItemComponentProto : GameItemComponentProto,
+	IArmableExplosiveTriggerPrototype, IGameItemComponentPrototypeRequirementProvider
+{
+	private static readonly IReadOnlyCollection<GameItemComponentPrototypeRequirement> Requirements =
+	[
+		new(typeof(IDetonatable), "it needs an explosive payload to detonate when the countdown expires")
+	];
+
+	protected CountdownDetonatorGameItemComponentProto(IFuturemud gameworld, IAccount originator)
+		: base(gameworld, originator, "CountdownDetonator")
+	{
+		DefaultDelay = TimeSpan.FromSeconds(10);
+		MinimumDelay = TimeSpan.FromSeconds(1);
+		MaximumDelay = TimeSpan.FromHours(24);
+		PlayersCanSetDelay = true;
+		CanBeDisarmed = true;
+		ArmEmote = "@ arm|arms the countdown detonator on $1.";
+		DisarmEmote = "@ disarm|disarms the countdown detonator on $1.";
+	}
+
+	protected CountdownDetonatorGameItemComponentProto(MudSharp.Models.GameItemComponentProto proto,
+		IFuturemud gameworld)
+		: base(proto, gameworld)
+	{
+	}
+
+	public override string TypeDescription => "CountdownDetonator";
+	public IReadOnlyCollection<GameItemComponentPrototypeRequirement> RequiredSiblingComponents => Requirements;
+	public TimeSpan DefaultDelay { get; protected set; }
+	public TimeSpan MinimumDelay { get; protected set; }
+	public TimeSpan MaximumDelay { get; protected set; }
+	public bool PlayersCanSetDelay { get; protected set; }
+	public bool CanBeDisarmed { get; protected set; }
+	public string ArmEmote { get; protected set; } = string.Empty;
+	public string DisarmEmote { get; protected set; } = string.Empty;
+
+	protected override void LoadFromXml(XElement root)
+	{
+		DefaultDelay = TimeSpan.FromSeconds(double.Parse(root.Element("DefaultDelaySeconds")?.Value ?? "10"));
+		MinimumDelay = TimeSpan.FromSeconds(double.Parse(root.Element("MinimumDelaySeconds")?.Value ?? "1"));
+		MaximumDelay = TimeSpan.FromSeconds(double.Parse(root.Element("MaximumDelaySeconds")?.Value ?? "86400"));
+		PlayersCanSetDelay = bool.Parse(root.Element("PlayersCanSetDelay")?.Value ?? "true");
+		CanBeDisarmed = bool.Parse(root.Element("CanBeDisarmed")?.Value ?? "true");
+		ArmEmote = root.Element("ArmEmote")?.Value ?? "@ arm|arms the countdown detonator on $1.";
+		DisarmEmote = root.Element("DisarmEmote")?.Value ?? "@ disarm|disarms the countdown detonator on $1.";
+	}
+
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition",
+			new XElement("DefaultDelaySeconds", DefaultDelay.TotalSeconds),
+			new XElement("MinimumDelaySeconds", MinimumDelay.TotalSeconds),
+			new XElement("MaximumDelaySeconds", MaximumDelay.TotalSeconds),
+			new XElement("PlayersCanSetDelay", PlayersCanSetDelay),
+			new XElement("CanBeDisarmed", CanBeDisarmed),
+			new XElement("ArmEmote", new XCData(ArmEmote)),
+			new XElement("DisarmEmote", new XCData(DisarmEmote))).ToString();
+	}
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "default":
+				return BuildingCommandDelay(actor, command, "default");
+			case "minimum":
+			case "min":
+				return BuildingCommandDelay(actor, command, "minimum");
+			case "maximum":
+			case "max":
+				return BuildingCommandDelay(actor, command, "maximum");
+			case "playerdelay":
+			case "playerset":
+				PlayersCanSetDelay = !PlayersCanSetDelay;
+				Changed = true;
+				actor.Send($"Players can {(PlayersCanSetDelay ? "now" : "no longer")} choose this detonator's countdown.");
+				return true;
+			case "disarmable":
+				CanBeDisarmed = !CanBeDisarmed;
+				Changed = true;
+				actor.Send($"This detonator is {(CanBeDisarmed ? "now" : "no longer")} disarmable once armed.");
+				return true;
+			case "armemote":
+				return BuildingCommandEmote(actor, command, true);
+			case "disarmemote":
+				return BuildingCommandEmote(actor, command, false);
+			default:
+				return base.BuildingCommand(actor, command.GetUndo());
+		}
+	}
+
+	private bool BuildingCommandDelay(ICharacter actor, StringStack command, string which)
+	{
+		if (command.IsFinished || !TimeSpan.TryParse(command.SafeRemainingArgument, actor, out var value) ||
+		    value <= TimeSpan.Zero)
+		{
+			actor.Send("You must specify a positive duration.");
+			return false;
+		}
+
+		switch (which)
+		{
+			case "default": DefaultDelay = value; break;
+			case "minimum": MinimumDelay = value; break;
+			case "maximum": MaximumDelay = value; break;
+		}
+
+		Changed = true;
+		actor.Send($"The {which} countdown delay is now {value.Describe(actor).ColourValue()}.");
+		return true;
+	}
+
+	private bool BuildingCommandEmote(ICharacter actor, StringStack command, bool arming)
+	{
+		if (command.IsFinished)
+		{
+			actor.Send("You must specify an emote using @ for the actor and $1 for the explosive item.");
+			return false;
+		}
+
+		var emote = new Emote(command.SafeRemainingArgument, actor, actor, new DummyPerceivable());
+		if (!emote.Valid)
+		{
+			actor.Send(emote.ErrorMessage);
+			return false;
+		}
+
+		if (arming) ArmEmote = command.SafeRemainingArgument;
+		else DisarmEmote = command.SafeRemainingArgument;
+		Changed = true;
+		actor.Send($"The {(arming ? "arming" : "disarming")} emote is now {command.SafeRemainingArgument.ColourCommand()}.");
+		return true;
+	}
+
+	public override bool CanSubmit()
+	{
+		return MinimumDelay > TimeSpan.Zero && MinimumDelay <= DefaultDelay && DefaultDelay <= MaximumDelay &&
+		       ExplosiveDeadlineScheduler.TryGetDeadline(DateTime.UtcNow, MaximumDelay, out _) &&
+		       base.CanSubmit();
+	}
+
+	public override string WhyCannotSubmit()
+	{
+		if (MinimumDelay <= TimeSpan.Zero) return "The minimum countdown must be positive.";
+		if (MinimumDelay > DefaultDelay) return "The minimum countdown cannot exceed the default countdown.";
+		if (DefaultDelay > MaximumDelay) return "The default countdown cannot exceed the maximum countdown.";
+		if (!ExplosiveDeadlineScheduler.TryGetDeadline(DateTime.UtcNow, MaximumDelay, out _))
+			return "The maximum countdown is too long to schedule safely.";
+		return base.WhyCannotSubmit();
+	}
+
+	private const string BuildingHelpText = @"You can use the following options with this component:
+	#3default <duration>#0 - sets the default countdown
+	#3minimum <duration>#0 - sets the shortest permitted countdown
+	#3maximum <duration>#0 - sets the longest permitted countdown
+	#3playerdelay#0 - toggles whether players may choose a countdown
+	#3disarmable#0 - toggles whether an armed countdown can be stopped
+	#3armemote <emote>#0 - sets the arming emote; @ is the actor and $1 is the item
+	#3disarmemote <emote>#0 - sets the disarming emote";
+
+	public override string ShowBuildingHelp => $"{base.ShowBuildingHelp}\n{BuildingHelpText}";
+
+	public override string ComponentDescriptionOLC(ICharacter actor)
+	{
+		return
+			$"{"Countdown Detonator Item Component".ColourName()} (#{Id.ToString("N0", actor)}r{RevisionNumber.ToString("N0", actor)}, {Name})\n\nDefault: {DefaultDelay.Describe(actor).ColourValue()}\nRange: {MinimumDelay.Describe(actor).ColourValue()} to {MaximumDelay.Describe(actor).ColourValue()}\nPlayer Settable: {PlayersCanSetDelay.ToColouredString()}\nDisarmable: {CanBeDisarmed.ToColouredString()}\nArm Emote: {ArmEmote.ColourCommand()}\nDisarm Emote: {DisarmEmote.ColourCommand()}";
+	}
+
+	public static void RegisterComponentInitialiser(GameItemComponentManager manager)
+	{
+		manager.AddBuilderLoader("countdowndetonator", true,
+			(gameworld, account) => new CountdownDetonatorGameItemComponentProto(gameworld, account));
+		manager.AddBuilderLoader("countdown detonator", false,
+			(gameworld, account) => new CountdownDetonatorGameItemComponentProto(gameworld, account));
+		manager.AddDatabaseLoader("CountdownDetonator",
+			(proto, gameworld) => new CountdownDetonatorGameItemComponentProto(proto, gameworld));
+		manager.AddTypeHelpInfo("CountdownDetonator",
+			$"An {"[armable]".Colour(Telnet.Yellow)} countdown trigger for a sibling explosive payload",
+			BuildingHelpText);
+	}
+
+	public override IGameItemComponent CreateNew(IGameItem parent, ICharacter? loader = null, bool temporary = false)
+	{
+		return new CountdownDetonatorGameItemComponent(this, parent, temporary);
+	}
+
+	public override IGameItemComponent LoadComponent(MudSharp.Models.GameItemComponent component, IGameItem parent)
+	{
+		return new CountdownDetonatorGameItemComponent(component, this, parent);
+	}
+
+	public override IEditableRevisableItem CreateNewRevision(ICharacter initiator)
+	{
+		return CreateNewRevision(initiator,
+			(proto, gameworld) => new CountdownDetonatorGameItemComponentProto(proto, gameworld));
+	}
+}

--- a/MudSharpCore/GameItems/Prototypes/PinPullDetonatorGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/PinPullDetonatorGameItemComponentProto.cs
@@ -1,0 +1,153 @@
+#nullable enable
+
+using MudSharp.Accounts;
+using MudSharp.Framework.Revision;
+using MudSharp.GameItems.Components;
+
+namespace MudSharp.GameItems.Prototypes;
+
+public class PinPullDetonatorGameItemComponentProto : GameItemComponentProto,
+	IPinPullExplosiveTriggerPrototype, IGameItemComponentPrototypeRequirementProvider
+{
+	private static readonly IReadOnlyCollection<GameItemComponentPrototypeRequirement> Requirements =
+	[
+		new(typeof(IDetonatable), "it needs an explosive payload to detonate after the pin is pulled")
+	];
+
+	protected PinPullDetonatorGameItemComponentProto(IFuturemud gameworld, IAccount originator)
+		: base(gameworld, originator, "PinPullDetonator")
+	{
+		Delay = TimeSpan.FromSeconds(5);
+		PullPinEmote = "@ pull|pulls the safety pin from $1, starting its irreversible countdown.";
+	}
+
+	protected PinPullDetonatorGameItemComponentProto(MudSharp.Models.GameItemComponentProto proto,
+		IFuturemud gameworld)
+		: base(proto, gameworld)
+	{
+	}
+
+	public override string TypeDescription => "PinPullDetonator";
+	public IReadOnlyCollection<GameItemComponentPrototypeRequirement> RequiredSiblingComponents => Requirements;
+	public TimeSpan Delay { get; protected set; }
+	public string PullPinEmote { get; protected set; } = string.Empty;
+
+	protected override void LoadFromXml(XElement root)
+	{
+		Delay = TimeSpan.FromSeconds(double.Parse(root.Element("DelaySeconds")?.Value ?? "5"));
+		PullPinEmote = root.Element("PullPinEmote")?.Value ??
+		               "@ pull|pulls the safety pin from $1, starting its irreversible countdown.";
+	}
+
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition",
+			new XElement("DelaySeconds", Delay.TotalSeconds),
+			new XElement("PullPinEmote", new XCData(PullPinEmote))).ToString();
+	}
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "delay":
+			case "time":
+				return BuildingCommandDelay(actor, command);
+			case "emote":
+			case "pullemote":
+				return BuildingCommandEmote(actor, command);
+			default:
+				return base.BuildingCommand(actor, command.GetUndo());
+		}
+	}
+
+	private bool BuildingCommandDelay(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !TimeSpan.TryParse(command.SafeRemainingArgument, actor, out var value) ||
+		    value <= TimeSpan.Zero)
+		{
+			actor.Send("You must specify a positive delay after the pin is pulled.");
+			return false;
+		}
+
+		Delay = value;
+		Changed = true;
+		actor.Send($"This pin-pull detonator will now explode after {Delay.Describe(actor).ColourValue()}.");
+		return true;
+	}
+
+	private bool BuildingCommandEmote(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.Send("You must specify an emote using @ for the actor and $1 for the explosive item.");
+			return false;
+		}
+
+		var emote = new Emote(command.SafeRemainingArgument, actor, actor, new DummyPerceivable());
+		if (!emote.Valid)
+		{
+			actor.Send(emote.ErrorMessage);
+			return false;
+		}
+
+		PullPinEmote = command.SafeRemainingArgument;
+		Changed = true;
+		actor.Send($"The pin-pull emote is now {PullPinEmote.ColourCommand()}.");
+		return true;
+	}
+
+	public override bool CanSubmit()
+	{
+		return ExplosiveDeadlineScheduler.TryGetDeadline(DateTime.UtcNow, Delay, out _) && base.CanSubmit();
+	}
+
+	public override string WhyCannotSubmit()
+	{
+		if (Delay <= TimeSpan.Zero) return "The pin-pull delay must be positive.";
+		if (!ExplosiveDeadlineScheduler.TryGetDeadline(DateTime.UtcNow, Delay, out _))
+			return "The pin-pull delay is too long to schedule safely.";
+		return base.WhyCannotSubmit();
+	}
+
+	private const string BuildingHelpText = @"You can use the following options with this component:
+	#3delay <duration>#0 - sets the irreversible delay after the pin is pulled
+	#3emote <emote>#0 - sets the pull-pin emote; @ is the actor and $1 is the item";
+
+	public override string ShowBuildingHelp => $"{base.ShowBuildingHelp}\n{BuildingHelpText}";
+
+	public override string ComponentDescriptionOLC(ICharacter actor)
+	{
+		return
+			$"{"Pin-Pull Detonator Item Component".ColourName()} (#{Id.ToString("N0", actor)}r{RevisionNumber.ToString("N0", actor)}, {Name})\n\nDelay: {Delay.Describe(actor).ColourValue()}\nPull Emote: {PullPinEmote.ColourCommand()}\nOnce pulled, the pin cannot be replaced and the countdown cannot be stopped.";
+	}
+
+	public static void RegisterComponentInitialiser(GameItemComponentManager manager)
+	{
+		manager.AddBuilderLoader("pinpulldetonator", true,
+			(gameworld, account) => new PinPullDetonatorGameItemComponentProto(gameworld, account));
+		manager.AddBuilderLoader("pin pull detonator", false,
+			(gameworld, account) => new PinPullDetonatorGameItemComponentProto(gameworld, account));
+		manager.AddDatabaseLoader("PinPullDetonator",
+			(proto, gameworld) => new PinPullDetonatorGameItemComponentProto(proto, gameworld));
+		manager.AddTypeHelpInfo("PinPullDetonator",
+			$"An irreversible {"[pin-pull]".Colour(Telnet.Yellow)} countdown trigger for an explosive payload",
+			BuildingHelpText);
+	}
+
+	public override IGameItemComponent CreateNew(IGameItem parent, ICharacter? loader = null, bool temporary = false)
+	{
+		return new PinPullDetonatorGameItemComponent(this, parent, temporary);
+	}
+
+	public override IGameItemComponent LoadComponent(MudSharp.Models.GameItemComponent component, IGameItem parent)
+	{
+		return new PinPullDetonatorGameItemComponent(component, this, parent);
+	}
+
+	public override IEditableRevisableItem CreateNewRevision(ICharacter initiator)
+	{
+		return CreateNewRevision(initiator,
+			(proto, gameworld) => new PinPullDetonatorGameItemComponentProto(proto, gameworld));
+	}
+}

--- a/MudSharpCore/GameItems/Prototypes/RadioDetonatorGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/RadioDetonatorGameItemComponentProto.cs
@@ -12,9 +12,17 @@ using MudSharp.GameItems.Components;
 
 namespace MudSharp.GameItems.Prototypes;
 
-public class RadioDetonatorGameItemComponentProto : GameItemComponentProto, IReceivePrototype, IConsumePowerPrototype, IOnOffPrototype, ISelectablePrototype, ISwitchablePrototype
+public class RadioDetonatorGameItemComponentProto : GameItemComponentProto, IReceivePrototype, IConsumePowerPrototype,
+	IOnOffPrototype, ISelectablePrototype, ISwitchablePrototype, IArmableExplosiveTriggerPrototype,
+	IGameItemComponentPrototypeRequirementProvider
 {
+	private static readonly IReadOnlyCollection<GameItemComponentPrototypeRequirement> Requirements =
+	[
+		new(typeof(IDetonatable), "it needs an explosive payload to detonate when the radio code is received")
+	];
+
     public override string TypeDescription => "RadioDetonator";
+	public IReadOnlyCollection<GameItemComponentPrototypeRequirement> RequiredSiblingComponents => Requirements;
 
     #region Constructors
 
@@ -174,7 +182,7 @@ public class RadioDetonatorGameItemComponentProto : GameItemComponentProto, IRec
         PowerConsumptionInWatts = value;
         Changed = true;
         actor.Send($"This radio detonator now uses {PowerConsumptionInWatts:N5} watts of power when armed.");
-        return false;
+        return true;
     }
 
     #endregion

--- a/MudSharpCore/GameItems/Prototypes/SignalDetonatorGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/SignalDetonatorGameItemComponentProto.cs
@@ -1,0 +1,281 @@
+#nullable enable
+
+using MudSharp.Accounts;
+using MudSharp.Framework.Revision;
+using MudSharp.GameItems.Components;
+
+namespace MudSharp.GameItems.Prototypes;
+
+public class SignalDetonatorGameItemComponentProto : GameItemComponentProto,
+	IArmableExplosiveTriggerPrototype, IRuntimeConfigurableSignalSinkComponentPrototype, IConsumePowerPrototype,
+	IGameItemComponentPrototypeRequirementProvider
+{
+	private static readonly IReadOnlyCollection<GameItemComponentPrototypeRequirement> Requirements =
+	[
+		new(typeof(IDetonatable), "it needs an explosive payload to detonate when its control signal activates")
+	];
+
+	protected SignalDetonatorGameItemComponentProto(IFuturemud gameworld, IAccount originator)
+		: base(gameworld, originator, "SignalDetonator")
+	{
+		SourceComponentName = string.Empty;
+		SourceEndpointKey = SignalComponentUtilities.DefaultLocalSignalEndpointKey;
+		ActivationThreshold = 0.5;
+		ActiveWhenAboveThreshold = true;
+		ActivationMode = ExplosiveSignalActivationMode.Edge;
+		RequiresPower = true;
+		PowerConsumptionInWatts = 0.1;
+		CanBeDisarmed = true;
+		ArmEmote = "@ arm|arms the signal detonator on $1.";
+		DisarmEmote = "@ disarm|disarms the signal detonator on $1.";
+	}
+
+	protected SignalDetonatorGameItemComponentProto(MudSharp.Models.GameItemComponentProto proto, IFuturemud gameworld)
+		: base(proto, gameworld)
+	{
+	}
+
+	public override string TypeDescription => "SignalDetonator";
+	public IReadOnlyCollection<GameItemComponentPrototypeRequirement> RequiredSiblingComponents => Requirements;
+	public long SourceComponentId { get; protected set; }
+	public string SourceComponentName { get; protected set; } = string.Empty;
+	public string SourceEndpointKey { get; protected set; } = SignalComponentUtilities.DefaultLocalSignalEndpointKey;
+	public double ActivationThreshold { get; protected set; }
+	public bool ActiveWhenAboveThreshold { get; protected set; }
+	public ExplosiveSignalActivationMode ActivationMode { get; protected set; }
+	public bool RequiresPower { get; protected set; }
+	public double PowerConsumptionInWatts { get; protected set; }
+	public bool CanBeDisarmed { get; protected set; }
+	public string ArmEmote { get; protected set; } = string.Empty;
+	public string DisarmEmote { get; protected set; } = string.Empty;
+
+	protected override void LoadFromXml(XElement root)
+	{
+		SourceComponentId = long.TryParse(root.Element("SourceComponentId")?.Value, out var sourceId) ? sourceId : 0L;
+		SourceComponentName = root.Element("SourceComponentName")?.Value ?? string.Empty;
+		SourceEndpointKey = SignalComponentUtilities.NormaliseSignalEndpointKey(root.Element("SourceEndpointKey")?.Value);
+		ActivationThreshold = double.TryParse(root.Element("ActivationThreshold")?.Value, out var threshold) &&
+		                      double.IsFinite(threshold) ? threshold : 0.5;
+		ActiveWhenAboveThreshold = bool.Parse(root.Element("ActiveWhenAboveThreshold")?.Value ?? "true");
+		ActivationMode = Enum.TryParse<ExplosiveSignalActivationMode>(root.Element("ActivationMode")?.Value, true,
+			out var mode) ? mode : ExplosiveSignalActivationMode.Edge;
+		RequiresPower = bool.Parse(root.Element("RequiresPower")?.Value ?? "true");
+		PowerConsumptionInWatts = double.TryParse(root.Element("PowerConsumptionInWatts")?.Value, out var watts) &&
+		                          double.IsFinite(watts) && watts >= 0.0 ? watts : 0.1;
+		CanBeDisarmed = bool.Parse(root.Element("CanBeDisarmed")?.Value ?? "true");
+		ArmEmote = root.Element("ArmEmote")?.Value ?? "@ arm|arms the signal detonator on $1.";
+		DisarmEmote = root.Element("DisarmEmote")?.Value ?? "@ disarm|disarms the signal detonator on $1.";
+	}
+
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition",
+			new XElement("SourceComponentId", SourceComponentId),
+			new XElement("SourceComponentName", new XCData(SourceComponentName)),
+			new XElement("SourceEndpointKey", new XCData(SourceEndpointKey)),
+			new XElement("ActivationThreshold", ActivationThreshold),
+			new XElement("ActiveWhenAboveThreshold", ActiveWhenAboveThreshold),
+			new XElement("ActivationMode", ActivationMode),
+			new XElement("RequiresPower", RequiresPower),
+			new XElement("PowerConsumptionInWatts", PowerConsumptionInWatts),
+			new XElement("CanBeDisarmed", CanBeDisarmed),
+			new XElement("ArmEmote", new XCData(ArmEmote)),
+			new XElement("DisarmEmote", new XCData(DisarmEmote))).ToString();
+	}
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "source": return BuildingCommandSource(actor, command);
+			case "threshold": return BuildingCommandThreshold(actor, command);
+			case "mode": return BuildingCommandMode(actor, command);
+			case "activation": return BuildingCommandActivation(actor, command);
+			case "power":
+			case "powered":
+				RequiresPower = !RequiresPower;
+				Changed = true;
+				actor.Send($"This signal detonator {(RequiresPower ? "now requires" : "no longer requires")} electrical power.");
+				return true;
+			case "watts":
+			case "wattage": return BuildingCommandWattage(actor, command);
+			case "disarmable":
+				CanBeDisarmed = !CanBeDisarmed;
+				Changed = true;
+				actor.Send($"This detonator is {(CanBeDisarmed ? "now" : "no longer")} disarmable once armed.");
+				return true;
+			case "armemote": return BuildingCommandEmote(actor, command, true);
+			case "disarmemote": return BuildingCommandEmote(actor, command, false);
+			default: return base.BuildingCommand(actor, command.GetUndo());
+		}
+	}
+
+	private bool BuildingCommandSource(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.Send("Which signal-source component prototype should drive this detonator?");
+			return false;
+		}
+		var identifier = command.PopSpeech();
+		if (!SignalComponentUtilities.TryResolveSignalComponentPrototype(Gameworld, identifier, out var prototype) ||
+		    prototype is not ISignalSourceComponentPrototype)
+		{
+			actor.Send("There is no such signal-source component prototype.");
+			return false;
+		}
+		SourceComponentId = prototype.Id;
+		SourceComponentName = prototype.Name;
+		SourceEndpointKey = SignalComponentUtilities.NormaliseSignalEndpointKey(
+			command.IsFinished ? null : command.PopSpeech());
+		Changed = true;
+		actor.Send($"This detonator now listens to {SourceComponentName.ColourName()} on the {SourceEndpointKey.ColourCommand()} endpoint.");
+		return true;
+	}
+
+	private bool BuildingCommandThreshold(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !double.TryParse(command.SafeRemainingArgument, out var value) ||
+		    !double.IsFinite(value))
+		{
+			actor.Send("What finite numeric threshold should activate this detonator?");
+			return false;
+		}
+		ActivationThreshold = value;
+		Changed = true;
+		actor.Send($"This detonator now uses a threshold of {value.ToString("N2", actor).ColourValue()}.");
+		return true;
+	}
+
+	private bool BuildingCommandMode(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.Send("Should this detonator activate above or below its threshold?");
+			return false;
+		}
+		switch (command.PopSpeech().ToLowerInvariant())
+		{
+			case "above":
+			case "high": ActiveWhenAboveThreshold = true; break;
+			case "below":
+			case "low": ActiveWhenAboveThreshold = false; break;
+			default:
+				actor.Send("You must specify either above or below.");
+				return false;
+		}
+		Changed = true;
+		actor.Send($"This detonator now activates {(ActiveWhenAboveThreshold ? "at or above" : "below")} its threshold.");
+		return true;
+	}
+
+	private bool BuildingCommandActivation(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !command.PopSpeech().TryParseEnum(out ExplosiveSignalActivationMode mode))
+		{
+			actor.Send("You must specify edge or level activation.");
+			return false;
+		}
+		ActivationMode = mode;
+		Changed = true;
+		actor.Send($"This detonator now uses {ActivationMode.DescribeEnum().ToLowerInvariant().ColourValue()} activation.");
+		return true;
+	}
+
+	private bool BuildingCommandWattage(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !double.TryParse(command.SafeRemainingArgument, out var value) ||
+		    !double.IsFinite(value) || value < 0.0)
+		{
+			actor.Send("How many non-negative watts should this detonator consume while armed?");
+			return false;
+		}
+		PowerConsumptionInWatts = value;
+		Changed = true;
+		actor.Send($"This detonator now consumes {value.ToString("N3", actor).ColourValue()} watts while armed.");
+		return true;
+	}
+
+	private bool BuildingCommandEmote(ICharacter actor, StringStack command, bool arming)
+	{
+		if (command.IsFinished)
+		{
+			actor.Send("You must specify an emote using @ for the actor and $1 for the explosive item.");
+			return false;
+		}
+		var emote = new Emote(command.SafeRemainingArgument, actor, actor, new DummyPerceivable());
+		if (!emote.Valid)
+		{
+			actor.Send(emote.ErrorMessage);
+			return false;
+		}
+		if (arming) ArmEmote = command.SafeRemainingArgument;
+		else DisarmEmote = command.SafeRemainingArgument;
+		Changed = true;
+		actor.Send($"The {(arming ? "arming" : "disarming")} emote is now {command.SafeRemainingArgument.ColourCommand()}.");
+		return true;
+	}
+
+	public override bool CanSubmit()
+	{
+		return SourceComponentId > 0 && double.IsFinite(ActivationThreshold) &&
+		       double.IsFinite(PowerConsumptionInWatts) && PowerConsumptionInWatts >= 0.0 && base.CanSubmit();
+	}
+
+	public override string WhyCannotSubmit()
+	{
+		if (SourceComponentId <= 0) return "You must select a signal-source component prototype.";
+		if (!double.IsFinite(ActivationThreshold)) return "The activation threshold must be finite.";
+		if (!double.IsFinite(PowerConsumptionInWatts) || PowerConsumptionInWatts < 0.0)
+			return "Power consumption must be a non-negative finite number.";
+		return base.WhyCannotSubmit();
+	}
+
+	private const string BuildingHelpText = @"You can use the following options with this component:
+	#3source <component> [<endpoint>]#0 - sets the signal source and endpoint
+	#3threshold <number>#0 - sets the activation threshold
+	#3mode <above|below>#0 - chooses which side of the threshold is active
+	#3activation <edge|level>#0 - chooses transition-only or active-level triggering
+	#3power#0 - toggles whether the armed detonator requires electrical power
+	#3watts <number>#0 - sets armed power consumption
+	#3disarmable#0 - toggles whether the armed detonator can be stopped
+	#3armemote <emote>#0 - sets the arming emote
+	#3disarmemote <emote>#0 - sets the disarming emote";
+
+	public override string ShowBuildingHelp => $"{base.ShowBuildingHelp}\n{BuildingHelpText}";
+
+	public override string ComponentDescriptionOLC(ICharacter actor)
+	{
+		return
+			$"{"Signal Detonator Item Component".ColourName()} (#{Id.ToString("N0", actor)}r{RevisionNumber.ToString("N0", actor)}, {Name})\n\nSource: {SignalComponentUtilities.DescribeSignalComponent(Gameworld, SourceComponentId, SourceComponentName, SourceEndpointKey).ColourName()}\nThreshold: {ActivationThreshold.ToString("N2", actor).ColourValue()} ({(ActiveWhenAboveThreshold ? "above" : "below")})\nActivation: {ActivationMode.DescribeEnum().ColourValue()}\nRequires Power: {RequiresPower.ToColouredString()}\nArmed Draw: {PowerConsumptionInWatts.ToString("N3", actor).ColourValue()} watts\nDisarmable: {CanBeDisarmed.ToColouredString()}\nArm Emote: {ArmEmote.ColourCommand()}\nDisarm Emote: {DisarmEmote.ColourCommand()}";
+	}
+
+	public static void RegisterComponentInitialiser(GameItemComponentManager manager)
+	{
+		manager.AddBuilderLoader("signaldetonator", true,
+			(gameworld, account) => new SignalDetonatorGameItemComponentProto(gameworld, account));
+		manager.AddBuilderLoader("signal detonator", false,
+			(gameworld, account) => new SignalDetonatorGameItemComponentProto(gameworld, account));
+		manager.AddDatabaseLoader("SignalDetonator",
+			(proto, gameworld) => new SignalDetonatorGameItemComponentProto(proto, gameworld));
+		manager.AddTypeHelpInfo("SignalDetonator",
+			$"An {SignalComponentUtilities.SignalConsumerTag} {"[armable]".Colour(Telnet.Yellow)} trigger for electronic or physical control signals",
+			BuildingHelpText);
+	}
+
+	public override IGameItemComponent CreateNew(IGameItem parent, ICharacter? loader = null, bool temporary = false)
+	{
+		return new SignalDetonatorGameItemComponent(this, parent, temporary);
+	}
+
+	public override IGameItemComponent LoadComponent(MudSharp.Models.GameItemComponent component, IGameItem parent)
+	{
+		return new SignalDetonatorGameItemComponent(component, this, parent);
+	}
+
+	public override IEditableRevisableItem CreateNewRevision(ICharacter initiator)
+	{
+		return CreateNewRevision(initiator,
+			(proto, gameworld) => new SignalDetonatorGameItemComponentProto(proto, gameworld));
+	}
+}


### PR DESCRIPTION
Adds countdown, clock, signal-input, and irreversible pin-pull explosive trigger components, shared arming interfaces and commands, radio-trigger integration, safety hardening, documentation, and regression coverage. Validation: full core unit suite (2,192 passed); MudSharpCore Debug build (0 warnings, 0 errors); git diff --check.