### PR TITLE
Let derived bodies replace movement gaits by position

### DIFF
--- a/DatabaseSeeder Unit Tests/MythicalAnimalSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/MythicalAnimalSeederTemplateTests.cs
@@ -977,7 +977,7 @@ public class MythicalAnimalSeederTemplateTests
         CollectionAssert.AreEquivalent(
             new[] { "stalk", "amble", "pace", "trot", "gallop" },
             MythicalAnimalSeeder.GetHybridMovementAliasesForTesting("Centaur").ToArray(),
-            "Centaurs should inherit quadruped gait options rather than only humanoid walking verbs.");
+            "Centaurs should own a quadruped gait set that replaces inherited humanoid standing speeds.");
         CollectionAssert.AreEquivalent(
             new[] { "slowfly", "fly", "franticfly" },
             MythicalAnimalSeeder.GetHybridMovementAliasesForTesting("Eastern Dragon").ToArray(),

--- a/Design Documents/Health/Health_Core_Runtime.md
+++ b/Design Documents/Health/Health_Core_Runtime.md
@@ -55,8 +55,6 @@ Stock seeded body layouts now use two distinct patterns:
 - additive `CountsAs` layering when a derived body should inherit all parent anatomy unchanged
 - flattened cloned anatomy when a seeder-built variant needs to remove, replace, or reroute parent bodyparts and limbs
 
-Movement speeds use position-specific replacement within additive layering. If a derived body defines one or more speeds for a position, those local speeds are the complete effective set for that position; speeds for positions with no local definitions continue to inherit through `CountsAs`. This lets a derived body replace standing gaits while retaining inherited anatomy and movement modes such as crawling or swimming.
-
 That flattening step must copy the full ancestor chain's bodyparts, organ relationships, limb definitions, and movement data into the concrete body prototype so every external bodypart still resolves to a limb at runtime.
 Direct cloned bodies also need to preserve bodypart upstream links so later subtree removals in hybrid seed templates delete the full branch rather than leaving uncovered descendants behind.
 - default health strategy

--- a/Design Documents/Health/Health_Core_Runtime.md
+++ b/Design Documents/Health/Health_Core_Runtime.md
@@ -55,6 +55,8 @@ Stock seeded body layouts now use two distinct patterns:
 - additive `CountsAs` layering when a derived body should inherit all parent anatomy unchanged
 - flattened cloned anatomy when a seeder-built variant needs to remove, replace, or reroute parent bodyparts and limbs
 
+Movement speeds use position-specific replacement within additive layering. If a derived body defines one or more speeds for a position, those local speeds are the complete effective set for that position; speeds for positions with no local definitions continue to inherit through `CountsAs`. This lets a derived body replace standing gaits while retaining inherited anatomy and movement modes such as crawling or swimming.
+
 That flattening step must copy the full ancestor chain's bodyparts, organ relationships, limb definitions, and movement data into the concrete body prototype so every external bodypart still resolves to a limb at runtime.
 Direct cloned bodies also need to preserve bodypart upstream links so later subtree removals in hybrid seed templates delete the full branch rather than leaving uncovered descendants behind.
 - default health strategy

--- a/Design Documents/World/Position_State_System.md
+++ b/Design Documents/World/Position_State_System.md
@@ -65,6 +65,12 @@ Current registered IDs:
 
 `BodyPrototype` loads valid positions from `BodyProtosPositions`. If an older prototype has no position rows, it falls back to a broad default set. Move speeds load from `MoveSpeeds` and point to a position ID. `Body.CurrentSpeeds` is then keyed by `IPositionState`, so a body can only move in positions for which it has speed rows.
 
+### Derived Body Speed Inheritance
+
+`CountsAs` inherits the parent body's effective movement speeds only for positions that the derived body does not define locally. Defining one or more local speeds for a position replaces the entire inherited set for that position; it does not add another selectable gait alongside the parent speeds. Other positions continue to inherit normally.
+
+This makes position-specific speed rows an intentional override boundary. A centaur, for example, owns its standing quadruped gait set and does not inherit humanoid standing speeds, while it can still inherit the humanoid climbing, swimming, and other unmodified movement modes. Seeders and future body-editing tools must define the complete desired set whenever they override a position.
+
 The zero-gravity bootstrap path ensures every body prototype has a zero-gravity floating move speed, copying flying, standing, or any available speed as a template.
 
 ## Command Flow

--- a/MudSharpCore Unit Tests/BodyPrototypeMovementSpeedTests.cs
+++ b/MudSharpCore Unit Tests/BodyPrototypeMovementSpeedTests.cs
@@ -68,6 +68,80 @@ public class BodyPrototypeMovementSpeedTests
 				.ToArray());
 	}
 
+	[TestMethod]
+	public void Constructor_LocalSpeedsReplaceEffectiveGrandparentSpeedsForTheSamePosition()
+	{
+		var grandparentSpeeds = new All<IMoveSpeed>();
+		grandparentSpeeds.Add(Speed(1, "stroll", PositionStanding.Instance.Id, 2.0));
+		grandparentSpeeds.Add(Speed(2, "walk", PositionStanding.Instance.Id, 1.0));
+		grandparentSpeeds.Add(Speed(3, "jog", PositionStanding.Instance.Id, 0.75));
+		grandparentSpeeds.Add(Speed(4, "run", PositionStanding.Instance.Id, 0.5));
+		grandparentSpeeds.Add(Speed(5, "sprint", PositionStanding.Instance.Id, 0.33));
+		grandparentSpeeds.Add(Speed(6, "crawl", PositionProne.Instance.Id, 5.0));
+		grandparentSpeeds.Add(Speed(7, "float", PositionFloatingInZeroGravity.Instance.Id, 1.0));
+
+		var grandparent = new Mock<IBodyPrototype>();
+		grandparent.SetupGet(x => x.Id).Returns(1);
+		grandparent.SetupGet(x => x.Name).Returns("Humanoid");
+		grandparent.SetupGet(x => x.FrameworkItemType).Returns("BodyPrototype");
+		grandparent.SetupGet(x => x.Speeds).Returns(grandparentSpeeds);
+
+		var bodies = new All<IBodyPrototype>();
+		bodies.Add(grandparent.Object);
+		var progs = new All<IFutureProg>();
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.BodyPrototypes).Returns(bodies);
+		gameworld.SetupGet(x => x.FutureProgs).Returns(progs);
+
+		var parentModel = new BodyProto
+		{
+			Id = 2,
+			Name = "Organic Humanoid",
+			CountsAsId = grandparent.Object.Id,
+			WearSizeParameter = WearRules(),
+			PlanarData = string.Empty
+		};
+		parentModel.BodyProtosPositions.Add(new BodyProtosPositions { Position = (int)PositionStanding.Instance.Id });
+		var parent = new BodyPrototype(parentModel, gameworld.Object);
+		bodies.Add(parent);
+
+		var childModel = new BodyProto
+		{
+			Id = 3,
+			Name = "Centaur",
+			CountsAsId = parent.Id,
+			WearSizeParameter = WearRules(),
+			PlanarData = string.Empty
+		};
+		childModel.BodyProtosPositions.Add(new BodyProtosPositions { Position = (int)PositionStanding.Instance.Id });
+		childModel.MoveSpeeds.Add(ModelSpeed(10, "stalk", PositionStanding.Instance.Id, 2.0));
+		childModel.MoveSpeeds.Add(ModelSpeed(11, "amble", PositionStanding.Instance.Id, 0.8));
+		childModel.MoveSpeeds.Add(ModelSpeed(12, "pace", PositionStanding.Instance.Id, 0.6));
+		childModel.MoveSpeeds.Add(ModelSpeed(13, "trot", PositionStanding.Instance.Id, 0.4));
+		childModel.MoveSpeeds.Add(ModelSpeed(14, "gallop", PositionStanding.Instance.Id, 0.2));
+
+		var child = new BodyPrototype(childModel, gameworld.Object);
+
+		CollectionAssert.AreEquivalent(
+			new[] { "stalk", "amble", "pace", "trot", "gallop" },
+			child.Speeds
+				.Where(x => x.Position == PositionStanding.Instance)
+				.Select(x => x.Name)
+				.ToArray());
+		CollectionAssert.AreEquivalent(
+			new[] { "crawl", "float" },
+			child.Speeds
+				.Where(x => x.Position != PositionStanding.Instance)
+				.Select(x => x.Name)
+				.ToArray());
+		CollectionAssert.AreEquivalent(
+			new[] { "stroll", "walk", "jog", "run", "sprint" },
+			parent.Speeds
+				.Where(x => x.Position == PositionStanding.Instance)
+				.Select(x => x.Name)
+				.ToArray());
+	}
+
 	private static (BodyPrototype Prototype, IBodyPrototype Parent, IBodypart InheritedBodypart) LoadDerivedPrototype()
 	{
 		var parentSpeeds = new All<IMoveSpeed>();

--- a/MudSharpCore Unit Tests/BodyPrototypeMovementSpeedTests.cs
+++ b/MudSharpCore Unit Tests/BodyPrototypeMovementSpeedTests.cs
@@ -1,0 +1,143 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Body;
+using MudSharp.Body.Implementations;
+using MudSharp.Body.Position;
+using MudSharp.Body.Position.PositionStates;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.Models;
+using MudSharp.Movement;
+using System.Linq;
+using MoveSpeed = MudSharp.Movement.MoveSpeed;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class BodyPrototypeMovementSpeedTests
+{
+	[ClassInitialize]
+	public static void Initialise(TestContext _)
+	{
+		PositionState.SetupPositions();
+	}
+
+	[TestMethod]
+	public void Constructor_LocalSpeedsReplaceInheritedSpeedsForTheSamePosition()
+	{
+		var (prototype, parent, inheritedBodypart) = LoadDerivedPrototype();
+
+		CollectionAssert.AreEqual(
+			new[] { "shamble" },
+			prototype.Speeds
+				.Where(x => x.Position == PositionStanding.Instance)
+				.Select(x => x.Name)
+				.ToArray());
+		Assert.AreEqual("shamble", prototype.Speeds
+			.Where(x => x.Position == PositionStanding.Instance)
+			.OrderBy(x => x.Multiplier)
+			.First().Name);
+		CollectionAssert.AreEquivalent(
+			new[] { "crawl", "float" },
+			prototype.Speeds
+				.Where(x => x.Position != PositionStanding.Instance)
+				.Select(x => x.Name)
+				.ToArray());
+		Assert.IsTrue(prototype.AllBodyparts.Contains(inheritedBodypart));
+		CollectionAssert.AreEquivalent(
+			new[] { "sprint", "walk", "crawl", "float" },
+			parent.Speeds.Select(x => x.Name).ToArray());
+	}
+
+	[TestMethod]
+	public void Constructor_ReloadPreservesPositionSpecificSpeedReplacement()
+	{
+		var first = LoadDerivedPrototype().Prototype;
+		var reloaded = LoadDerivedPrototype().Prototype;
+
+		CollectionAssert.AreEqual(
+			first.Speeds.Select(x => x.Id).OrderBy(x => x).ToArray(),
+			reloaded.Speeds.Select(x => x.Id).OrderBy(x => x).ToArray());
+		CollectionAssert.AreEqual(
+			new long[] { 10 },
+			reloaded.Speeds
+				.Where(x => x.Position == PositionStanding.Instance)
+				.Select(x => x.Id)
+				.ToArray());
+	}
+
+	private static (BodyPrototype Prototype, IBodyPrototype Parent, IBodypart InheritedBodypart) LoadDerivedPrototype()
+	{
+		var parentSpeeds = new All<IMoveSpeed>();
+		parentSpeeds.Add(Speed(1, "sprint", PositionStanding.Instance.Id, 0.33));
+		parentSpeeds.Add(Speed(2, "walk", PositionStanding.Instance.Id, 1.0));
+		parentSpeeds.Add(Speed(3, "crawl", PositionProne.Instance.Id, 5.0));
+		parentSpeeds.Add(Speed(4, "float", PositionFloatingInZeroGravity.Instance.Id, 1.0));
+
+		var inheritedBodypart = new Mock<IBodypart>().Object;
+		var parent = new Mock<IBodyPrototype>();
+		parent.SetupGet(x => x.Id).Returns(1);
+		parent.SetupGet(x => x.Name).Returns("Parent");
+		parent.SetupGet(x => x.FrameworkItemType).Returns("BodyPrototype");
+		parent.SetupGet(x => x.Speeds).Returns(parentSpeeds);
+		parent.SetupGet(x => x.AllBodyparts).Returns(new[] { inheritedBodypart });
+
+		var bodies = new All<IBodyPrototype>();
+		bodies.Add(parent.Object);
+		var progs = new All<IFutureProg>();
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.BodyPrototypes).Returns(bodies);
+		gameworld.SetupGet(x => x.FutureProgs).Returns(progs);
+
+		var model = new BodyProto
+		{
+			Id = 2,
+			Name = "Derived",
+			CountsAsId = 1,
+			WearSizeParameter = WearRules(),
+			PlanarData = string.Empty
+		};
+		model.BodyProtosPositions.Add(new BodyProtosPositions { Position = (int)PositionStanding.Instance.Id });
+		model.MoveSpeeds.Add(ModelSpeed(10, "shamble", PositionStanding.Instance.Id, 3.0));
+
+		return (new BodyPrototype(model, gameworld.Object), parent.Object, inheritedBodypart);
+	}
+
+	private static IMoveSpeed Speed(long id, string alias, long positionId, double multiplier)
+	{
+		return new MoveSpeed(ModelSpeed(id, alias, positionId, multiplier));
+	}
+
+	private static MudSharp.Models.MoveSpeed ModelSpeed(long id, string alias, long positionId, double multiplier)
+	{
+		return new MudSharp.Models.MoveSpeed
+		{
+			Id = id,
+			Alias = alias,
+			PositionId = positionId,
+			Multiplier = multiplier,
+			StaminaMultiplier = 1.0,
+			FirstPersonVerb = alias,
+			ThirdPersonVerb = $"{alias}s",
+			PresentParticiple = $"{alias}ing"
+		};
+	}
+
+	private static WearableSizeParameterRule WearRules()
+	{
+		const string ratios = "<Ratios><Ratio Item=\"2\" Min=\"0\" Max=\"1000\" /></Ratios>";
+		return new WearableSizeParameterRule
+		{
+			IgnoreTrait = true,
+			MinHeightFactor = 0.5,
+			MaxHeightFactor = 2.0,
+			MinWeightFactor = 0.5,
+			MaxWeightFactor = 2.0,
+			WeightVolumeRatios = ratios,
+			TraitVolumeRatios = ratios,
+			HeightLinearRatios = ratios
+		};
+	}
+}

--- a/MudSharpCore/Body/Implementations/BodyPrototype.cs
+++ b/MudSharpCore/Body/Implementations/BodyPrototype.cs
@@ -108,9 +108,10 @@ public class BodyPrototype : SaveableItem, IBodyPrototype
         IBodyPrototype parent = Gameworld.BodyPrototypes.Get(_countsAsId ?? 0);
         if (parent != null)
         {
+            var locallyDefinedPositions = _speeds.Select(x => x.Position).ToHashSet();
             foreach (IMoveSpeed speed in parent.Speeds)
             {
-                if (!_speeds.Has(speed))
+                if (!locallyDefinedPositions.Contains(speed.Position) && !_speeds.Has(speed))
                 {
                     _speeds.Add(speed);
                 }


### PR DESCRIPTION
## What changed

- Treat a derived body's locally defined movement speeds as the complete effective set for that position.
- Continue inheriting movement speeds for positions the derived body does not define.
- Add focused constructor and reload regressions covering restricted child gaits, retained parent gaits, inherited anatomy, fastest-speed selection, and persistence.
- Document the position-specific replacement rule.

## Why

`BodyPrototype` previously appended every speed from its `CountsAs` parent. A derived body could add a specialised gait, but could not prevent faster parent gaits for the same position from remaining effective. Any consumer selecting the fastest available gait would therefore ignore the derived body's intended restriction.

Applying the rule at the effective speed collection keeps all movement consumers consistent without special cases or selector-specific filtering.

## Impact

Derived bodies can replace standing, prone, swimming, or other position-specific gait sets while retaining inherited anatomy and movement modes for every unmodified position. Parent bodies are unchanged.

## Validation

- Focused `BodyPrototypeMovementSpeedTests`: 2 passed.
- Complete `MudSharpCore Unit Tests`: 2,226 passed, 0 failed, 0 skipped.
- `git diff --check`: passed.
