### PR TITLE
Harden hook dispatch against recursive crashes

### DIFF
--- a/Design Documents/AI/Event_System_for_AI_and_Hooks.md
+++ b/Design Documents/AI/Event_System_for_AI_and_Hooks.md
@@ -200,7 +200,7 @@ AI events do not block ordinary hooks from firing. The NPC still delegates to it
 
 FutureProg also provides `emitnoise(source, volume, type, echo)`. The source must be a located character or item; the echo uses `{0}` for direction and may use `{1}` for the attenuated volume. This lets an action hook declare that a builder-defined action made noise while receiving normal audio propagation and the same single origin event as native emitters.
 
-The intent is to support content-authored reactions through hooks and progs. A game can, for example, attach a `NoiseEmitted` hook to cells and use its prog to make zombies investigate the source or to update a zone-wide noise register. Those policies remain game content rather than engine behavior. A `NoiseEmitted` handler must not call `emitnoise` for the same sound, because doing so recursively emits another event.
+The intent is to support content-authored reactions through hooks and progs. A game can, for example, attach a `NoiseEmitted` hook to cells and use its prog to make zombies investigate the source or to update a zone-wide noise register. Those policies remain game content rather than engine behavior. Hook dispatch suppresses re-entry of the same installed hook on the same target within one synchronous dispatch chain, so a `NoiseEmitted` handler can safely call `emitnoise`: the nested sound still propagates, other hooks can react, and the same hook can still run on a different target, but the active hook does not recurse on its original target.
 
 ### Hook Dispatch
 Hooks are installed on event-capable perceivables. When those perceivables process an event, installed hooks of the matching type are eligible to run.

--- a/MudSharpCore Unit Tests/NoiseEmissionTests.cs
+++ b/MudSharpCore Unit Tests/NoiseEmissionTests.cs
@@ -1,16 +1,21 @@
 #nullable enable
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Events;
+using MudSharp.Events.Hooks;
 using MudSharp.Form.Audio;
 using MudSharp.Framework;
 using MudSharp.FutureProg;
 using MudSharp.FutureProg.Functions;
 using MudSharp.FutureProg.Variables;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
 
 namespace MudSharp_Unit_Tests;
 
@@ -98,5 +103,148 @@ public class NoiseEmissionTests
 			RoomLayer.GroundLevel,
 			true,
 			"impact"), Times.Once);
+	}
+
+	[TestMethod]
+	public void HandleEvent_SelfRecursiveHook_ExecutesOnlyOnce()
+	{
+		var target = new TestPerceivedItem(1);
+		var calls = 0;
+		var hook = CreateHook(EventType.NoiseEmitted, (type, arguments) =>
+		{
+			calls++;
+			target.HandleEvent(type, arguments);
+			return true;
+		});
+		target.InstallHook(hook.Object);
+
+		target.HandleEvent(EventType.NoiseEmitted, target);
+
+		Assert.AreEqual(1, calls);
+	}
+
+	[TestMethod]
+	public void HandleEvent_MutuallyRecursiveHooks_ExecuteOnceEach()
+	{
+		var target = new TestPerceivedItem(1);
+		var firstCalls = 0;
+		var secondCalls = 0;
+		var first = CreateHook(EventType.NoiseEmitted, (type, arguments) =>
+		{
+			firstCalls++;
+			target.HandleEvent(type, arguments);
+			return true;
+		});
+		var second = CreateHook(EventType.NoiseEmitted, (type, arguments) =>
+		{
+			secondCalls++;
+			target.HandleEvent(type, arguments);
+			return true;
+		});
+		target.InstallHook(first.Object);
+		target.InstallHook(second.Object);
+
+		target.HandleEvent(EventType.NoiseEmitted, target);
+
+		Assert.AreEqual(1, firstCalls);
+		Assert.AreEqual(1, secondCalls);
+	}
+
+	[TestMethod]
+	public void HandleEvent_SameHookOnDifferentTargets_CanRunReentrantly()
+	{
+		var firstTarget = new TestPerceivedItem(1);
+		var secondTarget = new TestPerceivedItem(2);
+		var calls = 0;
+		var hook = CreateHook(EventType.NoiseEmitted, (type, arguments) =>
+		{
+			calls++;
+			if (ReferenceEquals(arguments[0], firstTarget))
+			{
+				secondTarget.HandleEvent(type, secondTarget);
+			}
+
+			return true;
+		});
+		firstTarget.InstallHook(hook.Object);
+		secondTarget.InstallHook(hook.Object);
+
+		firstTarget.HandleEvent(EventType.NoiseEmitted, firstTarget);
+
+		Assert.AreEqual(2, calls);
+	}
+
+	[TestMethod]
+	public void HandleEvent_SequentialHookCalls_ExecuteEachTime()
+	{
+		var target = new TestPerceivedItem(1);
+		var calls = 0;
+		var hook = CreateHook(EventType.NoiseEmitted, (_, _) =>
+		{
+			calls++;
+			return true;
+		});
+		target.InstallHook(hook.Object);
+
+		target.HandleEvent(EventType.NoiseEmitted, target);
+		target.HandleEvent(EventType.NoiseEmitted, target);
+
+		Assert.AreEqual(2, calls);
+	}
+
+	[TestMethod]
+	public void HandleEvent_ThrowingHook_ReleasesReentrancyGuard()
+	{
+		var target = new TestPerceivedItem(1);
+		var calls = 0;
+		var hook = CreateHook(EventType.NoiseEmitted, (_, _) =>
+		{
+			calls++;
+			if (calls == 1)
+			{
+				throw new InvalidOperationException();
+			}
+
+			return true;
+		});
+		target.InstallHook(hook.Object);
+
+		Assert.ThrowsException<InvalidOperationException>(() => target.HandleEvent(EventType.NoiseEmitted, target));
+		target.HandleEvent(EventType.NoiseEmitted, target);
+
+		Assert.AreEqual(2, calls);
+	}
+
+	private static Mock<IHook> CreateHook(EventType type, Func<EventType, object[], bool> function)
+	{
+		var hook = new Mock<IHook>();
+		hook.SetupGet(x => x.Type).Returns(type);
+		hook.SetupGet(x => x.Function).Returns(function);
+		return hook;
+	}
+
+	private sealed class TestPerceivedItem : PerceivedItem
+	{
+		public TestPerceivedItem(long id) : base(id)
+		{
+			_name = $"test item {id}";
+			_keywords = new Lazy<List<string>>(() => ["test", "item"]);
+		}
+
+		public override string FrameworkItemType => "TestPerceivedItem";
+		public override ProgVariableTypes Type => ProgVariableTypes.Perceivable;
+
+		public override void Register(IOutputHandler handler)
+		{
+		}
+
+		public override object DatabaseInsert()
+		{
+			return this;
+		}
+
+		public override void SetIDFromDatabase(object dbitem)
+		{
+		}
 	}
 }

--- a/MudSharpCore/Framework/PerceivedItem.cs
+++ b/MudSharpCore/Framework/PerceivedItem.cs
@@ -25,7 +25,7 @@ public abstract class PerceivedItem : LateKeywordedInitialisingItem, IPerceivabl
 
     protected PerceivedItem()
     {
-        _hookedFunctions = _installedHooks.ToLookup(x => x.Type, x => x.Function);
+		_hookedFunctions = _installedHooks.ToLookup(x => x.Type, x => new HookFunction(x, x.Function));
         EffectHandler = new EffectHandler(this);
     }
 
@@ -868,8 +868,11 @@ public abstract class PerceivedItem : LateKeywordedInitialisingItem, IPerceivabl
         }
     }
 
+	protected readonly record struct HookFunction(IHook Hook, Func<EventType, object[], bool> Function);
+
     protected readonly List<IHook> _installedHooks = new();
-    protected ILookup<EventType, Func<EventType, object[], bool>> _hookedFunctions;
+	protected ILookup<EventType, HookFunction> _hookedFunctions;
+	[ThreadStatic] private static Dictionary<PerceivedItem, HashSet<IHook>> _activeHookDispatches;
 	private IProximityEventRegistration _proximityHookRegistration;
 
     public IEnumerable<IHook> Hooks => _installedHooks;
@@ -883,8 +886,36 @@ public abstract class PerceivedItem : LateKeywordedInitialisingItem, IPerceivabl
         }
 
         // Hooks cannot have exclusive "right to fire". Even if one hook handles the event, we want others to keep handling it.
-        return truth || _hookedFunctions[type].Select(x => x(type, arguments)).Any(x => x);
+        return truth || _hookedFunctions[type].Select(x => ExecuteHook(x, type, arguments)).Any(x => x);
     }
+
+	private bool ExecuteHook(HookFunction hook, EventType type, object[] arguments)
+	{
+		_activeHookDispatches ??= new Dictionary<PerceivedItem, HashSet<IHook>>(ReferenceEqualityComparer.Instance);
+		if (!_activeHookDispatches.TryGetValue(this, out var activeHooks))
+		{
+			activeHooks = new HashSet<IHook>(ReferenceEqualityComparer.Instance);
+			_activeHookDispatches[this] = activeHooks;
+		}
+
+		if (!activeHooks.Add(hook.Hook))
+		{
+			return false;
+		}
+
+		try
+		{
+			return hook.Function(type, arguments);
+		}
+		finally
+		{
+			activeHooks.Remove(hook.Hook);
+			if (activeHooks.Count == 0)
+			{
+				_activeHookDispatches.Remove(this);
+			}
+		}
+	}
 
     public virtual bool HandlesEvent(params EventType[] types)
     {
@@ -927,7 +958,7 @@ public abstract class PerceivedItem : LateKeywordedInitialisingItem, IPerceivabl
         }
 
         _installedHooks.Add(hook);
-        _hookedFunctions = _installedHooks.ToLookup(x => x.Type, x => x.Function);
+		_hookedFunctions = _installedHooks.ToLookup(x => x.Type, x => new HookFunction(x, x.Function));
 		if (hook.Type == EventType.PerceivableProximityChanged)
 		{
 			_proximityHookRegistration ??= Gameworld?.ProximityEventService?.Register(this);
@@ -969,7 +1000,7 @@ public abstract class PerceivedItem : LateKeywordedInitialisingItem, IPerceivabl
         }
 
         _installedHooks.Remove(hook);
-        _hookedFunctions = _installedHooks.ToLookup(x => x.Type, x => x.Function);
+		_hookedFunctions = _installedHooks.ToLookup(x => x.Type, x => new HookFunction(x, x.Function));
 		if (hook.Type == EventType.PerceivableProximityChanged &&
 			!_installedHooks.Any(x => x.Type == EventType.PerceivableProximityChanged))
 		{


### PR DESCRIPTION
## Summary
- prevent the same installed hook from re-entering on the same target during synchronous dispatch
- cover self-recursive, mutual, cross-target, sequential, and exception-cleanup behavior
- document the hook re-entrancy rule for NoiseEmitted and emitnoise

## Validation
- dotnet build MudSharpCore/MudSharpCore.csproj -c Debug --no-restore -m:1
- focused NoiseEmissionTests and FutureProgRuntimePerformanceTests: 19 passed
- MudSharpCore Unit Tests: 2,229 passed
- git diff --check