### PR TITLE
Prevent multitarget weapon attack crash on incompatible targets

### DIFF
--- a/Design Documents/Combat/Multi_Target_Combat_Attacks.md
+++ b/Design Documents/Combat/Multi_Target_Combat_Attacks.md
@@ -29,7 +29,7 @@ Auxiliary actions use `auxiliary set targets <1-100>`. Setting the value to `1` 
 
 ## Target Eligibility
 
-The explicitly selected target is always first. Additional targets must be hostile characters in the same combat, must pass the attack or auxiliary usability prog for that victim, and must not be allies of the assailant.
+The explicitly selected target is always first. Additional targets must be hostile characters in the same combat, must pass the same target-specific attack eligibility as the primary victim (including authored bodypart-shape requirements), and must not be allies of the assailant. Auxiliary actions evaluate their usability prog for each victim.
 
 For ordinary melee weapon, natural, and auxiliary moves, an additional victim must:
 

--- a/MudSharpCore Unit Tests/MultiTargetCombatMoveTests.cs
+++ b/MudSharpCore Unit Tests/MultiTargetCombatMoveTests.cs
@@ -8,6 +8,7 @@ using MudSharp.Combat;
 using MudSharp.Combat.Moves;
 using MudSharp.Construction;
 using MudSharp.Framework;
+using MudSharp.GameItems;
 using MudSharp.RPG.Checks;
 using System.Collections.Generic;
 using System.Linq;
@@ -40,6 +41,40 @@ public class MultiTargetCombatMoveTests
 			_ => singleMove.Object);
 
 		Assert.AreSame(singleMove.Object, move);
+	}
+
+	[TestMethod]
+	public void WrapWeaponAttack_TargetFailsTargetSpecificUsability_DoesNotAddSecondaryTarget()
+	{
+		Mock<ICombat> combat = new();
+		Mock<ICharacter> assailant = new();
+		Mock<ICharacter> primary = new();
+		Mock<ICharacter> secondary = new();
+		Mock<IWeaponAttack> attack = new();
+		Mock<IGameItem> weapon = new();
+		Mock<ICombatMove> primaryMove = new();
+
+		assailant.SetupGet(x => x.Combat).Returns(combat.Object);
+		assailant.Setup(x => x.ColocatedWith(secondary.Object)).Returns(true);
+		assailant.Setup(x => x.IsAlly(It.IsAny<ICharacter>())).Returns(false);
+		primary.SetupGet(x => x.Combat).Returns(combat.Object);
+		secondary.SetupGet(x => x.Combat).Returns(combat.Object);
+		secondary.SetupGet(x => x.CombatTarget).Returns(assailant.Object);
+		secondary.SetupGet(x => x.MeleeRange).Returns(true);
+		attack.SetupGet(x => x.MoveType).Returns(BuiltInCombatMoveType.UseWeaponAttack);
+		attack.SetupGet(x => x.MaximumTargets).Returns(2);
+		attack.Setup(x => x.UsableAttack(assailant.Object, weapon.Object, secondary.Object,
+				AttackHandednessOptions.Any, true, BuiltInCombatMoveType.UseWeaponAttack))
+		      .Returns(false);
+		combat.SetupGet(x => x.Combatants)
+		      .Returns(new IPerceiver[] { assailant.Object, primary.Object, secondary.Object });
+
+		var move = MultiTargetCombatMove.WrapWeaponAttack(assailant.Object, primary.Object, attack.Object,
+			weapon.Object, _ => primaryMove.Object);
+
+		Assert.AreSame(primaryMove.Object, move);
+		attack.Verify(x => x.UsableAttack(assailant.Object, weapon.Object, secondary.Object,
+			AttackHandednessOptions.Any, true, BuiltInCombatMoveType.UseWeaponAttack), Times.Once);
 	}
 
 	[TestMethod]

--- a/MudSharpCore/Combat/Moves/MultiTargetCombatMove.cs
+++ b/MudSharpCore/Combat/Moves/MultiTargetCombatMove.cs
@@ -102,7 +102,8 @@ public class MultiTargetCombatMove : CombatMoveBase
 		}
 
 		var targets = SelectTargets(assailant, primaryTarget, attack.MaximumTargets, IsRangedAttack(attack), attack,
-			candidate => attack.UsabilityProg?.ExecuteBool(assailant, weapon, candidate) ?? true)
+			candidate => attack.UsableAttack(assailant, weapon, candidate, AttackHandednessOptions.Any, true,
+				attack.MoveType))
 			.ToList();
 		if (targets.Count == 1)
 		{


### PR DESCRIPTION
## Summary
- apply target-aware weapon attack eligibility to every secondary multi-target victim
- prevent authored bodypart-shape attacks from creating moves against incompatible targets
- add regression coverage and update the multi-target combat design note

## Validation
- `dotnet build MudSharpCore\\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:UseSharedCompilation=false -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'MudSharpCore Unit Tests\\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 --filter FullyQualifiedName~MultiTargetCombatMoveTests -p:UseSharedCompilation=false -p:NoWarn=NU1902%3BNU1510` (9 passed)
- `dotnet test 'MudSharpCore Unit Tests\\MudSharpCore Unit Tests.csproj' -c Debug --no-build -m:1 --filter FullyQualifiedName~WeaponAttackTargetingTests -p:NoWarn=NU1902%3BNU1510` (1 passed)
- `git diff --check`