### PR TITLE
Improve trap spell and builder workflows

### DIFF
--- a/Design Documents/Core/Trap_System.md
+++ b/Design Documents/Core/Trap_System.md
@@ -9,7 +9,7 @@ Version 1 uses a gated domain model:
 | Domain | Anchor | Intended fiction | Prohibited v1 hybrid |
 |---|---|---|---|
 | Mechanical | Item or cell | Tripwires, pressure plates, trapped containers, bear traps, automation | Mechanical template plus magical payload |
-| Magical | Item or cell | Glyphs, wards, delayed spell effects | Spell template plus mechanical payload |
+| Magical | Item, cell, or exit side | Glyphs, wards, delayed spell effects | Spell template plus mechanical payload |
 | Natural | Cell, item, or NPC-created anchor | Spider webs, burrow snares, environmental hazards | Natural template plus foreign payload |
 
 An item may anchor a magical or natural trap, but its template still has exactly one domain. This avoids ambiguous costs, detection rules, law attribution, and builder support. Cross-domain combinations can be introduced later as a deliberate composite feature.
@@ -24,7 +24,7 @@ Version 1 therefore permits broad reuse within a domain but gates combinations a
 
 Mechanical traps use existing items and cells rather than a Trap game-item component. Every mechanical template declares at least one tagged trigger component and one tagged payload component. A single requirement may be both roles, and one item carrying two applicable tags may satisfy separate trigger and payload requirements; this is the bear-trap case. The requirement also configures spent recovery chance and quality weight. IDetonatable and existing automation components are still required for detonation and owner-routed signal payloads. A character may install parts they are holding or loose parts in the current cell; held/wielded matches are selected before room matches. Every selected part must pass the normal manipulation/access gate, held parts must also be removable from the character's inventory, and both checks are repeated when timed setup completes. Successful placement extracts non-anchor components from their former inventory or cell collection and gives their reservation effect the trap anchor as an effective spatial host. They therefore cease to be loose targetable objects while their effective `Location`, `TrueLocations`, layer, and RouteCell position continue to resolve through the trap for explosions, signals, and other spatial behavior; the component remains its own `LocationLevelPerceivable` so layer-sensitive payload code uses that effective context. The captured install layer and RouteCell coordinate are persisted with the trap binding so this remains stable across reboot. Removal restores extant components at the captured anchor position before releasing their reservations. Contained items, worn items, and items in another character's inventory are not eligible. This keeps crafting free to produce ordinary physical items while making the actual parts, their quality, their authorization, and their fate explicit.
 
-Magical traps are authored as magical templates, then placed by the createtrap/placetrap magic spell effect. Their payload can resolve another prepared spell. removetrap/dispeltrap is the corresponding magical countermeasure. This keeps casting costs with placement and makes dispelling a clear, configurable interaction rather than an item-only disarm exception.
+Magical traps are authored as magical templates, then placed by the createtrap/placetrap magic spell effect. An `exit` spell trigger creates the trap on the selected origin-side exit binding, rather than on the underlying shared exit object, so it responds only to traversal in that direction. Their payload can resolve another prepared spell. removetrap/dispeltrap is the corresponding magical countermeasure. This keeps casting costs with placement and makes dispelling a clear, configurable interaction rather than an item-only disarm exception.
 
 Natural hazards use the same template/effect model. NaturalTrap AI gives an NPC a current natural template plus enabled/site FutureProgs; on its minute tick it anchors a proximity hazard to that NPC and other hazards to the suitable current cell. FutureProg createtrap is the complementary option for scripted world events. These approaches are preferred to a special spider-web object because they preserve the same detection, persistence, layer, restraint, and payload rules as all other traps.
 
@@ -84,7 +84,7 @@ New check types are SetTrapCheck, SpotTrapCheck, SearchForTrapCheck, AvoidTrapCh
 
 The default seeder setup uses a dedicated Traps skill, while individual templates may use difficulty and FutureProg filters to model specialist domains. Existing Spot, Search, Survival, and magic traits remain valid template/campaign overrides.
 
-Disarm policy is Impossible, Safe, Risky, or Dispellable. Risky failure manually triggers the trap. Magical deployment is supplied by the builder spell effect createtrap (alias placetrap), which accepts a current magical traptemplate and targets an item, cell, or character; a proximity template cannot target a cell. Magical dispelling is supplied by removetrap (alias dispeltrap), which targets a character, item, or cell and uses DispelTrapCheck after the spell's normal casting checks; trap disarm does not silently remove a magical trap.
+Disarm policy is Impossible, Safe, Risky, or Dispellable. Risky failure manually triggers the trap. Magical deployment is supplied by the builder spell effect createtrap (alias placetrap), which accepts a current magical traptemplate and targets an item, cell, or selected exit side; a proximity template cannot target a cell. Magical dispelling is supplied by removetrap (alias dispeltrap), which targets a character, item, or cell and uses DispelTrapCheck after the spell's normal casting checks; trap disarm does not silently remove a magical trap.
 
 Mechanical templates require positive setup, disarm (when disarmable), and recovery times before review. `trap lay`, `trap disarm`, and `trap recover` use cancellable general/movement actions for non-administrators and revalidate the anchor and trap state at completion. With no `using` clauses, `trap lay` first matches usable held or wielded parts, then loose parts at the actor's current layer; explicit clauses constrain that choice. Before the trap is installed, an inventory plan validates and moves each matched component to the current location using normal drop rules, then captures its installed spatial position. This includes persistence, reservation, custody/location, drop feasibility, and the ordinary `CanManipulateItem` access decision for every selected physical item. Administrative operations remain immediate. Magical and natural deployment continue to use their spell, AI, or FutureProg action timing rather than the mundane setup timer.
 
@@ -94,7 +94,7 @@ Component quality is averaged by configured quality weight relative to Standard.
 
 Player surface:
 
-- trap list
+- traps
 - trap types (aliases: trap known, trap templates)
 - trap inspect item|exit|here
 - trap lay template on item|exit|here [using item ...] (held/wielded items are preferred; otherwise each item must be loose and manipulable in the current cell)
@@ -107,9 +107,9 @@ Player surface:
 
 arm item recognises an item-anchored trap. disarm item directs players to the safer trap disarm workflow.
 
-Administrators additionally use trap create, trap debug, trap arm, trap trigger, trap reset, trap reveal, and trap delete.
+Administrators additionally use `trap list` for every active trap in the game, plus trap create, trap debug, trap arm, trap trigger, trap reset, trap reveal, and trap delete. `impdebug cleartraps` deletes every installed trap and its pending trap payload/cooldown effects after an explicit ACCEPT confirmation.
 
-Builders author revisions through traptemplate, with list, show, edit, set, and review lifecycle. set domain, set trigger, set payload, set component, set charges, set cooldown, set setuptime, set disarmtime, set recoverytime, set knowprog, set disarm, set lifecycle, and set validate are the first-party builder surface. `component add <trigger|payload|both> <tag> [spent recovery %] [quality weight]` and `component remove <number>` manage physical requirements. `traptemplate set trigger <number>` displays every supported parameter with its current or default value. Invalid trigger editing syntax returns this contextual help rather than a generic parameter error.
+Builders author revisions through traptemplate (aliases `trapt` and `tt`), with list, show, edit, set, and review lifecycle. set domain, set trigger, set payload, set component, set charges, set cooldown, set setuptime, set disarmtime, set recoverytime, set knowprog, set disarm, set lifecycle, and set validate are the first-party builder surface. `component add <trigger|payload|both> <tag> [spent recovery %] [quality weight]` and `component remove <number>` manage physical requirements. `traptemplate set trigger <number>` and `traptemplate set payload <number>` display every supported setting and parameter with its current or default value, valid values, and guidance. Invalid trigger or payload editing syntax returns this contextual help rather than a generic parameter error.
 
 ## FutureProg and automation integration
 

--- a/MudSharpCore Unit Tests/TrapModuleDefinitionTests.cs
+++ b/MudSharpCore Unit Tests/TrapModuleDefinitionTests.cs
@@ -15,11 +15,14 @@ using MudSharp.FutureProg.Variables;
 using MudSharp.GameItems;
 using MudSharp.Health;
 using MudSharp.Magic;
+using MudSharp.Magic.SpellEffects;
 using MudSharp.Movement;
 using MudSharp.Traps;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Xml.Linq;
 
 namespace MudSharp_Unit_Tests;
@@ -116,6 +119,60 @@ public class TrapModuleDefinitionTests
 		Assert.AreEqual(TrapTargetSelector.AnchorOccupants, loaded.TargetSelector);
 		Assert.AreEqual("entangled in webbing", loaded.Parameters["description"]);
 		Assert.IsTrue(loaded.CompatibleSourceKinds.Contains(TrapSourceKind.Natural));
+	}
+
+	[TestMethod]
+	public void PayloadDefinitions_AdvertiseOnlySupportedParametersWithGuidance()
+	{
+		var damageParameters = TrapPayloadDefinition.ParametersFor(TrapPayloadType.DirectDamage)
+			.ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
+		CollectionAssert.AreEquivalent(
+			new[] { "echo", "damage", "damagetype" },
+			damageParameters.Keys.ToList());
+		Assert.AreEqual("required", damageParameters["damage"].DefaultValue);
+		StringAssert.Contains(damageParameters["damagetype"].Description, "damage type");
+		Assert.IsTrue(TrapPayloadDefinition.IsSupportedParameter(TrapPayloadType.DirectDamage, "damage"));
+		Assert.IsFalse(TrapPayloadDefinition.IsSupportedParameter(TrapPayloadType.DirectDamage, "liquid"));
+
+		var gasParameters = TrapPayloadDefinition.ParametersFor(TrapPayloadType.GasCloud)
+			.Select(x => x.Name)
+			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+		CollectionAssert.IsSubsetOf(
+			new[] { "echo", "gas", "dose", "duration", "cloudecho" },
+			gasParameters.ToList());
+	}
+
+	[TestMethod]
+	public void CreateTrapSpellEffect_AcceptsExitTriggers()
+	{
+		var spell = new Mock<IMagicSpell>();
+		var effect = (CreateTrapSpellEffect)Activator.CreateInstance(
+			typeof(CreateTrapSpellEffect),
+			BindingFlags.Instance | BindingFlags.NonPublic,
+			null,
+			[new XElement("Effect"), spell.Object],
+			null)!;
+		var exitTrigger = new Mock<IMagicTrigger>();
+		exitTrigger.SetupGet(x => x.TargetTypes).Returns("exit");
+
+		Assert.IsTrue(effect.IsCompatibleWithTrigger(exitTrigger.Object));
+	}
+
+	[TestMethod]
+	public void TrapCommandSurface_SeparatesPlayerListingAndAdministratorMaintenance()
+	{
+		var trapModuleSource = File.ReadAllText(GetSourcePath("MudSharpCore", "Commands", "Modules", "TrapModule.cs"));
+		StringAssert.Contains(trapModuleSource, "[PlayerCommand(\"Traps\", \"traps\")]");
+		StringAssert.Contains(trapModuleSource, "case \"list\" when actor.IsAdministrator():");
+		StringAssert.Contains(trapModuleSource, "internal static int DeleteAllTraps");
+		StringAssert.Contains(trapModuleSource, "TrapPayloadScheduleEffect");
+
+		var builderSource = File.ReadAllText(GetSourcePath("MudSharpCore", "Commands", "Modules", "ActivityBuilderModule.cs"));
+		StringAssert.Contains(builderSource, "[PlayerCommand(\"TrapTemplate\", \"traptemplate\", \"trapt\", \"tt\")]");
+
+		var implementorSource = File.ReadAllText(GetSourcePath("MudSharpCore", "Commands", "Modules", "ImplementorModule.cs"));
+		StringAssert.Contains(implementorSource, "case \"cleartraps\":");
+		StringAssert.Contains(implementorSource, "TrapModule.DeleteAllTraps(actor.Gameworld)");
 	}
 
 	[TestMethod]
@@ -317,5 +374,20 @@ public class TrapModuleDefinitionTests
 		Assert.IsTrue(SpellEffectFactory.MagicEffectTypes.Contains("dispeltrap"));
 		Assert.IsTrue(SpellEffectFactory.MagicEffectTypes.Contains("createtrap"));
 		Assert.IsTrue(SpellEffectFactory.MagicEffectTypes.Contains("placetrap"));
+	}
+
+	private static string GetSourcePath(params string[] segments)
+	{
+		for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
+		{
+			if (!File.Exists(Path.Combine(directory.FullName, "MudSharp.sln")))
+			{
+				continue;
+			}
+
+			return Path.Combine([directory.FullName, .. segments]);
+		}
+
+		throw new DirectoryNotFoundException("Could not locate the FutureMUD repository root.");
 	}
 }

--- a/MudSharpCore/Commands/Modules/ActivityBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/ActivityBuilderModule.cs
@@ -1075,7 +1075,7 @@ Use the following options:
 	#3traptemplate set name <name>#0 - renames this template
 	#3traptemplate set domain mechanical|magical|natural#0 - selects its source domain
 	#3traptemplate set trigger add <type>#0 - adds an OR trigger; use #3trigger remove <number>#0 or #3trigger <number> parameter <name> <value>#0 to configure it
-	#3traptemplate set payload add <type>#0 - adds an ordered payload; use #3payload remove <number>#0, #3payload <number> delay <timespan>#0, #3payload <number> target <selector>#0, or #3payload <number> parameter <name> <value>#0 to configure it
+	#3traptemplate set payload add <type>#0 - adds an ordered payload; use #3payload <number>#0 to see every valid setting, parameter, current value, and guidance
 	#3traptemplate set component add <trigger|payload|both> <tag> [spent recovery %] [quality weight]#0 - adds a tagged physical requirement to a mechanical trap
 	#3traptemplate set component remove <number>#0 - removes a physical requirement
 	#3traptemplate set charges <number>#0 - sets uses before the trap is spent
@@ -1088,9 +1088,9 @@ Use the following options:
 	#3traptemplate set lifecycle indefinite|fixedexpiry <timespan>|unstable <timespan>#0 - sets lifecycle policy
 	#3traptemplate set validate#0 - reports readiness errors
 
-Use #3traptemplate set trigger <number>#0 to see the supported trigger parameters and their current values. The same command also shows syntax help when an argument is invalid.";
+Use #3traptemplate set trigger <number>#0 or #3traptemplate set payload <number>#0 to see the supported settings and parameters with their current values. The same commands also show contextual help when an argument is invalid.";
 
-    [PlayerCommand("TrapTemplate", "traptemplate", "trapt")]
+    [PlayerCommand("TrapTemplate", "traptemplate", "trapt", "tt")]
     [CommandPermission(PermissionLevel.Admin)]
     [HelpInfo("traptemplate", TrapTemplateHelpText, AutoHelp.HelpArgOrNoArg)]
     protected static void TrapTemplate(ICharacter actor, string input)

--- a/MudSharpCore/Commands/Modules/ImplementorModule.cs
+++ b/MudSharpCore/Commands/Modules/ImplementorModule.cs
@@ -395,6 +395,7 @@ The syntax is:
 	#3employment legacy#0 - reports legacy job/new employment-host contract divergence
 	#3freezetime#0 - freezes all in game clocks
 	#3unfreezetime#0 - resumes all in game clocks
+	#3cleartraps#0 - permanently deletes every installed trap and cancels its delayed payloads after confirmation
 	#3weatherstats <controller> [years <n>] [burnin <n>] [seed <n>] [file <basename>]#0 - runs a non-destructive Monte Carlo weather analysis and writes multiple CSVs", AutoHelp.HelpArgOrNoArg)]
     [CommandPermission(PermissionLevel.Founder)]
     protected static void ImpDebug(ICharacter actor, string input)
@@ -407,6 +408,10 @@ The syntax is:
                 return;
             case "unfreezetime":
                 DebugUnfreezeTime(actor);
+                return;
+            case "cleartraps":
+            case "deletetraps":
+                DebugClearTraps(actor, ss);
                 return;
             case "weatherstats":
                 DebugWeatherStats(actor, ss);
@@ -531,6 +536,36 @@ The syntax is:
                 actor.Send("That's not a known debug routine.");
                 return;
         }
+    }
+
+    private static void DebugClearTraps(ICharacter actor, StringStack ss)
+    {
+        if (!ss.IsFinished)
+        {
+            actor.OutputHandler.Send($"The syntax is {"impdebug cleartraps".ColourCommand()}.");
+            return;
+        }
+
+        var count = TrapModule.AllTraps(actor.Gameworld, includeOfflineCharacters: true).Count;
+        if (count == 0)
+        {
+            actor.OutputHandler.Send("There are no installed traps to delete.");
+            return;
+        }
+
+        actor.OutputHandler.Send(
+            $"This will permanently delete {count.ToString("N0", actor).ColourValue()} installed traps throughout the game and cancel their delayed payloads and cooldowns. This cannot be undone.\n{Accept.StandardAcceptPhrasing}");
+        actor.AddEffect(new Accept(actor, new GenericProposal
+        {
+            DescriptionString = "Deleting all traps",
+            AcceptAction = _ =>
+            {
+                var deleted = TrapModule.DeleteAllTraps(actor.Gameworld);
+                actor.OutputHandler.Send($"You delete {deleted.ToString("N0", actor).ColourValue()} traps and cancel their pending trap effects.");
+            },
+            RejectAction = _ => actor.OutputHandler.Send("You decide not to delete the traps."),
+            ExpireAction = () => actor.OutputHandler.Send("You decide not to delete the traps.")
+        }), TimeSpan.FromSeconds(120));
     }
 
     private const int MaximumEmploymentPayrollDebugDays = 31;

--- a/MudSharpCore/Commands/Modules/TrapModule.cs
+++ b/MudSharpCore/Commands/Modules/TrapModule.cs
@@ -34,29 +34,42 @@ internal class TrapModule : Module<ICharacter>
 
 	public static TrapModule Instance { get; } = new();
 
-	private const string HelpText = @"The #3trap#0 command lets you set, inspect, reveal and deal with traps. Templates are authored separately with #3traptemplate#0 by builders.
+	private const string PlayerHelpText = @"The #3trap#0 command lets you set, inspect, reveal and deal with traps. Builders author templates separately with #3traptemplate#0.
 
-	#3trap list#0 - lists traps you know at this location
+	#3traps#0 - lists the traps you know at this location
 	#3trap types#0 - lists the trap templates your character knows
 	#3trap inspect <item|exit|here>#0 - inspects a known trap
-	#3trap lay <template> on <item|exit|here> [using <item> ...]#0 - deploys a known current trap template; repeat using for tagged mechanical parts you hold or can manipulate loose in the room (held parts are preferred)
-	#3trap pointout <person> <item|exit|here>#0 - shares knowledge of a trap
+	#3trap lay <template> on <item|exit|here> [using <item> ...]#0 - deploys a known current mechanical trap with its required physical parts
+	#3trap pointout <person> <item|exit|here>#0 - shares your knowledge of a trap
 	#3trap disarm <item|exit|here>#0 - attempts to disarm a known trap
-	#3trap recover <item|exit|here>#0 - removes a safely disarmed trap
-	#3trap struggle#0 - attempts to escape a trap restraint
+	#3trap recover <item|exit|here>#0 - dismantles a safely disarmed or spent trap
+	#3trap struggle#0 - attempts to escape a trap restraint";
 
-Administrators additionally have #3trap create|show|debug|arm|trigger|reset|reveal|delete#0 for verification and world maintenance.";
+	private const string AdminHelpText = @"The #3trap#0 administrator command includes all player trap controls plus these immediate diagnostic and maintenance operations:
+
+	#3trap list#0 - lists every active trap in the game, including its anchor, template, state, charges and creator
+	#3trap create <template> on <item|exit|here> [using <item> ...]#0 - immediately deploys a template without player knowledge, timing or skill checks
+	#3trap debug <item|exit|here>#0 - inspects a local trap whether or not it has been identified
+	#3trap arm <item|exit|here>#0 - arms a local trap when its current state permits it
+	#3trap trigger <item|exit|here>#0 - immediately forces a local trap to resolve
+	#3trap reset <item|exit|here>#0 - ends the cooldown of a local trap with charges remaining
+	#3trap reveal <item|exit|here> <character>#0 - grants a character knowledge of a local trap
+	#3trap delete <item|exit|here>#0 - immediately removes a local trap and releases its components";
+
+	private const string TrapsHelpText = @"The #3traps#0 command lists the traps your character knows at the current location.
+
+	#3traps#0 - lists known local traps";
 
 	[PlayerCommand("Trap", "trap")]
 	[RequiredCharacterState(CharacterState.Able)]
-	[HelpInfo("trap", HelpText, AutoHelp.HelpArgOrNoArg)]
+	[HelpInfo("trap", PlayerHelpText, AutoHelp.HelpArgOrNoArg, AdminHelpText)]
 	protected static void Trap(ICharacter actor, string input)
 	{
 		var command = new StringStack(input.RemoveFirstWord());
 		switch (command.PopForSwitch())
 		{
-			case "list":
-				ListTraps(actor);
+			case "list" when actor.IsAdministrator():
+				ListActiveTraps(actor);
 				return;
 			case "types":
 			case "known":
@@ -105,9 +118,24 @@ Administrators additionally have #3trap create|show|debug|arm|trigger|reset|reve
 				DeleteTrap(actor, command);
 				return;
 			default:
-				actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+				actor.OutputHandler.Send((actor.IsAdministrator() ? AdminHelpText : PlayerHelpText).SubstituteANSIColour());
 				return;
 		}
+	}
+
+	[PlayerCommand("Traps", "traps")]
+	[RequiredCharacterState(CharacterState.Able)]
+	[HelpInfo("traps", TrapsHelpText, AutoHelp.HelpArg)]
+	protected static void Traps(ICharacter actor, string input)
+	{
+		var command = new StringStack(input.RemoveFirstWord());
+		if (!command.IsFinished)
+		{
+			actor.OutputHandler.Send(TrapsHelpText.SubstituteANSIColour());
+			return;
+		}
+
+		ListKnownTraps(actor);
 	}
 
 	private static bool KnowsTemplate(ICharacter actor, ITrapTemplate template)
@@ -147,7 +175,7 @@ Administrators additionally have #3trap create|show|debug|arm|trigger|reset|reve
 			new[] { "Id", "Trap", "Source", "Setup", "Deployment", "Triggers" }, actor, Telnet.Green));
 	}
 
-	private static void ListTraps(ICharacter actor)
+	private static void ListKnownTraps(ICharacter actor)
 	{
 		var traps = EnumerateLocalTraps(actor)
 			.Where(x => x.Trap.IsKnownBy(actor))
@@ -169,6 +197,83 @@ Administrators additionally have #3trap create|show|debug|arm|trigger|reset|reve
 			},
 			new[] { "Anchor", "Template", "State", "Charges" },
 			actor, Telnet.Green));
+	}
+
+	private static void ListActiveTraps(ICharacter actor)
+	{
+		var traps = AllTraps(actor.Gameworld, activeOnly: true);
+		if (!traps.Any())
+		{
+			actor.Send("There are no active traps in the game.");
+			return;
+		}
+
+		actor.Send(StringUtilities.GetTextTable(
+			from entry in traps
+			let trap = entry.Trap
+			let template = trap.Template
+			select new[]
+			{
+				trap.InstanceId.ToString(),
+				trap.DescribeAnchor(actor),
+				template?.Name ?? $"orphaned template {trap.TemplateId:N0}r{trap.TemplateRevisionNumber:N0}",
+				trap.SourceKind.DescribeEnum(),
+				trap.State.DescribeEnum(),
+				trap.RemainingCharges.ToString("N0", actor),
+				trap.CreatorId > 0 ? trap.CreatorId.ToString("N0", actor) : "none"
+			},
+			new[] { "Instance", "Anchor", "Template", "Source", "State", "Charges", "Creator" },
+			actor, Telnet.Green));
+	}
+
+	internal static IReadOnlyList<(IPerceivable Anchor, TrapEffect Trap)> AllTraps(IFuturemud gameworld,
+		bool activeOnly = false, bool includeOfflineCharacters = false)
+	{
+		var traps = AllTrapAnchors(gameworld, includeOfflineCharacters)
+			.SelectMany(anchor => anchor.EffectsOfType<TrapEffect>().Select(trap => (Anchor: anchor, Trap: trap)));
+		return (activeOnly
+			? traps.Where(x => x.Trap.State is not TrapState.Spent and not TrapState.Expired)
+			: traps)
+			.ToList();
+	}
+
+	internal static int DeleteAllTraps(IFuturemud gameworld)
+	{
+		var anchors = AllTrapAnchors(gameworld, includeOfflineCharacters: true);
+		var traps = anchors
+			.SelectMany(anchor => anchor.EffectsOfType<TrapEffect>().Select(trap => (Anchor: anchor, Trap: trap)))
+			.ToList();
+		foreach (var (anchor, trap) in traps)
+		{
+			anchor.RemoveEffect(trap, true);
+		}
+
+		foreach (var anchor in anchors)
+		{
+			anchor.RemoveAllEffects<TrapPayloadScheduleEffect>(null, true);
+			anchor.RemoveAllEffects<TrapResetEffect>(null, true);
+			anchor.RemoveAllEffects<TrapSpentCleanupEffect>(null, true);
+		}
+
+		return traps.Count;
+	}
+
+	private static IReadOnlyList<IPerceivable> AllTrapAnchors(IFuturemud gameworld, bool includeOfflineCharacters)
+	{
+		var characters = gameworld.Actors
+			.Concat(gameworld.CachedActors)
+			.Concat(gameworld.Characters);
+		if (includeOfflineCharacters)
+		{
+			characters = characters.Concat(gameworld.LoadAllPlayerCharacters());
+		}
+
+		return gameworld.Cells
+			.Cast<IPerceivable>()
+			.Concat(gameworld.Items)
+			.Concat(characters)
+			.Distinct()
+			.ToList();
 	}
 
 	private static void InspectTrap(ICharacter actor, StringStack command, bool debug)

--- a/MudSharpCore/Magic/SpellEffects/CreateTrapSpellEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/CreateTrapSpellEffect.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using MudSharp.Effects.Concrete;
+using MudSharp.Construction.Boundary;
 using MudSharp.GameItems;
 using MudSharp.Framework.Revision;
 using MudSharp.RPG.Checks;
@@ -120,7 +121,7 @@ public sealed class CreateTrapSpellEffect : IMagicSpellEffectTemplate
 
 	private static bool IsCompatibleTargetType(string targetTypes)
 	{
-		return targetTypes is "item" or "room";
+		return targetTypes is "item" or "room" or "exit";
 	}
 
 	public IMagicSpellEffect? GetOrApplyEffect(ICharacter caster, IPerceivable? target,
@@ -128,21 +129,25 @@ public sealed class CreateTrapSpellEffect : IMagicSpellEffectTemplate
 		SpellAdditionalParameter[] additionalParameters)
 	{
 		var template = TrapTemplate;
-		if (target is null || template is null || template.SourceKind != TrapSourceKind.Magical ||
-		    template.Status != RevisionStatus.Current || !template.CanSubmit() || !TrapEffect.IsValidAnchor(template, target) ||
-		    target.EffectsOfType<TrapEffect>().Any(x => x.State is not TrapState.Spent and not TrapState.Expired))
+		var boundExit = additionalParameters
+			.FirstOrDefault(x => x.ParameterName.EqualTo("exit"))?.Item as ICellExit;
+		var anchor = boundExit?.Origin ?? target;
+		if (anchor is null || template is null || template.SourceKind != TrapSourceKind.Magical ||
+		    template.Status != RevisionStatus.Current || !template.CanSubmit() || !TrapEffect.IsValidAnchor(template, anchor) ||
+		    anchor.EffectsOfType<TrapEffect>().Any(x => x.State is not TrapState.Spent and not TrapState.Expired &&
+		                                           HasSameBinding(x, boundExit)))
 		{
 			return null;
 		}
 
-		var trap = new TrapEffect(target, template, caster);
+		var trap = new TrapEffect(anchor, template, caster, boundExit);
 		if (TrapEffect.HasTimedLifetime(template))
 		{
-			target.AddEffect(trap, template.Lifespan!.Value);
+			anchor.AddEffect(trap, template.Lifespan!.Value);
 		}
 		else
 		{
-			target.AddEffect(trap);
+			anchor.AddEffect(trap);
 		}
 
 		if (!caster.IsAdministrator())
@@ -151,12 +156,16 @@ public sealed class CreateTrapSpellEffect : IMagicSpellEffectTemplate
 				caster,
 				CrimeTypes.BoobyTrapping,
 				null,
-				target as IGameItem,
+				anchor as IGameItem,
 				template.Name);
 		}
 
 		return null;
 	}
+
+	private static bool HasSameBinding(TrapEffect trap, ICellExit? exit) => exit is null
+		? !trap.BoundExitId.HasValue
+		: trap.BoundExitId == exit.Exit.Id && trap.BoundExitOriginId == exit.Origin.Id;
 
 	public IMagicSpellEffectTemplate Clone()
 	{

--- a/MudSharpCore/Traps/TrapModuleDefinitions.cs
+++ b/MudSharpCore/Traps/TrapModuleDefinitions.cs
@@ -4,6 +4,8 @@ using System.Globalization;
 using MudSharp.Traps;
 using MudSharp.Movement;
 using MudSharp.Framework;
+using MudSharp.Health;
+using MudSharp.Magic;
 
 namespace MudSharp.Traps;
 
@@ -150,6 +152,54 @@ public sealed class TrapTriggerDefinition : ITrapTrigger
 
 public sealed class TrapPayloadDefinition : ITrapPayload
 {
+	public sealed record ParameterHelp(string Name, string Description, string DefaultValue);
+
+	private static readonly IReadOnlyList<ParameterHelp> CommonParameters =
+	[
+		new("echo", "optional emote shown to each target when this payload resolves", "none")
+	];
+
+	private static readonly IReadOnlyDictionary<TrapPayloadType, IReadOnlyList<ParameterHelp>> TypeParameters =
+		new Dictionary<TrapPayloadType, IReadOnlyList<ParameterHelp>>
+		{
+			[TrapPayloadType.CastSpell] =
+			[
+				new("spell", "required ready magic spell ID to resolve when the trap fires", "required"),
+				new("power", $"spell power ({string.Join(", ", Enum.GetNames<SpellPower>())})", "Standard")
+			],
+			[TrapPayloadType.EmitSignal] =
+			[
+				new("targetitem", "optional item ID with a signal sink; defaults to a matched payload component", "matched payload component"),
+				new("value", "numeric signal value sent to the signal sink", "1")
+			],
+			[TrapPayloadType.ExecuteProg] =
+			[
+				new("prog", "required FutureProg ID with a supported target and/or anchor signature", "required")
+			],
+			[TrapPayloadType.DirectDamage] =
+			[
+				new("damage", "required positive damage, pain and stun amount", "required"),
+				new("damagetype", $"damage type ({string.Join(", ", Enum.GetNames<DamageType>())})", "Piercing")
+			],
+			[TrapPayloadType.LiquidDischarge] =
+			[
+				new("liquid", "required liquid ID to expose targets to", "required"),
+				new("amount", "positive liquid amount in litres", "0.1")
+			],
+			[TrapPayloadType.GasCloud] =
+			[
+				new("gas", "required gas ID to release", "required"),
+				new("dose", "positive inhaled drug dose per unit volume when applicable", "the gas default"),
+				new("duration", "positive cloud duration as a timespan", "00:00:30"),
+				new("cloudecho", "room text shown when the cloud is created", "A cloud of gas billows out.")
+			],
+			[TrapPayloadType.Restraint] =
+			[
+				new("duration", "positive restraint duration as a timespan", "00:00:30"),
+				new("description", "description used for the target's restraint", "caught by a trap")
+			]
+		};
+
 	private static readonly IReadOnlySet<TrapSourceKind> AllDomains = new HashSet<TrapSourceKind>(Enum.GetValues<TrapSourceKind>());
 	private static readonly IReadOnlySet<TrapSourceKind> MechanicalOnly = new HashSet<TrapSourceKind> { TrapSourceKind.Mechanical };
 	private static readonly IReadOnlySet<TrapSourceKind> MagicalOnly = new HashSet<TrapSourceKind> { TrapSourceKind.Magical };
@@ -182,6 +232,12 @@ public sealed class TrapPayloadDefinition : ITrapPayload
 	public IReadOnlyDictionary<string, string> Parameters => _parameters;
 
 	public void SetParameter(string name, string value) => _parameters[name] = value;
+
+	public static IEnumerable<ParameterHelp> ParametersFor(TrapPayloadType type) =>
+		CommonParameters.Concat(TypeParameters.GetValueOrDefault(type) ?? []);
+
+	public static bool IsSupportedParameter(TrapPayloadType type, string name) =>
+		ParametersFor(type).Any(x => x.Name.EqualTo(name));
 
 	public void SetDelay(TimeSpan delay) => Delay = delay;
 	public void SetTargetSelector(TrapTargetSelector selector) => TargetSelector = selector;

--- a/MudSharpCore/Traps/TrapTemplate.cs
+++ b/MudSharpCore/Traps/TrapTemplate.cs
@@ -828,7 +828,7 @@ public sealed class TrapTemplate : EditableItem, ITrapTemplate
 	{
 		if (command.IsFinished)
 		{
-			actor.Send("Use payload add <type>, payload remove <number>, payload <number> delay <time>, payload <number> target <selector>, or payload <number> parameter <name> <value>.");
+			actor.Send("Use payload add <type>, payload remove <number>, or payload <number> to inspect and configure a payload.");
 			return false;
 		}
 
@@ -872,6 +872,12 @@ public sealed class TrapTemplate : EditableItem, ITrapTemplate
 			return false;
 		}
 
+		if (command.IsFinished)
+		{
+			actor.Send(PayloadBuildingHelp(actor, payloadIndex));
+			return false;
+		}
+
 		switch (command.PopForSwitch())
 		{
 			case "delay" when TimeSpan.TryParse(command.SafeRemainingArgument, actor, out var delay) && delay >= TimeSpan.Zero:
@@ -887,18 +893,41 @@ public sealed class TrapTemplate : EditableItem, ITrapTemplate
 			case "parameter":
 				if (command.IsFinished)
 				{
-					actor.Send("You must specify a parameter name and value.");
+					actor.Send(PayloadBuildingHelp(actor, payloadIndex));
 					return false;
 				}
 				var parameterName = command.PopSpeech();
+				if (!TrapPayloadDefinition.IsSupportedParameter(payloadDefinition.PayloadType, parameterName) || command.IsFinished)
+				{
+					actor.Send(PayloadBuildingHelp(actor, payloadIndex));
+					return false;
+				}
 				payloadDefinition.SetParameter(parameterName, command.SafeRemainingArgument);
 				Changed = true;
 				actor.Send($"You set the {parameterName.ColourName()} parameter on that payload.");
 				return true;
 			default:
-				actor.Send("Use payload <number> delay <time>, target <selector>, or parameter <name> <value>.");
+				actor.Send(PayloadBuildingHelp(actor, payloadIndex));
 				return false;
 		}
+	}
+
+	private string PayloadBuildingHelp(ICharacter actor, int payloadIndex)
+	{
+		var payload = _payloads[payloadIndex - 1];
+		var sb = new StringBuilder();
+		sb.AppendLine($"Payload {payloadIndex.ToString("N0", actor).ColourValue()}: {payload.PayloadType.DescribeEnum().ColourName()}");
+		sb.AppendLine($"Delay: {payload.Delay.Describe(actor).ColourValue()} - use {"payload <number> delay <timespan>".ColourCommand()} to change it.");
+		sb.AppendLine($"Target: {payload.TargetSelector.DescribeEnum().ColourValue()} - valid selectors are {Enum.GetValues<TrapTargetSelector>().Select(x => x.DescribeEnum().ColourCommand()).ListToString()}. Use {"payload <number> target <selector>".ColourCommand()} to change it.");
+		sb.AppendLine("Parameters:");
+		foreach (var parameter in TrapPayloadDefinition.ParametersFor(payload.PayloadType))
+		{
+			var value = payload.Parameters.GetValueOrDefault(parameter.Name) ?? parameter.DefaultValue;
+			sb.AppendLine($"\t{parameter.Name.ColourCommand()} = {value.ColourValue()} - {parameter.Description}");
+		}
+		sb.AppendLine();
+		sb.AppendLine($"Use {"payload <number> parameter <name> <value>".ColourCommand()} to change a parameter.");
+		return sb.ToString();
 	}
 
 	private bool BuildingCommandCharges(ICharacter actor, StringStack command)


### PR DESCRIPTION
Allows exit-bound magical traps; makes payload settings discoverable; adds tt and separate player/admin trap command views; adds founder cleartraps maintenance. Updated Trap_System.md and core trap tests. Validation: dotnet test MudSharpCore Unit Tests (2,251 passed).