### PR TITLE
Harden Linux MudClient release ownership

### DIFF
--- a/MudClient/DEPLOYMENT.md
+++ b/MudClient/DEPLOYMENT.md
@@ -31,7 +31,7 @@ Linux additionally requires systemd, bash, curl, unzip, and Caddy v2 managed by 
 
 ## One-time migration and automated upgrades
 
-MudClient 1.2.0 is the first release with a safe upgrade layout. Its release files are immutable under `releases/<version>`; `current`, `web`, and `proxy` stay at stable paths so an upgrade does not alter Caddy, DNS, TLS, firewall, MUD, or database configuration. Operator settings are moved to `/etc/mudclient` on Linux and `%ProgramData%\FutureMUD\MudClient` on Windows.
+MudClient 1.2.0 is the first release with a safe upgrade layout. Its release files are immutable under `releases/<version>`; on Linux they remain root-owned and are not writable by the `mudclient` proxy account because root invokes the updater and verification tools from the active release. `current`, `web`, and `proxy` stay at stable paths so an upgrade does not alter Caddy, DNS, TLS, firewall, MUD, or database configuration. Operator settings are moved to `/etc/mudclient` on Linux and `%ProgramData%\FutureMUD\MudClient` on Windows.
 
 To migrate an existing 1.0.1 or 1.1.0 Linux installation, download and extract the 1.2.0 archive once, then run the installer with the original archive:
 

--- a/MudClient/deploy/linux/install-mudclient.sh
+++ b/MudClient/deploy/linux/install-mudclient.sh
@@ -93,7 +93,12 @@ chmod +x "$release/proxy/MudWebSocketProxy" "$release/tools/MudClientDeployment"
 if ! id -u mudclient >/dev/null 2>&1; then
 	useradd --system --home "$install_root" --shell /usr/sbin/nologin mudclient
 fi
-chown -R mudclient:mudclient "$install_root/releases" "$config_root/proxy"
+# Release scripts and verification tools are invoked by root during upgrades, so the
+# unprivileged proxy account must never be able to replace them.
+chown root:root "$install_root"
+chown -R root:root "$install_root/releases"
+chmod -R go-w "$install_root/releases"
+chown -R mudclient:mudclient "$config_root/proxy"
 install -m 0644 "$release/deploy/linux/mudclient-proxy.service" /etc/systemd/system/mudclient-proxy.service
 
 if [[ -n "$domain" ]]; then


### PR DESCRIPTION
### Motivation
- Prevent local privilege escalation where the unprivileged `mudclient` service account could modify release files that are later executed by a root-run updater, bypassing signed-manifest protections.

### Description
- Change `MudClient/deploy/linux/install-mudclient.sh` to keep the installation root and `releases/*` owned by `root:root` and remove group/other write bits from retained releases, while continuing to make only the proxy configuration (`/etc/mudclient/proxy`) owned by `mudclient`.
- Add a short clarification to `MudClient/DEPLOYMENT.md` documenting that on Linux retained release files remain root-owned and are not writable by the `mudclient` proxy account so the root-run verifier and updater are trusted.

### Testing
- Ran `bash -n MudClient/deploy/linux/install-mudclient.sh MudClient/deploy/linux/update-mudclient.sh` and the scripts parse with no syntax errors (succeeded).
- Ran `git diff --check` and basic repo checks to ensure no whitespace/patch problems (succeeded).
- Verified via `rg` that the installer no longer assigns `chown -R mudclient:mudclient "$install_root/releases"` and that `chown -R root:root "$install_root/releases"` and `chmod -R go-w "$install_root/releases"` are present (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71445e6f648323b0337cda11457d2a)