### PR TITLE
Harden trap payload validation and add explosive damage

### DIFF
--- a/DatabaseSeeder Unit Tests/TrapSeederTests.cs
+++ b/DatabaseSeeder Unit Tests/TrapSeederTests.cs
@@ -123,7 +123,7 @@ public class TrapSeederTests
 		Assert.AreEqual(ShouldSeedResult.MayAlreadyBeInstalled, seeder.ShouldSeedData(context));
 		Assert.AreEqual(1, context.TraitDefinitions.Count(x => x.Name == "Traps"));
 		Assert.AreEqual(7, context.Checks.Count(x => trapCheckTypes.Contains(x.Type)));
-		Assert.AreEqual(9, context.TrapTemplates.Count(x => x.Name.StartsWith("Stock Trap - ")));
+		Assert.AreEqual(10, context.TrapTemplates.Count(x => x.Name.StartsWith("Stock Trap - ")));
 		Assert.AreEqual(11, context.Tags.Count(x => x.Name == "Trap Components" || x.Parent != null && x.Parent.Name == "Trap Components"));
 		Assert.AreEqual("Functions", context.Tags.Single(x => x.Name == "Trap Components").Parent?.Name);
 
@@ -141,7 +141,48 @@ public class TrapSeederTests
 
 		var natural = context.TrapTemplates.Single(x => x.Name == "Stock Trap - Spider Web");
 		var magical = context.TrapTemplates.Single(x => x.Name == "Stock Trap - Magical Glyph");
+		var magicalExplosion = context.TrapTemplates.Single(x => x.Name == "Stock Trap - Magical Explosion Glyph");
 		Assert.AreEqual("Natural", XElement.Parse(natural.Definition).Attribute("source")?.Value);
 		Assert.AreEqual("Magical", XElement.Parse(magical.Definition).Attribute("source")?.Value);
+		var explosivePayload = XElement.Parse(magicalExplosion.Definition).Element("Payloads")!.Element("Payload")!;
+		Assert.AreEqual(TrapPayloadType.ExplosiveDamage.ToString(), explosivePayload.Attribute("type")?.Value);
+		var explosiveParameters = explosivePayload.Elements("Parameter")
+			.ToDictionary(x => x.Attribute("name")!.Value, x => x.Value, StringComparer.OrdinalIgnoreCase);
+		CollectionAssert.IsSubsetOf(
+			new[] { "damage", "pain", "stun", "damagetype", "explosionsize", "maximumproximity", "elevation" },
+			explosiveParameters.Keys.ToList());
+
+		foreach (var directDamage in context.TrapTemplates
+			         .Where(x => x.Name.StartsWith("Stock Trap - "))
+			         .AsEnumerable()
+			         .SelectMany(x => XElement.Parse(x.Definition).Element("Payloads")!.Elements("Payload"))
+			         .Where(x => x.Attribute("type")?.Value == TrapPayloadType.DirectDamage.ToString()))
+		{
+			var parameters = directDamage.Elements("Parameter")
+				.ToDictionary(x => x.Attribute("name")!.Value, x => x.Value, StringComparer.OrdinalIgnoreCase);
+			Assert.IsTrue(parameters.ContainsKey("damage"));
+			Assert.IsTrue(parameters.ContainsKey("pain"));
+			Assert.IsTrue(parameters.ContainsKey("stun"));
+		}
+
+		foreach (var stockTemplate in context.TrapTemplates
+			         .Where(x => x.Name.StartsWith("Stock Trap - "))
+			         .AsEnumerable())
+		{
+			var definition = XElement.Parse(stockTemplate.Definition);
+			foreach (var trigger in definition.Element("Triggers")!.Elements("Trigger")
+			         .Select(TrapTriggerDefinition.LoadFromXml))
+			{
+				Assert.IsTrue(TrapTriggerDefinition.TryValidateParameters(trigger.TriggerType, trigger.Parameters, out _),
+					stockTemplate.Name);
+			}
+
+			foreach (var payload in definition.Element("Payloads")!.Elements("Payload")
+			         .Select(TrapPayloadDefinition.LoadFromXml))
+			{
+				Assert.IsTrue(TrapPayloadDefinition.TryValidateParameters(payload.PayloadType, payload.Parameters, out _),
+					stockTemplate.Name);
+			}
+		}
 	}
 }

--- a/DatabaseSeeder/Seeders/TrapSeeder.cs
+++ b/DatabaseSeeder/Seeders/TrapSeeder.cs
@@ -216,7 +216,7 @@ public sealed class TrapSeeder : IDatabaseSeeder
 			Definition(TrapSourceKind.Mechanical, TrapDisarmPolicy.Safe,
 				Trigger(TrapTriggerType.ExitTraversal),
 				[Component(tags["Tripwire Trigger"], TrapComponentRole.Trigger, 85.0), Component(tags["Signal Trap Payload"], TrapComponentRole.Payload, 95.0)],
-				Payload(TrapPayloadType.EmitSignal, ("targetitem", "0"), ("value", "1"))));
+				Payload(TrapPayloadType.EmitSignal, ("value", "1"))));
 		EnsureTemplate(context, ref nextId, accountId, now, "Tripwire Explosive",
 			Definition(TrapSourceKind.Mechanical, TrapDisarmPolicy.Risky,
 				Trigger(TrapTriggerType.ExitTraversal),
@@ -226,7 +226,7 @@ public sealed class TrapSeeder : IDatabaseSeeder
 			Definition(TrapSourceKind.Mechanical, TrapDisarmPolicy.Risky,
 				Trigger(TrapTriggerType.CellEntry),
 				[Component(tags["Pressure Trap Mechanism"], TrapComponentRole.TriggerAndPayload, 70.0)],
-				Payload(TrapPayloadType.DirectDamage, ("damage", "8"), ("damagetype", "Crushing"))));
+				Payload(TrapPayloadType.DirectDamage, ("damage", "8 * quality / 5"), ("pain", "6 * quality / 5"), ("stun", "4 * quality / 5"), ("damagetype", "Crushing"))));
 		EnsureTemplate(context, ref nextId, accountId, now, "Trapped Chest Liquid Splash",
 			Definition(TrapSourceKind.Mechanical, TrapDisarmPolicy.Safe,
 				Trigger(TrapTriggerType.Openable),
@@ -236,12 +236,12 @@ public sealed class TrapSeeder : IDatabaseSeeder
 			Definition(TrapSourceKind.Mechanical, TrapDisarmPolicy.Risky,
 				Trigger(TrapTriggerType.Openable),
 				[Component(tags["Needle Trap Mechanism"], TrapComponentRole.TriggerAndPayload, 65.0)],
-				Payload(TrapPayloadType.DirectDamage, ("damage", "3"), ("damagetype", "Piercing"))));
+				Payload(TrapPayloadType.DirectDamage, ("damage", "3 * quality / 5"), ("pain", "2 * quality / 5"), ("stun", "quality / 5"), ("damagetype", "Piercing"))));
 		EnsureTemplate(context, ref nextId, accountId, now, "Bear Trap",
 			Definition(TrapSourceKind.Mechanical, TrapDisarmPolicy.Risky,
 				Trigger(TrapTriggerType.Proximity),
 				[Component(tags["Bear Trap Mechanism"], TrapComponentRole.TriggerAndPayload, 80.0)],
-				Payload(TrapPayloadType.DirectDamage, ("damage", "10"), ("damagetype", "Piercing")),
+				Payload(TrapPayloadType.DirectDamage, ("damage", "10 * quality / 5"), ("pain", "8 * quality / 5"), ("stun", "4 * quality / 5"), ("damagetype", "Piercing")),
 				Payload(TrapPayloadType.Restraint, ("duration", "00:00:30"), ("description", "caught in a bear trap"))));
 		EnsureTemplate(context, ref nextId, accountId, now, "Spider Web",
 			Definition(TrapSourceKind.Natural, TrapDisarmPolicy.Safe,
@@ -254,7 +254,13 @@ public sealed class TrapSeeder : IDatabaseSeeder
 				[],
 				spellId > 0
 					? Payload(TrapPayloadType.CastSpell, ("spell", spellId.ToString()), ("power", "Standard"))
-					: Payload(TrapPayloadType.DirectDamage, ("damage", "5"), ("damagetype", "Electrical"))));
+					: Payload(TrapPayloadType.DirectDamage, ("damage", "power"), ("pain", "power * 1.5"), ("stun", "power / 2"), ("damagetype", "Electrical"))));
+		EnsureTemplate(context, ref nextId, accountId, now, "Magical Explosion Glyph",
+			Definition(TrapSourceKind.Magical, TrapDisarmPolicy.Dispellable,
+				Trigger(TrapTriggerType.CellEntry),
+				[],
+				Payload(TrapPayloadType.ExplosiveDamage, ("damage", "power * 2"), ("pain", "damage"), ("stun", "power"),
+					("damagetype", "Shockwave"), ("explosionsize", "Normal"), ("maximumproximity", "Proximate"), ("elevation", "0"))));
 		EnsureTemplate(context, ref nextId, accountId, now, "Gas Release",
 			Definition(TrapSourceKind.Mechanical, TrapDisarmPolicy.Safe,
 				Trigger(TrapTriggerType.Openable),

--- a/Design Documents/Core/Trap_System.md
+++ b/Design Documents/Core/Trap_System.md
@@ -69,12 +69,27 @@ Payload parameters are named so template XML remains extensible without schema c
 | CastSpell | spell, optional power | Resolves prepared spell effects using the recorded creator as caster, with duration and target resistance but no second cast action/resource cost; an unavailable creator fails safely |
 | EmitSignal | optional targetitem, optional value | Delivers a ComputerSignal to the explicit item, or to a matched payload component with signal sinks when omitted |
 | ExecuteProg | prog | Calls a matching character or character+anchor FutureProg |
-| DirectDamage | damage, optional damagetype | Applies a normal damage packet to a random target bodypart |
+| DirectDamage | damage, optional pain, optional stun, optional damagetype | Applies a normal damage packet to a random target bodypart |
+| ExplosiveDamage | damage, optional pain, stun, damagetype, explosionsize, maximumproximity, elevation | Creates an outward `IExplosiveDamage` packet at the trap anchor without requiring or deleting an explosive item; every nearby target is resolved by the established explosion handler |
 | LiquidDischarge | liquid, optional amount | Exposes target bodyparts to a LiquidMixture |
 | GasCloud | gas, optional duration, dose, cloudecho | Creates temporary local-layer gas cloud without changing bulk room atmosphere |
 | Restraint | optional duration, description | Applies a timed movement-blocking TrapRestraintEffect |
 
 A payload can target the triggerer, all same-layer anchor occupants, or a snapshot excluding the triggerer. Delayed payloads retain intended target ID rather than dynamically choosing a later bystander.
+
+### Parameter syntax and validation
+
+`traptemplate set trigger <number>` and `traptemplate set payload <number>` list each setting as `name <syntax> = current value`, with the accepted value form and default beside it. Set an optional parameter to `none` to remove its stored value and restore the documented default; `none` is never emitted as literal echo text. Required references must be positive IDs, and the builder verifies that referenced spells, FutureProgs, liquids, gases, and signal-sink items exist and are compatible before it records the change.
+
+Numeric parameters accept finite decimal values only. Chance is 0–100; damage, liquid amount, dose, and configured durations must be positive; signal values may be any finite number. Direct damage is a single positive number (for example, `25`), not a dice expression such as `1d40`. Enum parameters accept only named defined values, and paired signal bounds and exit size bounds cannot be inverted. A malformed legacy definition is rejected at template validation and fails closed at runtime rather than falling through to a harmful default.
+
+#### Direct and Explosive Damage formulas
+
+The generic numeric `damage` rule above applies to payload families that use a scalar damage value; it does not apply to Direct Damage or Explosive Damage.
+
+The Direct and Explosive Damage-specific formula rules supersede the numeric `damage` rule above. `damage` is a required `IExpression`; `pain` and `stun` are separate optional expressions that default to the resolved damage. Formulas may use `quality` (the weighted payload-item quality, with Standard = 5) and `power` (the spell power that created a magical trap, with Standard = 5); pain and stun formulas may additionally use the resolved `damage`. Dice syntax such as `1d40` is supported. The builder checks formula syntax, permitted names, and a finite non-negative evaluation before it accepts the setting, and runtime repeats the guard before applying the resulting damage packet.
+
+Explosive Damage has safe defaults suitable for a magical blast: `damagetype` is `Shockwave`, `explosionsize` is `Normal`, `maximumproximity` is `Proximate`, and `elevation` is `0` metres at the anchor. It uses the outward, local `IExplosiveDamage` path: no explosive item is required or deleted, and no contained-item or inventory branch is used. The target selector is ignored and this payload resolves once per activation; the established explosion handler selects affected body areas and applies its normal proximity and size propagation rules. `Unapproximable` is rejected as a maximum proximity because it cannot affect a local target.
 
 ## Detection, avoidance, and disarming
 
@@ -89,6 +104,8 @@ Disarm policy is Impossible, Safe, Risky, or Dispellable. Risky failure manually
 Mechanical templates require positive setup, disarm (when disarmable), and recovery times before review. `trap lay`, `trap disarm`, and `trap recover` use cancellable general/movement actions for non-administrators and revalidate the anchor and trap state at completion. With no `using` clauses, `trap lay` first matches usable held or wielded parts, then loose parts at the actor's current layer; explicit clauses constrain that choice. Before the trap is installed, an inventory plan validates and moves each matched component to the current location using normal drop rules, then captures its installed spatial position. This includes persistence, reservation, custody/location, drop feasibility, and the ordinary `CanManipulateItem` access decision for every selected physical item. Administrative operations remain immediate. Magical and natural deployment continue to use their spell, AI, or FutureProg action timing rather than the mundane setup timer.
 
 Component quality is averaged by configured quality weight relative to Standard. Each trigger-quality stage changes configured trigger chance by 2.5 percentage points; every two stages change spot and avoidance difficulty by one step. Payload quality scales direct damage, discharged liquid, gas dose, and restraint duration by 5% per stage, clamped to 50-150%; specialised item payloads such as explosives retain their own item implementation as well. Safe dismantling returns every extant component. Dismantling a spent trap rolls each distinct item's base recovery chance plus 5 percentage points per weighted quality stage; failures delete the broken item. Spent traps retain their no-get reservations while any component has a non-zero recovery opportunity. If no recoverable component remains, the effect and any zero-chance remnants are removed automatically after the final delayed payload, preventing persistent clutter.
+
+Direct and Explosive Damage formulas receive the unmodified weighted payload quality value instead, so template authors choose exactly how it affects damage, pain, and stun; magical traps likewise retain the creating spell's power through delayed payload resolution.
 
 ## Commands
 
@@ -109,7 +126,7 @@ arm item recognises an item-anchored trap. disarm item directs players to the sa
 
 Administrators additionally use `trap list` for every active trap in the game, plus trap create, trap debug, trap arm, trap trigger, trap reset, trap reveal, and trap delete. `impdebug cleartraps` deletes every installed trap and its pending trap payload/cooldown effects after an explicit ACCEPT confirmation.
 
-Builders author revisions through traptemplate (aliases `trapt` and `tt`), with list, show, edit, set, and review lifecycle. set domain, set trigger, set payload, set component, set charges, set cooldown, set setuptime, set disarmtime, set recoverytime, set knowprog, set disarm, set lifecycle, and set validate are the first-party builder surface. `component add <trigger|payload|both> <tag> [spent recovery %] [quality weight]` and `component remove <number>` manage physical requirements. `traptemplate set trigger <number>` and `traptemplate set payload <number>` display every supported setting and parameter with its current or default value, valid values, and guidance. Invalid trigger or payload editing syntax returns this contextual help rather than a generic parameter error.
+Builders author revisions through traptemplate (aliases `trapt` and `tt`), with list, show, edit, set, and review lifecycle. set domain, set trigger, set payload, set component, set charges, set cooldown, set setuptime, set disarmtime, set recoverytime, set knowprog, set disarm, set lifecycle, and set validate are the first-party builder surface. `component add <trigger|payload|both> <tag> [spent recovery %] [quality weight]` and `component remove <number>` manage physical requirements. `traptemplate set trigger <number>` and `traptemplate set payload <number>` display every supported setting and parameter with its current/default value, exact syntax, valid values, and guidance. Invalid values are rejected immediately with the relevant syntax help; template review remains a second guard for imported or legacy XML definitions.
 
 ## FutureProg and automation integration
 
@@ -125,7 +142,7 @@ Balance defaults are conservative: one charge, normal deployment difficulty, har
 
 ## Seeder content
 
-The trap seeder supplies a Traps skill; check definitions; a `Functions / Trap Components` tag family; and current template examples: tripwire alarm, tripwire explosive, pressure plate, trapped chest liquid splash, trapped chest needle, bear trap, spider web, magical glyph, and gas release. Every stock mechanical example has tagged trigger and payload requirements, including dual-role pressure, needle, and bear-trap mechanisms. The seeder deliberately provides the reusable tag contract rather than inventing duplicate item prototypes: games apply those tags to their own crafted or seeded wire, mechanisms, explosives, reservoirs, and automation hardware. Signal-trigger parts must additionally implement the existing automation signal-source interface, while signal payload parts without an explicit target must implement a signal sink.
+The trap seeder supplies a Traps skill; check definitions; a `Functions / Trap Components` tag family; and current template examples: tripwire alarm, tripwire explosive, pressure plate, trapped chest liquid splash, trapped chest needle, bear trap, spider web, magical glyph, magical explosion glyph, and gas release. Every stock mechanical example has tagged trigger and payload requirements, including dual-role pressure, needle, and bear-trap mechanisms. The seeder deliberately provides the reusable tag contract rather than inventing duplicate item prototypes: games apply those tags to their own crafted or seeded wire, mechanisms, explosives, reservoirs, and automation hardware. Signal-trigger parts must additionally implement the existing automation signal-source interface, while signal payload parts without an explicit target must implement a signal sink.
 
 These examples are trap templates and reusable tag contracts, not new hard-coded item component types or duplicate physical item prototypes. NPCs create natural traps through a dedicated natural-trap AI/Prog action that deploys a current natural template with its NPC as creator.
 

--- a/FutureMUDLibrary/Traps/TrapEnums.cs
+++ b/FutureMUDLibrary/Traps/TrapEnums.cs
@@ -52,6 +52,7 @@ public enum TrapPayloadType
 	EmitSignal,
 	ExecuteProg,
 	DirectDamage,
+	ExplosiveDamage,
 	LiquidDischarge,
 	GasCloud,
 	Restraint

--- a/MudSharpCore Unit Tests/TrapModuleDefinitionTests.cs
+++ b/MudSharpCore Unit Tests/TrapModuleDefinitionTests.cs
@@ -2,6 +2,8 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using MudSharp.Body;
+using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Effects;
@@ -93,13 +95,15 @@ public class TrapModuleDefinitionTests
 		template.SetupGet(x => x.RevisionNumber).Returns(4);
 		template.SetupGet(x => x.Charges).Returns(1);
 
-		var trap = new TrapEffect(cell.Object, template.Object, null, cellExit.Object);
+		var trap = new TrapEffect(cell.Object, template.Object, null, cellExit.Object, power: SpellPower.Strong);
 		var xml = trap.SaveToXml(new Dictionary<IEffect, TimeSpan>());
 
 		Assert.AreEqual(200L, trap.BoundExitId);
 		Assert.AreEqual(100L, trap.BoundExitOriginId);
+		Assert.AreEqual(SpellPower.Strong, trap.Power);
 		Assert.AreEqual("200", xml.Descendants("BoundExitId").Single().Value);
 		Assert.AreEqual("100", xml.Descendants("BoundExitOriginId").Single().Value);
+		Assert.AreEqual("Strong", xml.Descendants("Power").Single().Value);
 	}
 
 	[TestMethod]
@@ -122,17 +126,58 @@ public class TrapModuleDefinitionTests
 	}
 
 	[TestMethod]
+	public void MalformedTrapDefinitions_PreserveValuesAndFailClosed()
+	{
+		var malformedTrigger = TrapTriggerDefinition.LoadFromXml(
+			XElement.Parse("<Trigger type=\"Openable\"><Parameter name=\"chance\">101</Parameter></Trigger>"));
+		Assert.AreEqual("101", malformedTrigger.Parameters["chance"]);
+		Assert.IsFalse(TrapTriggerDefinition.TryValidateParameters(malformedTrigger.TriggerType,
+			malformedTrigger.Parameters, out _));
+
+		var malformedPayload = TrapPayloadDefinition.LoadFromXml(
+			XElement.Parse("<Payload type=\"DirectDamage\" delay=\"not-a-timespan\" target=\"NotASelector\"><Parameter name=\"damage\">traitbonus</Parameter></Payload>"));
+		Assert.AreEqual("traitbonus", malformedPayload.Parameters["damage"]);
+		Assert.IsTrue(malformedPayload.Delay < TimeSpan.Zero);
+		Assert.IsFalse(Enum.IsDefined(malformedPayload.TargetSelector));
+		Assert.IsFalse(TrapPayloadDefinition.TryValidateParameters(malformedPayload.PayloadType,
+			malformedPayload.Parameters, out _));
+
+		Assert.IsFalse(TrapTriggerDefinition.TryValidateParameters((TrapTriggerType)999,
+			new Dictionary<string, string>(), out _));
+		Assert.IsFalse(TrapPayloadDefinition.TryValidateParameters((TrapPayloadType)999,
+			new Dictionary<string, string>(), out _));
+		Assert.IsFalse(new TrapPayloadDefinition((TrapPayloadType)999).CompatibleSourceKinds.Any());
+	}
+
+	[TestMethod]
 	public void PayloadDefinitions_AdvertiseOnlySupportedParametersWithGuidance()
 	{
 		var damageParameters = TrapPayloadDefinition.ParametersFor(TrapPayloadType.DirectDamage)
 			.ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
 		CollectionAssert.AreEquivalent(
-			new[] { "echo", "damage", "damagetype" },
+			new[] { "echo", "damage", "pain", "stun", "damagetype" },
 			damageParameters.Keys.ToList());
 		Assert.AreEqual("required", damageParameters["damage"].DefaultValue);
+		Assert.AreEqual("<expression>", damageParameters["damage"].Syntax);
+		Assert.AreEqual("damage", damageParameters["pain"].DefaultValue);
+		Assert.AreEqual("damage", damageParameters["stun"].DefaultValue);
+		Assert.AreEqual("<damage type|none>", damageParameters["damagetype"].Syntax);
+		StringAssert.Contains(damageParameters["damage"].Description, "quality");
+		StringAssert.Contains(damageParameters["pain"].Description, "damage");
 		StringAssert.Contains(damageParameters["damagetype"].Description, "damage type");
 		Assert.IsTrue(TrapPayloadDefinition.IsSupportedParameter(TrapPayloadType.DirectDamage, "damage"));
 		Assert.IsFalse(TrapPayloadDefinition.IsSupportedParameter(TrapPayloadType.DirectDamage, "liquid"));
+
+		var explosiveParameters = TrapPayloadDefinition.ParametersFor(TrapPayloadType.ExplosiveDamage)
+			.ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
+		CollectionAssert.AreEquivalent(
+			new[] { "echo", "damage", "pain", "stun", "damagetype", "explosionsize", "maximumproximity", "elevation" },
+			explosiveParameters.Keys.ToList());
+		Assert.AreEqual("Shockwave", explosiveParameters["damagetype"].DefaultValue);
+		Assert.AreEqual("Normal", explosiveParameters["explosionsize"].DefaultValue);
+		Assert.AreEqual("Proximate", explosiveParameters["maximumproximity"].DefaultValue);
+		Assert.AreEqual("0", explosiveParameters["elevation"].DefaultValue);
+		StringAssert.Contains(explosiveParameters["elevation"].Description, "height");
 
 		var gasParameters = TrapPayloadDefinition.ParametersFor(TrapPayloadType.GasCloud)
 			.Select(x => x.Name)
@@ -140,6 +185,226 @@ public class TrapModuleDefinitionTests
 		CollectionAssert.IsSubsetOf(
 			new[] { "echo", "gas", "dose", "duration", "cloudecho" },
 			gasParameters.ToList());
+	}
+
+	[TestMethod]
+	public void TrapParameterValidation_RejectsInvalidValuesForEveryTypedParameter()
+	{
+		var invalidTriggerParameters = new[]
+		{
+			(Type: TrapTriggerType.Openable, Name: "chance", Value: "101"),
+			(Type: TrapTriggerType.Openable, Name: "spotdifficulty", Value: "not-a-difficulty"),
+			(Type: TrapTriggerType.Openable, Name: "avoiddifficulty", Value: "not-a-difficulty"),
+			(Type: TrapTriggerType.Openable, Name: "filterprog", Value: "0"),
+			(Type: TrapTriggerType.Openable, Name: "triggerecho", Value: " "),
+			(Type: TrapTriggerType.ExitTraversal, Name: "movementtypes", Value: "Teleporting"),
+			(Type: TrapTriggerType.ExitTraversal, Name: "minimumsize", Value: "Colossal"),
+			(Type: TrapTriggerType.ExitTraversal, Name: "maximumsize", Value: "Colossal"),
+			(Type: TrapTriggerType.Proximity, Name: "maximumproximity", Value: "Adjacent"),
+			(Type: TrapTriggerType.Signal, Name: "minimumvalue", Value: "NaN"),
+			(Type: TrapTriggerType.Signal, Name: "maximumvalue", Value: "Infinity")
+		};
+		foreach (var parameter in invalidTriggerParameters)
+		{
+			Assert.IsFalse(TrapTriggerDefinition.TryValidateParameter(parameter.Type, parameter.Name, parameter.Value, out _),
+				$"{parameter.Type} {parameter.Name} accepted {parameter.Value}.");
+		}
+
+		var invalidPayloadParameters = new[]
+		{
+			(Type: TrapPayloadType.DirectDamage, Name: "echo", Value: " "),
+			(Type: TrapPayloadType.CastSpell, Name: "spell", Value: "0"),
+			(Type: TrapPayloadType.CastSpell, Name: "power", Value: "Impossible"),
+			(Type: TrapPayloadType.EmitSignal, Name: "targetitem", Value: "0"),
+			(Type: TrapPayloadType.EmitSignal, Name: "value", Value: "NaN"),
+			(Type: TrapPayloadType.ExecuteProg, Name: "prog", Value: "0"),
+			(Type: TrapPayloadType.DirectDamage, Name: "damage", Value: "traitbonus + 1"),
+			(Type: TrapPayloadType.DirectDamage, Name: "damage", Value: "-1"),
+			(Type: TrapPayloadType.DirectDamage, Name: "pain", Value: "damage - 1"),
+			(Type: TrapPayloadType.DirectDamage, Name: "damagetype", Value: "Disintegration"),
+			(Type: TrapPayloadType.ExplosiveDamage, Name: "explosionsize", Value: "Unreal"),
+			(Type: TrapPayloadType.ExplosiveDamage, Name: "maximumproximity", Value: "Unapproximable"),
+			(Type: TrapPayloadType.ExplosiveDamage, Name: "elevation", Value: "NaN"),
+			(Type: TrapPayloadType.LiquidDischarge, Name: "liquid", Value: "0"),
+			(Type: TrapPayloadType.LiquidDischarge, Name: "amount", Value: "-0.1"),
+			(Type: TrapPayloadType.GasCloud, Name: "gas", Value: "0"),
+			(Type: TrapPayloadType.GasCloud, Name: "dose", Value: "0"),
+			(Type: TrapPayloadType.GasCloud, Name: "duration", Value: "-00:00:01"),
+			(Type: TrapPayloadType.GasCloud, Name: "cloudecho", Value: " "),
+			(Type: TrapPayloadType.Restraint, Name: "duration", Value: "00:00:00"),
+			(Type: TrapPayloadType.Restraint, Name: "description", Value: " ")
+		};
+		foreach (var parameter in invalidPayloadParameters)
+		{
+			Assert.IsFalse(TrapPayloadDefinition.TryValidateParameter(parameter.Type, parameter.Name, parameter.Value, out _),
+				$"{parameter.Type} {parameter.Name} accepted {parameter.Value}.");
+		}
+	}
+
+	[TestMethod]
+	public void TrapParameterValidation_RejectsInvalidRangesAndRestoresOptionalDefaults()
+	{
+		Assert.IsFalse(TrapTriggerDefinition.TryValidateParameters(TrapTriggerType.Signal,
+			new Dictionary<string, string>
+			{
+				["minimumvalue"] = "2",
+				["maximumvalue"] = "1"
+			}, out var signalError));
+		StringAssert.Contains(signalError, "minimumvalue");
+
+		Assert.IsFalse(TrapTriggerDefinition.TryValidateParameters(TrapTriggerType.ExitTraversal,
+			new Dictionary<string, string>
+			{
+				["minimumsize"] = "Large",
+				["maximumsize"] = "Small"
+			}, out var sizeError));
+		StringAssert.Contains(sizeError, "minimumsize");
+
+		Assert.IsFalse(TrapPayloadDefinition.TryValidateParameters(TrapPayloadType.DirectDamage,
+			new Dictionary<string, string> { ["damagetype"] = "999" }, out var damageError));
+		StringAssert.Contains(damageError, "damagetype");
+
+		var payload = new TrapPayloadDefinition(TrapPayloadType.DirectDamage);
+		payload.SetParameter("echo", "A sharp crack sounds.");
+		payload.SetParameter("echo", "none");
+		Assert.IsFalse(payload.Parameters.ContainsKey("echo"));
+		Assert.IsTrue(payload.SetParameter("damage", "1d40 + quality"));
+		Assert.AreEqual("1d40 + quality", payload.Parameters["damage"]);
+		Assert.IsTrue(payload.SetParameter("pain", "damage + power"));
+		Assert.AreEqual("damage + power", payload.Parameters["pain"]);
+		Assert.IsFalse(payload.SetParameter("stun", "damage / 0"));
+		Assert.IsFalse(payload.Parameters.ContainsKey("stun"));
+
+		Assert.IsTrue(TrapParameterValidation.TryEvaluateDamageExpression("damage + quality + power", 7.0,
+			SpellPower.Strong, 3.0, out var evaluated, out _));
+		Assert.AreEqual(16.0, evaluated);
+	}
+
+	[TestMethod]
+	public void DirectDamagePayload_EvaluatesDamagePainAndStunFormulasAtResolution()
+	{
+		var gameworld = new Mock<IFuturemud>();
+		var owner = new Mock<ICell>();
+		owner.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		var template = new Mock<ITrapTemplate>();
+		template.SetupGet(x => x.Id).Returns(300L);
+		template.SetupGet(x => x.RevisionNumber).Returns(4);
+		template.SetupGet(x => x.Charges).Returns(1);
+		var templates = new RevisableAll<ITrapTemplate>();
+		templates.Add(template.Object);
+		gameworld.SetupGet(x => x.TrapTemplates).Returns(templates);
+		var bodypart = new Mock<IBodypart>();
+		var body = new Mock<IBody>();
+		body.SetupGet(x => x.RandomBodypart).Returns(bodypart.Object);
+		var target = new Mock<ICharacter>();
+		target.SetupGet(x => x.Body).Returns(body.Object);
+		target.Setup(x => x.SufferDamage(It.IsAny<IDamage>()))
+			.Returns(Enumerable.Empty<IWound>());
+		var payload = new TrapPayloadDefinition(TrapPayloadType.DirectDamage);
+		Assert.IsTrue(payload.SetParameter("damage", "quality + power"));
+		Assert.IsTrue(payload.SetParameter("pain", "damage + 2"));
+		Assert.IsTrue(payload.SetParameter("stun", "power"));
+
+		var trap = new TrapEffect(owner.Object, template.Object, power: SpellPower.Strong);
+		typeof(TrapEffect).GetMethod("ExecuteDamagePayload", BindingFlags.Instance | BindingFlags.NonPublic)!
+			.Invoke(trap, [payload, target.Object]);
+
+		target.Verify(x => x.SufferDamage(It.Is<IDamage>(damage =>
+			damage.DamageAmount == 11.0 && damage.PainAmount == 13.0 && damage.StunAmount == 6.0)), Times.Once);
+	}
+
+	[TestMethod]
+	public void InvalidPayloadTargetSelector_FailsClosedAtRuntime()
+	{
+		var gameworld = new Mock<IFuturemud>();
+		var owner = new Mock<ICell>();
+		owner.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		var template = new Mock<ITrapTemplate>();
+		template.SetupGet(x => x.Id).Returns(300L);
+		template.SetupGet(x => x.RevisionNumber).Returns(4);
+		template.SetupGet(x => x.Charges).Returns(1);
+		var templates = new RevisableAll<ITrapTemplate>();
+		templates.Add(template.Object);
+		gameworld.SetupGet(x => x.TrapTemplates).Returns(templates);
+		var target = new Mock<ICharacter>();
+		target.Setup(x => x.SufferDamage(It.IsAny<IDamage>())).Returns(Enumerable.Empty<IWound>());
+		var payload = new TrapPayloadDefinition(TrapPayloadType.DirectDamage);
+		Assert.IsTrue(payload.SetParameter("damage", "1"));
+		payload.SetTargetSelector((TrapTargetSelector)(-1));
+
+		var trap = new TrapEffect(owner.Object, template.Object);
+		typeof(TrapEffect).GetMethod("ExecutePayload", BindingFlags.Instance | BindingFlags.NonPublic, null,
+			[typeof(ITrapPayload), typeof(ICharacter)], null)!
+			.Invoke(trap, [payload, target.Object]);
+
+		target.Verify(x => x.SufferDamage(It.IsAny<IDamage>()), Times.Never);
+	}
+
+	[TestMethod]
+	public void InvalidManualTrigger_FailsClosedBeforeConsumingACharge()
+	{
+		var gameworld = new Mock<IFuturemud>();
+		var owner = new Mock<ICell>();
+		owner.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		var invalidManualTrigger = TrapTriggerDefinition.LoadFromXml(
+			XElement.Parse("<Trigger type=\"Manual\"><Parameter name=\"chance\">101</Parameter></Trigger>"));
+		var template = new Mock<ITrapTemplate>();
+		template.SetupGet(x => x.Id).Returns(300L);
+		template.SetupGet(x => x.RevisionNumber).Returns(4);
+		template.SetupGet(x => x.Charges).Returns(1);
+		template.SetupGet(x => x.Triggers).Returns(new ITrapTrigger[] { invalidManualTrigger });
+		template.SetupGet(x => x.Payloads).Returns(Array.Empty<ITrapPayload>());
+		var templates = new RevisableAll<ITrapTemplate>();
+		templates.Add(template.Object);
+		gameworld.SetupGet(x => x.TrapTemplates).Returns(templates);
+
+		var trap = new TrapEffect(owner.Object, template.Object);
+
+		Assert.IsFalse(trap.TriggerManually());
+		Assert.AreEqual(TrapState.Armed, trap.State);
+		Assert.AreEqual(1, trap.ChargesRemaining);
+	}
+
+	[TestMethod]
+	public void ExplosiveDamagePayload_UsesStandardExplosionHandlingWithConfiguredPacket()
+	{
+		var gameworld = new Mock<IFuturemud>();
+		var owner = new Mock<ICell>();
+		owner.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		IExplosiveDamage? resolvedExplosion = null;
+		owner.Setup(x => x.ExplosionEmantingFromPerceivable(It.IsAny<IExplosiveDamage>()))
+			.Callback<IExplosiveDamage>(explosion => resolvedExplosion = explosion)
+			.Returns(Enumerable.Empty<IWound>());
+		var template = new Mock<ITrapTemplate>();
+		template.SetupGet(x => x.Id).Returns(300L);
+		template.SetupGet(x => x.RevisionNumber).Returns(4);
+		template.SetupGet(x => x.Charges).Returns(1);
+		var templates = new RevisableAll<ITrapTemplate>();
+		templates.Add(template.Object);
+		gameworld.SetupGet(x => x.TrapTemplates).Returns(templates);
+		var payload = new TrapPayloadDefinition(TrapPayloadType.ExplosiveDamage);
+		Assert.IsTrue(payload.SetParameter("damage", "quality + power"));
+		Assert.IsTrue(payload.SetParameter("pain", "damage + 2"));
+		Assert.IsTrue(payload.SetParameter("stun", "power"));
+		Assert.IsTrue(payload.SetParameter("damagetype", "Electrical"));
+		Assert.IsTrue(payload.SetParameter("explosionsize", "Large"));
+		Assert.IsTrue(payload.SetParameter("maximumproximity", "Distant"));
+		Assert.IsTrue(payload.SetParameter("elevation", "1.5"));
+
+		var trap = new TrapEffect(owner.Object, template.Object, power: SpellPower.Strong);
+		typeof(TrapEffect).GetMethod("ExecuteExplosiveDamagePayload", BindingFlags.Instance | BindingFlags.NonPublic)!
+			.Invoke(trap, [payload]);
+
+		owner.Verify(x => x.ExplosionEmantingFromPerceivable(It.IsAny<IExplosiveDamage>()), Times.Once);
+		Assert.IsNotNull(resolvedExplosion);
+		Assert.AreEqual(SizeCategory.Large, resolvedExplosion.ExplosionSize);
+		Assert.AreEqual(Proximity.Distant, resolvedExplosion.MaximumProximity);
+		Assert.AreEqual(1.5, resolvedExplosion.Elevation);
+		var damage = resolvedExplosion.ReferenceDamages.Single();
+		Assert.AreEqual(DamageType.Electrical, damage.DamageType);
+		Assert.AreEqual(11.0, damage.DamageAmount);
+		Assert.AreEqual(13.0, damage.PainAmount);
+		Assert.AreEqual(6.0, damage.StunAmount);
 	}
 
 	[TestMethod]

--- a/MudSharpCore/Effects/Concrete/TrapEffect.cs
+++ b/MudSharpCore/Effects/Concrete/TrapEffect.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System.Globalization;
+using ExpressionEngine;
 using MudSharp.Character;
 using MudSharp.Character.Heritage;
 using MudSharp.Body;
@@ -136,13 +137,14 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 	}
 
 	public TrapEffect(IPerceivable owner, ITrapTemplate template, ICharacter? creator = null, ICellExit? boundExit = null,
-		IEnumerable<TrapComponentBinding>? components = null)
+		IEnumerable<TrapComponentBinding>? components = null, SpellPower power = SpellPower.Standard)
 		: base(owner)
 	{
 		InstanceId = Guid.NewGuid();
 		TemplateId = template.Id;
 		TemplateRevision = template.RevisionNumber;
 		CreatorId = creator?.Id ?? 0L;
+		Power = power;
 		ChargesRemaining = template.Charges;
 		State = TrapState.Armed;
 		BoundExitId = boundExit?.Exit.Id;
@@ -150,13 +152,15 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 		_components.AddRange(components ?? []);
 	}
 
-	internal TrapEffect(IPerceivable owner, ITrapTemplate template, Guid instanceId, long creatorId)
+	internal TrapEffect(IPerceivable owner, ITrapTemplate template, Guid instanceId, long creatorId,
+		SpellPower power = SpellPower.Standard)
 		: base(owner)
 	{
 		InstanceId = instanceId;
 		TemplateId = template.Id;
 		TemplateRevision = template.RevisionNumber;
 		CreatorId = creatorId;
+		Power = power;
 		ChargesRemaining = 0;
 		State = TrapState.Resolving;
 	}
@@ -169,6 +173,10 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 		TemplateId = long.Parse(effect.Element("TemplateId")!.Value);
 		TemplateRevision = int.Parse(effect.Element("TemplateRevision")!.Value);
 		CreatorId = long.Parse(effect.Element("CreatorId")?.Value ?? "0");
+		Power = TrapParameterValidation.TryParseDefinedEnum<SpellPower>(effect.Element("Power")?.Value ?? string.Empty,
+			out var power)
+			? power
+			: SpellPower.Standard;
 		ChargesRemaining = int.Parse(effect.Element("ChargesRemaining")?.Value ?? "0");
 		State = Enum.TryParse(effect.Element("State")?.Value, true, out TrapState state)
 			? state
@@ -186,6 +194,7 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 	public int TemplateRevision { get; }
 	public int TemplateRevisionNumber => TemplateRevision;
 	public long CreatorId { get; }
+	public SpellPower Power { get; }
 	public int ChargesRemaining { get; private set; }
 	public int RemainingCharges => ChargesRemaining;
 	public long? BoundExitId { get; }
@@ -244,6 +253,7 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 			new XElement("TemplateId", TemplateId),
 			new XElement("TemplateRevision", TemplateRevision),
 			new XElement("CreatorId", CreatorId),
+			new XElement("Power", Power),
 			new XElement("ChargesRemaining", ChargesRemaining),
 			new XElement("State", State),
 			BoundExitId.HasValue ? new XElement("BoundExitId", BoundExitId.Value) : null,
@@ -524,7 +534,8 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 		if (!force)
 		{
 			var activeTrigger = trigger!;
-			if (!PassesTriggerFilter(activeTrigger, triggerer, triggerSource) || !PassesChance(activeTrigger.Parameters))
+			if (!TrapTriggerDefinition.TryValidateParameters(activeTrigger.TriggerType, activeTrigger.Parameters, out _) ||
+			    !PassesTriggerFilter(activeTrigger, triggerer, triggerSource) || !PassesChance(activeTrigger.Parameters))
 			{
 				return false;
 			}
@@ -558,7 +569,13 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 
 		foreach ((ITrapPayload payload, int index) in template.Payloads.Select((payload, index) => (payload, index)))
 		{
-			if (payload.PayloadType is TrapPayloadType.DetonateItem or TrapPayloadType.EmitSignal or TrapPayloadType.GasCloud)
+			if (payload.Delay < TimeSpan.Zero || !Enum.IsDefined(payload.TargetSelector) ||
+			    !TrapPayloadDefinition.TryValidateParameters(payload.PayloadType, payload.Parameters, out _))
+			{
+				continue;
+			}
+
+			if (payload.PayloadType is TrapPayloadType.DetonateItem or TrapPayloadType.EmitSignal or TrapPayloadType.GasCloud or TrapPayloadType.ExplosiveDamage)
 			{
 				ScheduleOrExecutePayload(payload, index, null);
 				continue;
@@ -583,6 +600,11 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 
 	private bool MatchesEvent(ITrapTrigger trigger, EventType eventType, dynamic[] arguments)
 	{
+		if (!TrapTriggerDefinition.TryValidateParameters(trigger.TriggerType, trigger.Parameters, out _))
+		{
+			return false;
+		}
+
 		switch (trigger.TriggerType)
 		{
 			case TrapTriggerType.Openable:
@@ -785,6 +807,7 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 					TemplateId,
 					TemplateRevision,
 					CreatorId,
+					Power,
 					index,
 					target?.Id ?? 0L),
 				payload.Delay);
@@ -897,6 +920,12 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 
 	private void ExecutePayload(ITrapPayload payload, ICharacter? target)
 	{
+		if (payload.Delay < TimeSpan.Zero || !Enum.IsDefined(payload.TargetSelector) ||
+		    !TrapPayloadDefinition.TryValidateParameters(payload.PayloadType, payload.Parameters, out _))
+		{
+			return;
+		}
+
 		SendEcho(payload.Parameters, "echo", target);
 
 		switch (payload.PayloadType)
@@ -927,6 +956,10 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 				}
 				break;
 
+			case TrapPayloadType.ExplosiveDamage:
+				ExecuteExplosiveDamagePayload(payload);
+				break;
+
 			case TrapPayloadType.LiquidDischarge:
 				if (target is not null)
 				{
@@ -950,7 +983,7 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 	private void ExecuteSpellPayload(ITrapPayload payload, ICharacter target)
 	{
 		if (!payload.Parameters.TryGetValue("spell", out var spellText) ||
-		    !long.TryParse(spellText, out var spellId))
+		    !TrapParameterValidation.TryParsePositiveLong(spellText, out var spellId))
 		{
 			return;
 		}
@@ -959,30 +992,48 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 		var caster = CreatorId > 0 ? Gameworld.TryGetCharacter(CreatorId, true) : null;
 		if (spell is not null && caster is not null)
 		{
-			var power = payload.Parameters.TryGetValue("power", out var powerText) &&
-			            Enum.TryParse(powerText, true, out SpellPower parsedPower)
-				? parsedPower
-				: SpellPower.Standard;
+			var power = SpellPower.Standard;
+			if (payload.Parameters.TryGetValue("power", out var powerText))
+			{
+				if (!TrapParameterValidation.TryParseDefinedEnum<SpellPower>(powerText, out power))
+				{
+					return;
+				}
+			}
+
 			spell.ResolveTriggeredSpell(caster, target, power);
 		}
 	}
 
 	private void ExecuteSignalPayload(ITrapPayload payload)
 	{
-		var targetItem = payload.Parameters.TryGetValue("targetitem", out var targetItemText) &&
-		                 long.TryParse(targetItemText, out var targetItemId) &&
-		                 targetItemId > 0L
-			? Gameworld.TryGetItem(targetItemId, true)
-			: FindPayloadItem(x => x.Components.OfType<ISignalSink>().Any());
+		IGameItem? targetItem;
+		if (payload.Parameters.TryGetValue("targetitem", out var targetItemText))
+		{
+			if (!TrapParameterValidation.TryParsePositiveLong(targetItemText, out var targetItemId))
+			{
+				return;
+			}
+
+			targetItem = Gameworld.TryGetItem(targetItemId, true);
+		}
+		else
+		{
+			targetItem = FindPayloadItem(x => x.Components.OfType<ISignalSink>().Any());
+		}
+
 		if (targetItem is null)
 		{
 			return;
 		}
 
-		var value = payload.Parameters.TryGetValue("value", out var valueText) &&
-		            double.TryParse(valueText, out var parsedValue)
-			? parsedValue
-			: 1.0;
+		var value = 1.0;
+		if (payload.Parameters.TryGetValue("value", out var valueText) &&
+		    !TrapParameterValidation.TryParseFiniteDouble(valueText, out value))
+		{
+			return;
+		}
+
 		var signal = new ComputerSignal(value, null, null);
 		var source = new TrapSignalSource(this, signal);
 		foreach (ISignalSink sink in targetItem.Components.OfType<ISignalSink>())
@@ -994,7 +1045,7 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 	private void ExecuteProgPayload(ITrapPayload payload, ICharacter? target)
 	{
 		if (!payload.Parameters.TryGetValue("prog", out var progText) ||
-		    !long.TryParse(progText, out var progId))
+		    !TrapParameterValidation.TryParsePositiveLong(progText, out var progId))
 		{
 			return;
 		}
@@ -1025,32 +1076,108 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 
 	private void ExecuteDamagePayload(ITrapPayload payload, ICharacter target)
 	{
-		var amount = payload.Parameters.TryGetValue("damage", out var amountText) &&
-		             double.TryParse(amountText, out var parsedAmount)
-			? Math.Max(0.0, parsedAmount)
-			: 1.0;
-		amount *= PayloadQualityMultiplier;
-		var damageType = payload.Parameters.TryGetValue("damagetype", out var damageTypeText) &&
-		                 Enum.TryParse(damageTypeText, true, out DamageType parsedType)
-			? parsedType
-			: DamageType.Piercing;
+		if (!payload.Parameters.TryGetValue("damage", out var damageFormula) ||
+		    !TrapParameterValidation.TryEvaluateDamageExpression(damageFormula, PayloadQuality, Power, 0.0,
+			    out var damage, out _) ||
+		    !TryEvaluateDamageFormula(payload, "pain", damage, out var pain) ||
+		    !TryEvaluateDamageFormula(payload, "stun", damage, out var stun) ||
+		    damage <= 0.0 && pain <= 0.0 && stun <= 0.0)
+		{
+			return;
+		}
+
+		var damageType = DamageType.Piercing;
+		if (payload.Parameters.TryGetValue("damagetype", out var damageTypeText) &&
+		    !TrapParameterValidation.TryParseDefinedEnum<DamageType>(damageTypeText, out damageType))
+		{
+			return;
+		}
+
 		target.SufferDamage(new Damage
 		{
 			ActorOrigin = CreatorId > 0 ? Gameworld.TryGetCharacter(CreatorId, true) : null,
 			ToolOrigin = FindPayloadItem(_ => true),
 			Bodypart = target.Body.RandomBodypart,
-			DamageAmount = amount,
-			PainAmount = amount,
-			StunAmount = amount,
+			DamageAmount = damage,
+			PainAmount = pain,
+			StunAmount = stun,
 			DamageType = damageType
 		}).ProcessPassiveWounds();
 		RecordHarmCrime(target);
 	}
 
+	private bool TryEvaluateDamageFormula(ITrapPayload payload, string parameterName, double damage,
+		out double result)
+	{
+		result = damage;
+		return !payload.Parameters.TryGetValue(parameterName, out var formula) ||
+		       TrapParameterValidation.TryEvaluateDamageExpression(formula, PayloadQuality, Power, damage,
+			       out result, out _);
+	}
+
+	private void ExecuteExplosiveDamagePayload(ITrapPayload payload)
+	{
+		if (!payload.Parameters.TryGetValue("damage", out var damageFormula) ||
+		    !TrapParameterValidation.TryEvaluateDamageExpression(damageFormula, PayloadQuality, Power, 0.0,
+			    out var damage, out _) ||
+		    !TryEvaluateDamageFormula(payload, "pain", damage, out var pain) ||
+		    !TryEvaluateDamageFormula(payload, "stun", damage, out var stun) ||
+		    damage <= 0.0 && pain <= 0.0 && stun <= 0.0)
+		{
+			return;
+		}
+
+		var damageType = DamageType.Shockwave;
+		if (payload.Parameters.TryGetValue("damagetype", out var damageTypeText) &&
+		    !TrapParameterValidation.TryParseDefinedEnum<DamageType>(damageTypeText, out damageType))
+		{
+			return;
+		}
+
+		var explosionSize = SizeCategory.Normal;
+		if (payload.Parameters.TryGetValue("explosionsize", out var explosionSizeText) &&
+		    !TrapParameterValidation.TryParseDefinedEnum<SizeCategory>(explosionSizeText, out explosionSize))
+		{
+			return;
+		}
+
+		var maximumProximity = Proximity.Proximate;
+		if (payload.Parameters.TryGetValue("maximumproximity", out var maximumProximityText) &&
+		    !TrapParameterValidation.TryParseExplosionMaximumProximity(maximumProximityText, out maximumProximity))
+		{
+			return;
+		}
+
+		var elevation = 0.0;
+		if (payload.Parameters.TryGetValue("elevation", out var elevationText) &&
+		    !TrapParameterValidation.TryParseFiniteDouble(elevationText, out elevation))
+		{
+			return;
+		}
+
+		var explosiveDamage = new ExplosiveDamage(
+			new[]
+			{
+				new Damage
+				{
+					ActorOrigin = CreatorId > 0 ? Gameworld.TryGetCharacter(CreatorId, true) : null,
+					ToolOrigin = FindPayloadItem(_ => true),
+					DamageAmount = damage,
+					PainAmount = pain,
+					StunAmount = stun,
+					DamageType = damageType
+				}
+			},
+			elevation,
+			explosionSize,
+			maximumProximity);
+		Owner.ExplosionEmantingFromPerceivable(explosiveDamage).ProcessPassiveWounds();
+	}
+
 	private void ExecuteLiquidPayload(ITrapPayload payload, ICharacter target)
 	{
 		if (!payload.Parameters.TryGetValue("liquid", out var liquidText) ||
-		    !long.TryParse(liquidText, out var liquidId))
+		    !TrapParameterValidation.TryParsePositiveLong(liquidText, out var liquidId))
 		{
 			return;
 		}
@@ -1061,10 +1188,13 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 			return;
 		}
 
-		var amount = payload.Parameters.TryGetValue("amount", out var amountText) &&
-		             double.TryParse(amountText, out var parsedAmount)
-			? Math.Max(0.0, parsedAmount)
-			: 0.1;
+		var amount = 0.1;
+		if (payload.Parameters.TryGetValue("amount", out var amountText) &&
+		    (!TrapParameterValidation.TryParseFiniteDouble(amountText, out amount) || amount <= 0.0))
+		{
+			return;
+		}
+
 		amount *= PayloadQualityMultiplier;
 		var mixture = new LiquidMixture(liquid, amount, Gameworld);
 		target.Body.ExposeToLiquid(mixture,
@@ -1075,7 +1205,7 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 	private void ExecuteGasPayload(ITrapPayload payload, ICharacter? target)
 	{
 		if (!payload.Parameters.TryGetValue("gas", out var gasText) ||
-		    !long.TryParse(gasText, out var gasId))
+		    !TrapParameterValidation.TryParsePositiveLong(gasText, out var gasId))
 		{
 			return;
 		}
@@ -1087,14 +1217,20 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 			return;
 		}
 
-		var duration = payload.Parameters.TryGetValue("duration", out var durationText) &&
-		               TimeSpan.TryParse(durationText, out var parsedDuration) && parsedDuration > TimeSpan.Zero
-			? parsedDuration
-			: TimeSpan.FromSeconds(30);
-		var dose = payload.Parameters.TryGetValue("dose", out var doseText) &&
-		           double.TryParse(doseText, out var parsedDose)
-			? Math.Max(0.0, parsedDose)
-			: gas.DrugGramsPerUnitVolume;
+		var duration = TimeSpan.FromSeconds(30);
+		if (payload.Parameters.TryGetValue("duration", out var durationText) &&
+		    (!TimeSpan.TryParse(durationText, CultureInfo.InvariantCulture, out duration) || duration <= TimeSpan.Zero))
+		{
+			return;
+		}
+
+		var dose = gas.DrugGramsPerUnitVolume;
+		if (payload.Parameters.TryGetValue("dose", out var doseText) &&
+		    (!TrapParameterValidation.TryParseFiniteDouble(doseText, out dose) || dose <= 0.0))
+		{
+			return;
+		}
+
 		dose *= PayloadQualityMultiplier;
 		var echo = payload.Parameters.TryGetValue("cloudecho", out var cloudEcho)
 			? cloudEcho
@@ -1104,10 +1240,13 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 
 	private void ExecuteRestraintPayload(ITrapPayload payload, ICharacter target)
 	{
-		var duration = payload.Parameters.TryGetValue("duration", out var durationText) &&
-		               TimeSpan.TryParse(durationText, out var parsedDuration) && parsedDuration > TimeSpan.Zero
-			? parsedDuration
-			: TimeSpan.FromSeconds(30);
+		var duration = TimeSpan.FromSeconds(30);
+		if (payload.Parameters.TryGetValue("duration", out var durationText) &&
+		    (!TimeSpan.TryParse(durationText, CultureInfo.InvariantCulture, out duration) || duration <= TimeSpan.Zero))
+		{
+			return;
+		}
+
 		duration *= PayloadQualityMultiplier;
 		var description = payload.Parameters.TryGetValue("description", out var descriptionText)
 			? descriptionText
@@ -1144,7 +1283,11 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 			return;
 		}
 
-		(target.Location ?? Owner.Location)?.HandleRoomEcho(new EmoteOutput(new Emote(echo, target, target)));
+		var emote = new Emote(echo, target, target);
+		if (emote.Valid)
+		{
+			(target.Location ?? Owner.Location)?.HandleRoomEcho(new EmoteOutput(emote));
+		}
 	}
 
 	private static Difficulty ParseDifficulty(IReadOnlyDictionary<string, string> parameters, string parameterName,
@@ -1259,6 +1402,20 @@ public sealed class TrapEffect : Effect, ITrap, IHandleEventsEffect, IEvaluateDe
 
 	private double PayloadQualityMultiplier => Math.Clamp(1.0 + QualityStageScore(TrapComponentRole.Payload) * 0.05,
 		0.5, 1.5);
+
+	private double PayloadQuality
+	{
+		get
+		{
+			var weighted = _components
+				.Where(x => x.Role.HasFlag(TrapComponentRole.Payload) && x.Item is not null && x.QualityWeight > 0.0)
+				.Select(x => (Quality: (double)(int)x.Item!.Quality, x.QualityWeight))
+				.ToList();
+			return weighted.Count == 0
+				? (int)ItemQuality.Standard
+				: weighted.Sum(x => x.Quality * x.QualityWeight) / weighted.Sum(x => x.QualityWeight);
+		}
+	}
 
 	private void ReserveComponents()
 	{
@@ -1462,13 +1619,14 @@ public sealed class TrapPayloadScheduleEffect : Effect
 	}
 
 	public TrapPayloadScheduleEffect(IPerceivable owner, Guid trapInstanceId, long templateId, int templateRevision,
-		long creatorId, int payloadIndex, long targetCharacterId)
+		long creatorId, SpellPower power, int payloadIndex, long targetCharacterId)
 		: base(owner)
 	{
 		TrapInstanceId = trapInstanceId;
 		TemplateId = templateId;
 		TemplateRevision = templateRevision;
 		CreatorId = creatorId;
+		Power = power;
 		PayloadIndex = payloadIndex;
 		TargetCharacterId = targetCharacterId;
 	}
@@ -1481,6 +1639,10 @@ public sealed class TrapPayloadScheduleEffect : Effect
 		TemplateId = long.Parse(effect.Element("TemplateId")?.Value ?? "0");
 		TemplateRevision = int.Parse(effect.Element("TemplateRevision")?.Value ?? "0");
 		CreatorId = long.Parse(effect.Element("CreatorId")?.Value ?? "0");
+		Power = TrapParameterValidation.TryParseDefinedEnum<SpellPower>(effect.Element("Power")?.Value ?? string.Empty,
+			out var power)
+			? power
+			: SpellPower.Standard;
 		PayloadIndex = int.Parse(effect.Element("PayloadIndex")!.Value);
 		TargetCharacterId = long.Parse(effect.Element("TargetCharacterId")!.Value);
 	}
@@ -1489,6 +1651,7 @@ public sealed class TrapPayloadScheduleEffect : Effect
 	public long TemplateId { get; }
 	public int TemplateRevision { get; }
 	public long CreatorId { get; }
+	public SpellPower Power { get; }
 	public int PayloadIndex { get; }
 	public long TargetCharacterId { get; }
 	public override bool SavingEffect => true;
@@ -1501,6 +1664,7 @@ public sealed class TrapPayloadScheduleEffect : Effect
 			new XElement("TemplateId", TemplateId),
 			new XElement("TemplateRevision", TemplateRevision),
 			new XElement("CreatorId", CreatorId),
+			new XElement("Power", Power),
 			new XElement("PayloadIndex", PayloadIndex),
 			new XElement("TargetCharacterId", TargetCharacterId));
 	}
@@ -1516,7 +1680,7 @@ public sealed class TrapPayloadScheduleEffect : Effect
 			var template = Gameworld.TrapTemplates.Get(TemplateId, TemplateRevision);
 			if (template is not null)
 			{
-				trap = new TrapEffect(Owner, template, TrapInstanceId, CreatorId);
+				trap = new TrapEffect(Owner, template, TrapInstanceId, CreatorId, Power);
 			}
 		}
 

--- a/MudSharpCore/Magic/SpellEffects/CreateTrapSpellEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/CreateTrapSpellEffect.cs
@@ -140,7 +140,7 @@ public sealed class CreateTrapSpellEffect : IMagicSpellEffectTemplate
 			return null;
 		}
 
-		var trap = new TrapEffect(anchor, template, caster, boundExit);
+		var trap = new TrapEffect(anchor, template, caster, boundExit, power: power);
 		if (TrapEffect.HasTimedLifetime(template))
 		{
 			anchor.AddEffect(trap, template.Lifespan!.Value);

--- a/MudSharpCore/Traps/TrapModuleDefinitions.cs
+++ b/MudSharpCore/Traps/TrapModuleDefinitions.cs
@@ -1,11 +1,15 @@
 #nullable enable
 
 using System.Globalization;
+using ExpressionEngine;
 using MudSharp.Traps;
 using MudSharp.Movement;
 using MudSharp.Framework;
+using MudSharp.Construction;
+using MudSharp.GameItems;
 using MudSharp.Health;
 using MudSharp.Magic;
+using MudSharp.RPG.Checks;
 
 namespace MudSharp.Traps;
 
@@ -59,15 +63,16 @@ public sealed class TrapComponentRequirementDefinition : ITrapComponentRequireme
 /// </summary>
 public sealed class TrapTriggerDefinition : ITrapTrigger
 {
-	public sealed record ParameterHelp(string Name, string Description, string DefaultValue);
+	public sealed record ParameterHelp(string Name, string Syntax, string Description, string DefaultValue,
+		bool Optional = true);
 
 	private static readonly IReadOnlyList<ParameterHelp> CommonParameters =
 	[
-		new("chance", "percentage chance that this trigger fires (0-100)", "100"),
-		new("spotdifficulty", "difficulty to notice the trap when it triggers", "Hard"),
-		new("avoiddifficulty", "difficulty to avoid the trap once triggered", "Normal"),
-		new("filterprog", "optional boolean FutureProg ID used to filter targets", "none"),
-		new("triggerecho", "optional emote shown when this trigger fires", "none")
+		new("chance", "<0-100>", "percentage chance that this trigger fires", "100"),
+		new("spotdifficulty", "<difficulty>", "difficulty to notice the trap when it triggers", "Hard"),
+		new("avoiddifficulty", "<difficulty>", "difficulty to avoid the trap once triggered", "Normal"),
+		new("filterprog", "<FutureProg ID|none>", "boolean FutureProg used to filter targets", "none"),
+		new("triggerecho", "<emote|none>", "emote shown when this trigger fires", "none")
 	];
 
 	private static readonly IReadOnlyDictionary<TrapTriggerType, IReadOnlyList<ParameterHelp>> TypeParameters =
@@ -75,18 +80,18 @@ public sealed class TrapTriggerDefinition : ITrapTrigger
 		{
 			[TrapTriggerType.ExitTraversal] =
 			[
-				new("movementtypes", $"comma-separated movement types ({string.Join(", ", Enum.GetNames<MovementType>().Where(x => x is not "None" and not "All"))})", "All"),
-				new("minimumsize", "smallest character size that can trigger it", "Miniscule"),
-				new("maximumsize", "largest character size that can trigger it", "Titanic")
+				new("movementtypes", "<All|type[,type...]>", $"movement types: {string.Join(", ", Enum.GetNames<MovementType>().Where(x => x is not "None" and not "All"))}", "All"),
+				new("minimumsize", "<size category>", "smallest character size that can trigger it", "Miniscule"),
+				new("maximumsize", "<size category>", "largest character size that can trigger it", "Titanic")
 			],
 			[TrapTriggerType.Proximity] =
 			[
-				new("maximumproximity", "proximity threshold crossed to fire the trap", "Immediate")
+				new("maximumproximity", "<proximity>", "proximity threshold crossed to fire the trap", "Immediate")
 			],
 			[TrapTriggerType.Signal] =
 			[
-				new("minimumvalue", "minimum signal value that fires the trap", "unbounded"),
-				new("maximumvalue", "maximum signal value that fires the trap", "unbounded")
+				new("minimumvalue", "<number|none>", "minimum signal value that fires the trap", "unbounded"),
+				new("maximumvalue", "<number|none>", "maximum signal value that fires the trap", "unbounded")
 			]
 		};
 
@@ -95,8 +100,94 @@ public sealed class TrapTriggerDefinition : ITrapTrigger
 
 	public static bool IsSupportedParameter(TrapTriggerType type, string name) =>
 		ParametersFor(type).Any(x => x.Name.EqualTo(name));
+
+	public static ParameterHelp? ParameterFor(TrapTriggerType type, string name) =>
+		ParametersFor(type).FirstOrDefault(x => x.Name.EqualTo(name));
+
+	public static bool TryValidateParameter(TrapTriggerType type, string name, string value, out string error)
+	{
+		var parameter = ParameterFor(type, name);
+		if (parameter is null)
+		{
+			error = $"{name} is not supported by {type.DescribeEnum()} triggers.";
+			return false;
+		}
+
+		if (string.IsNullOrWhiteSpace(value))
+		{
+			error = $"The {parameter.Name} parameter requires {parameter.Syntax}.";
+			return false;
+		}
+
+		if (parameter.Optional && value.EqualTo("none"))
+		{
+			error = string.Empty;
+			return true;
+		}
+
+		var valid = parameter.Name.CollapseString() switch
+		{
+			"chance" => TrapParameterValidation.TryParseFiniteDouble(value, out var chance) && chance is >= 0.0 and <= 100.0,
+			"spotdifficulty" or "avoiddifficulty" => TrapParameterValidation.TryParseDefinedEnum<Difficulty>(value, out _),
+			"filterprog" => TrapParameterValidation.TryParsePositiveLong(value, out _),
+			"movementtypes" => TrapParameterValidation.TryParseMovementTypes(value),
+			"minimumsize" or "maximumsize" => TrapParameterValidation.TryParseDefinedEnum<SizeCategory>(value, out _),
+			"maximumproximity" => TrapParameterValidation.TryParseDefinedEnum<Proximity>(value, out _),
+			"minimumvalue" or "maximumvalue" => TrapParameterValidation.TryParseFiniteDouble(value, out _),
+			_ => true
+		};
+		if (valid)
+		{
+			error = string.Empty;
+			return true;
+		}
+
+		error = $"The {parameter.Name} parameter requires {parameter.Syntax}.";
+		return false;
+	}
+
+	public static bool TryValidateParameters(TrapTriggerType type, IReadOnlyDictionary<string, string> parameters,
+		out string error)
+	{
+		if (!Compatibility.ContainsKey(type))
+		{
+			error = $"{type} is not a supported trap trigger type.";
+			return false;
+		}
+
+		foreach (var parameter in parameters)
+		{
+			if (!TryValidateParameter(type, parameter.Key, parameter.Value, out error))
+			{
+				return false;
+			}
+		}
+
+		if (parameters.TryGetValue("minimumvalue", out var minimumValue) &&
+		    parameters.TryGetValue("maximumvalue", out var maximumValue) &&
+		    TrapParameterValidation.TryParseFiniteDouble(minimumValue, out var minimum) &&
+		    TrapParameterValidation.TryParseFiniteDouble(maximumValue, out var maximum) && minimum > maximum)
+		{
+			error = "The minimumvalue parameter cannot exceed maximumvalue.";
+			return false;
+		}
+
+		if (parameters.TryGetValue("minimumsize", out var minimumSize) &&
+		    parameters.TryGetValue("maximumsize", out var maximumSize) &&
+		    TrapParameterValidation.TryParseDefinedEnum<SizeCategory>(minimumSize, out var minimumCategory) &&
+		    TrapParameterValidation.TryParseDefinedEnum<SizeCategory>(maximumSize, out var maximumCategory) &&
+		    minimumCategory > maximumCategory)
+		{
+			error = "The minimumsize parameter cannot exceed maximumsize.";
+			return false;
+		}
+
+		error = string.Empty;
+		return true;
+	}
 	private static readonly IReadOnlySet<TrapSourceKind> AllDomains = new HashSet<TrapSourceKind>(Enum.GetValues<TrapSourceKind>());
 	private static readonly IReadOnlySet<TrapSourceKind> MechanicalOnly = new HashSet<TrapSourceKind> { TrapSourceKind.Mechanical };
+	private static readonly IReadOnlySet<TrapSourceKind> NoDomains = new HashSet<TrapSourceKind>();
 	private static readonly IReadOnlyDictionary<TrapTriggerType, IReadOnlySet<TrapSourceKind>> Compatibility =
 		new Dictionary<TrapTriggerType, IReadOnlySet<TrapSourceKind>>
 		{
@@ -114,11 +205,33 @@ public sealed class TrapTriggerDefinition : ITrapTrigger
 	}
 
 	public TrapTriggerType TriggerType { get; }
-	public IReadOnlySet<TrapSourceKind> CompatibleSourceKinds => Compatibility[TriggerType];
+	public IReadOnlySet<TrapSourceKind> CompatibleSourceKinds => Compatibility.GetValueOrDefault(TriggerType) ?? NoDomains;
 	private readonly Dictionary<string, string> _parameters = new(StringComparer.OrdinalIgnoreCase);
 	public IReadOnlyDictionary<string, string> Parameters => _parameters;
 
-	public void SetParameter(string name, string value) => _parameters[name] = value;
+	public bool SetParameter(string name, string value)
+	{
+		if (ParameterFor(TriggerType, name)?.Optional == true && value.EqualTo("none"))
+		{
+			_parameters.Remove(name);
+			return true;
+		}
+
+		if (!TryValidateParameter(TriggerType, name, value, out _))
+		{
+			return false;
+		}
+
+		var parameters = _parameters.ToDictionary(x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase);
+		parameters[name] = value;
+		if (!TryValidateParameters(TriggerType, parameters, out _))
+		{
+			return false;
+		}
+
+		_parameters[name] = value;
+		return true;
+	}
 
 	public static TrapTriggerDefinition LoadFromXml(XElement root)
 	{
@@ -133,7 +246,10 @@ public sealed class TrapTriggerDefinition : ITrapTrigger
 			var name = parameter.Attribute("name")?.Value;
 			if (!string.IsNullOrWhiteSpace(name))
 			{
-				result.SetParameter(name, parameter.Value);
+				if (!result.SetParameter(name, parameter.Value))
+				{
+					result._parameters[name] = parameter.Value;
+				}
 			}
 		}
 
@@ -152,11 +268,12 @@ public sealed class TrapTriggerDefinition : ITrapTrigger
 
 public sealed class TrapPayloadDefinition : ITrapPayload
 {
-	public sealed record ParameterHelp(string Name, string Description, string DefaultValue);
+	public sealed record ParameterHelp(string Name, string Syntax, string Description, string DefaultValue,
+		bool Optional = true);
 
 	private static readonly IReadOnlyList<ParameterHelp> CommonParameters =
 	[
-		new("echo", "optional emote shown to each target when this payload resolves", "none")
+		new("echo", "<emote|none>", "emote shown to each target when this payload resolves", "none")
 	];
 
 	private static readonly IReadOnlyDictionary<TrapPayloadType, IReadOnlyList<ParameterHelp>> TypeParameters =
@@ -164,45 +281,58 @@ public sealed class TrapPayloadDefinition : ITrapPayload
 		{
 			[TrapPayloadType.CastSpell] =
 			[
-				new("spell", "required ready magic spell ID to resolve when the trap fires", "required"),
-				new("power", $"spell power ({string.Join(", ", Enum.GetNames<SpellPower>())})", "Standard")
+				new("spell", "<ready spell ID>", "magic spell to resolve when the trap fires", "required", false),
+				new("power", "<spell power>", $"spell power: {string.Join(", ", Enum.GetNames<SpellPower>())}", "Standard")
 			],
 			[TrapPayloadType.EmitSignal] =
 			[
-				new("targetitem", "optional item ID with a signal sink; defaults to a matched payload component", "matched payload component"),
-				new("value", "numeric signal value sent to the signal sink", "1")
+				new("targetitem", "<signal-sink item ID|none>", "item with a signal sink; none uses a matched payload component", "matched payload component"),
+				new("value", "<number|none>", "signal value sent to the signal sink", "1")
 			],
 			[TrapPayloadType.ExecuteProg] =
 			[
-				new("prog", "required FutureProg ID with a supported target and/or anchor signature", "required")
+				new("prog", "<FutureProg ID>", "FutureProg with a supported target and/or anchor signature", "required", false)
 			],
 			[TrapPayloadType.DirectDamage] =
 			[
-				new("damage", "required positive damage, pain and stun amount", "required"),
-				new("damagetype", $"damage type ({string.Join(", ", Enum.GetNames<DamageType>())})", "Piercing")
+				new("damage", "<expression>", "physical wound damage formula; may use quality and power", "required", false),
+				new("pain", "<expression|none>", "pain formula; may use damage, quality and power; none uses the resolved damage", "damage"),
+				new("stun", "<expression|none>", "stun formula; may use damage, quality and power; none uses the resolved damage", "damage"),
+				new("damagetype", "<damage type|none>", $"damage type: {string.Join(", ", Enum.GetNames<DamageType>())}", "Piercing")
+			],
+			[TrapPayloadType.ExplosiveDamage] =
+			[
+				new("damage", "<expression>", "explosion wound damage formula; may use quality and power", "required", false),
+				new("pain", "<expression|none>", "pain formula; may use damage, quality and power; none uses the resolved damage", "damage"),
+				new("stun", "<expression|none>", "stun formula; may use damage, quality and power; none uses the resolved damage", "damage"),
+				new("damagetype", "<damage type|none>", $"damage type: {string.Join(", ", Enum.GetNames<DamageType>())}", "Shockwave"),
+				new("explosionsize", "<size category|none>", $"explosion coverage size: {string.Join(", ", Enum.GetNames<SizeCategory>())}", "Normal"),
+				new("maximumproximity", "<proximity|none>", $"furthest affected proximity: {string.Join(", ", Enum.GetNames<Proximity>().Where(x => x != nameof(Proximity.Unapproximable)))}", "Proximate"),
+				new("elevation", "<finite metres|none>", "explosion height relative to the anchor, used to select affected body orientations", "0")
 			],
 			[TrapPayloadType.LiquidDischarge] =
 			[
-				new("liquid", "required liquid ID to expose targets to", "required"),
-				new("amount", "positive liquid amount in litres", "0.1")
+				new("liquid", "<liquid ID>", "liquid to expose targets to", "required", false),
+				new("amount", "<positive litres|none>", "liquid amount in litres", "0.1")
 			],
 			[TrapPayloadType.GasCloud] =
 			[
-				new("gas", "required gas ID to release", "required"),
-				new("dose", "positive inhaled drug dose per unit volume when applicable", "the gas default"),
-				new("duration", "positive cloud duration as a timespan", "00:00:30"),
-				new("cloudecho", "room text shown when the cloud is created", "A cloud of gas billows out.")
+				new("gas", "<gas ID>", "gas to release", "required", false),
+				new("dose", "<positive number|none>", "inhaled drug dose per unit volume; none uses the gas default", "the gas default"),
+				new("duration", "<positive timespan|none>", "cloud duration; none uses 30 seconds", "00:00:30"),
+				new("cloudecho", "<room text|none>", "room text shown when the cloud is created", "A cloud of gas billows out.")
 			],
 			[TrapPayloadType.Restraint] =
 			[
-				new("duration", "positive restraint duration as a timespan", "00:00:30"),
-				new("description", "description used for the target's restraint", "caught by a trap")
+				new("duration", "<positive timespan|none>", "restraint duration; none uses 30 seconds", "00:00:30"),
+				new("description", "<description|none>", "description used for the target's restraint", "caught by a trap")
 			]
 		};
 
 	private static readonly IReadOnlySet<TrapSourceKind> AllDomains = new HashSet<TrapSourceKind>(Enum.GetValues<TrapSourceKind>());
 	private static readonly IReadOnlySet<TrapSourceKind> MechanicalOnly = new HashSet<TrapSourceKind> { TrapSourceKind.Mechanical };
 	private static readonly IReadOnlySet<TrapSourceKind> MagicalOnly = new HashSet<TrapSourceKind> { TrapSourceKind.Magical };
+	private static readonly IReadOnlySet<TrapSourceKind> NoDomains = new HashSet<TrapSourceKind>();
 	private static readonly IReadOnlyDictionary<TrapPayloadType, IReadOnlySet<TrapSourceKind>> Compatibility =
 		new Dictionary<TrapPayloadType, IReadOnlySet<TrapSourceKind>>
 		{
@@ -211,6 +341,7 @@ public sealed class TrapPayloadDefinition : ITrapPayload
 			[TrapPayloadType.EmitSignal] = MechanicalOnly,
 			[TrapPayloadType.ExecuteProg] = AllDomains,
 			[TrapPayloadType.DirectDamage] = AllDomains,
+			[TrapPayloadType.ExplosiveDamage] = AllDomains,
 			[TrapPayloadType.LiquidDischarge] = AllDomains,
 			[TrapPayloadType.GasCloud] = AllDomains,
 			[TrapPayloadType.Restraint] = AllDomains
@@ -225,19 +356,108 @@ public sealed class TrapPayloadDefinition : ITrapPayload
 	}
 
 	public TrapPayloadType PayloadType { get; }
-	public IReadOnlySet<TrapSourceKind> CompatibleSourceKinds => Compatibility[PayloadType];
+	public IReadOnlySet<TrapSourceKind> CompatibleSourceKinds => Compatibility.GetValueOrDefault(PayloadType) ?? NoDomains;
 	public TimeSpan Delay { get; private set; }
 	public TrapTargetSelector TargetSelector { get; private set; }
 	private readonly Dictionary<string, string> _parameters = new(StringComparer.OrdinalIgnoreCase);
 	public IReadOnlyDictionary<string, string> Parameters => _parameters;
-
-	public void SetParameter(string name, string value) => _parameters[name] = value;
 
 	public static IEnumerable<ParameterHelp> ParametersFor(TrapPayloadType type) =>
 		CommonParameters.Concat(TypeParameters.GetValueOrDefault(type) ?? []);
 
 	public static bool IsSupportedParameter(TrapPayloadType type, string name) =>
 		ParametersFor(type).Any(x => x.Name.EqualTo(name));
+
+	public static ParameterHelp? ParameterFor(TrapPayloadType type, string name) =>
+		ParametersFor(type).FirstOrDefault(x => x.Name.EqualTo(name));
+
+	public static bool TryValidateParameter(TrapPayloadType type, string name, string value, out string error)
+	{
+		var parameter = ParameterFor(type, name);
+		if (parameter is null)
+		{
+			error = $"{name} is not supported by {type.DescribeEnum()} payloads.";
+			return false;
+		}
+
+		if (string.IsNullOrWhiteSpace(value))
+		{
+			error = $"The {parameter.Name} parameter requires {parameter.Syntax}.";
+			return false;
+		}
+
+		if (parameter.Optional && value.EqualTo("none"))
+		{
+			error = string.Empty;
+			return true;
+		}
+
+		var collapsedName = parameter.Name.CollapseString();
+		if (collapsedName is "damage" or "pain" or "stun")
+		{
+			return TrapParameterValidation.TryValidateDamageExpression(collapsedName, value, out error);
+		}
+
+		var valid = collapsedName switch
+		{
+			"spell" or "prog" or "targetitem" or "liquid" or "gas" => TrapParameterValidation.TryParsePositiveLong(value, out _),
+			"power" => TrapParameterValidation.TryParseDefinedEnum<SpellPower>(value, out _),
+			"value" => TrapParameterValidation.TryParseFiniteDouble(value, out _),
+			"amount" or "dose" => TrapParameterValidation.TryParseFiniteDouble(value, out var number) && number > 0.0,
+			"damagetype" => TrapParameterValidation.TryParseDefinedEnum<DamageType>(value, out _),
+			"explosionsize" => TrapParameterValidation.TryParseDefinedEnum<SizeCategory>(value, out _),
+			"maximumproximity" => TrapParameterValidation.TryParseExplosionMaximumProximity(value, out _),
+			"elevation" => TrapParameterValidation.TryParseFiniteDouble(value, out _),
+			"duration" => TimeSpan.TryParse(value, CultureInfo.InvariantCulture, out var duration) && duration > TimeSpan.Zero,
+			_ => true
+		};
+		if (valid)
+		{
+			error = string.Empty;
+			return true;
+		}
+
+		error = $"The {parameter.Name} parameter requires {parameter.Syntax}.";
+		return false;
+	}
+
+	public static bool TryValidateParameters(TrapPayloadType type, IReadOnlyDictionary<string, string> parameters,
+		out string error)
+	{
+		if (!Compatibility.ContainsKey(type))
+		{
+			error = $"{type} is not a supported trap payload type.";
+			return false;
+		}
+
+		foreach (var parameter in parameters)
+		{
+			if (!TryValidateParameter(type, parameter.Key, parameter.Value, out error))
+			{
+				return false;
+			}
+		}
+
+		error = string.Empty;
+		return true;
+	}
+
+	public bool SetParameter(string name, string value)
+	{
+		if (ParameterFor(PayloadType, name)?.Optional == true && value.EqualTo("none"))
+		{
+			_parameters.Remove(name);
+			return true;
+		}
+
+		if (!TryValidateParameter(PayloadType, name, value, out _))
+		{
+			return false;
+		}
+
+		_parameters[name] = value;
+		return true;
+	}
 
 	public void SetDelay(TimeSpan delay) => Delay = delay;
 	public void SetTargetSelector(TrapTargetSelector selector) => TargetSelector = selector;
@@ -249,17 +469,28 @@ public sealed class TrapPayloadDefinition : ITrapPayload
 			throw new ApplicationException($"Unknown trap payload type '{root.Attribute("type")?.Value}'.");
 		}
 
-		var delay = TimeSpan.TryParse(root.Attribute("delay")?.Value, out var parsedDelay) ? parsedDelay : TimeSpan.Zero;
-		var targetSelector = Enum.TryParse(root.Attribute("target")?.Value, true, out TrapTargetSelector parsedSelector)
-			? parsedSelector
-			: TrapTargetSelector.Triggerer;
+		var delayText = root.Attribute("delay")?.Value;
+		var delay = string.IsNullOrWhiteSpace(delayText)
+			? TimeSpan.Zero
+			: TimeSpan.TryParse(delayText, out var parsedDelay)
+				? parsedDelay
+				: TimeSpan.MinValue;
+		var targetText = root.Attribute("target")?.Value;
+		var targetSelector = string.IsNullOrWhiteSpace(targetText)
+			? TrapTargetSelector.Triggerer
+			: TrapParameterValidation.TryParseDefinedEnum(targetText, out TrapTargetSelector parsedSelector)
+				? parsedSelector
+				: (TrapTargetSelector)(-1);
 		var result = new TrapPayloadDefinition(payloadType, delay, targetSelector);
 		foreach (var parameter in root.Elements("Parameter"))
 		{
 			var name = parameter.Attribute("name")?.Value;
 			if (!string.IsNullOrWhiteSpace(name))
 			{
-				result.SetParameter(name, parameter.Value);
+				if (!result.SetParameter(name, parameter.Value))
+				{
+					result._parameters[name] = parameter.Value;
+				}
 			}
 		}
 
@@ -275,5 +506,135 @@ public sealed class TrapPayloadDefinition : ITrapPayload
 			_parameters.OrderBy(x => x.Key, StringComparer.OrdinalIgnoreCase)
 				.Select(x => new XElement("Parameter", new XAttribute("name", x.Key), new XCData(x.Value))))
 			.ToString();
+	}
+}
+
+internal static class TrapParameterValidation
+{
+	private static readonly IReadOnlySet<string> DamageFormulaParameters =
+		new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "quality", "power" };
+
+	private static readonly IReadOnlySet<string> PainAndStunFormulaParameters =
+		new HashSet<string>(DamageFormulaParameters, StringComparer.OrdinalIgnoreCase) { "damage" };
+
+	public static bool TryParseFiniteDouble(string value, out double number)
+	{
+		return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out number) &&
+		       double.IsFinite(number);
+	}
+
+	public static bool TryParsePositiveLong(string value, out long number)
+	{
+		return long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out number) && number > 0L;
+	}
+
+	public static bool TryParseDefinedEnum<TEnum>(string value, out TEnum parsed)
+		where TEnum : struct, Enum
+	{
+		return Enum.TryParse(value, true, out parsed) && Enum.IsDefined(parsed);
+	}
+
+	public static bool TryParseExplosionMaximumProximity(string value, out Proximity proximity)
+	{
+		return TryParseDefinedEnum(value, out proximity) && proximity != Proximity.Unapproximable;
+	}
+
+	public static bool TryValidateDamageExpression(string parameterName, string value, out string error)
+	{
+		var expression = new Expression(value);
+		if (expression.HasErrors())
+		{
+			error = $"The {parameterName} expression is invalid: {expression.Error}";
+			return false;
+		}
+
+		var allowedParameters = parameterName is "pain" or "stun"
+			? PainAndStunFormulaParameters
+			: DamageFormulaParameters;
+		var unsupportedParameters = expression.ParameterNames
+			.Where(x => !allowedParameters.Contains(x))
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.ToList();
+		if (unsupportedParameters.Any())
+		{
+			error = $"The {parameterName} expression may only use {allowedParameters.OrderBy(x => x).ListToString()}; it also uses {unsupportedParameters.ListToString()}.";
+			return false;
+		}
+
+		if (!TryEvaluateDamageExpression(value, (int)ItemQuality.Standard, SpellPower.Standard, 0.0,
+			out _, out var evaluationError))
+		{
+			error = $"The {parameterName} expression is invalid: {evaluationError}";
+			return false;
+		}
+
+		error = string.Empty;
+		return true;
+	}
+
+	public static bool TryEvaluateDamageExpression(string value, double quality, SpellPower power, double damage,
+		out double result, out string error)
+	{
+		result = 0.0;
+		error = string.Empty;
+		var expression = new Expression(value);
+		if (expression.HasErrors())
+		{
+			error = expression.Error;
+			return false;
+		}
+
+		string? expressionError = null;
+		EventHandler<string> errorHandler = (sender, message) =>
+		{
+			if (ReferenceEquals(sender, expression))
+			{
+				expressionError = message;
+			}
+		};
+		Expression.ExpressionError += errorHandler;
+		try
+		{
+			result = expression.EvaluateDoubleWith(("quality", quality), ("power", (int)power), ("damage", damage));
+		}
+		catch (Exception ex) when (ex is ArgumentException or OverflowException or InvalidOperationException or FormatException)
+		{
+			error = ex.Message;
+			return false;
+		}
+		finally
+		{
+			Expression.ExpressionError -= errorHandler;
+		}
+
+		if (expressionError is not null)
+		{
+			error = expressionError;
+			return false;
+		}
+
+		if (!double.IsFinite(result) || result < 0.0)
+		{
+			error = "it must evaluate to a finite, non-negative number";
+			return false;
+		}
+
+		return true;
+	}
+
+	public static bool TryParseMovementTypes(string text)
+	{
+		var movementTypes = MovementType.None;
+		foreach (var value in text.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+		{
+			if (!TryParseDefinedEnum<MovementType>(value, out var parsed) || parsed == MovementType.None)
+			{
+				return false;
+			}
+
+			movementTypes |= parsed;
+		}
+
+		return movementTypes != MovementType.None;
 	}
 }

--- a/MudSharpCore/Traps/TrapTemplate.cs
+++ b/MudSharpCore/Traps/TrapTemplate.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using MudSharp.Accounts;
+using MudSharp.Computers;
 using MudSharp.Construction;
 using MudSharp.Database;
 using MudSharp.Framework.Revision;
@@ -203,77 +204,9 @@ public sealed class TrapTemplate : EditableItem, ITrapTemplate
 
 	private string? ValidateTrigger(ITrapTrigger trigger)
 	{
-		if (trigger.Parameters.TryGetValue("chance", out var chance) &&
-		    (!double.TryParse(chance, out var chanceValue) || chanceValue is < 0.0 or > 100.0))
+		if (!TrapTriggerDefinition.TryValidateParameters(trigger.TriggerType, trigger.Parameters, out var parameterError))
 		{
-			return $"{trigger.TriggerType.DescribeEnum()} trigger chance must be a percentage from 0 to 100.";
-		}
-
-		if (trigger.Parameters.TryGetValue("minimumvalue", out var minimumValue) &&
-		    !double.TryParse(minimumValue, out _))
-		{
-			return $"{trigger.TriggerType.DescribeEnum()} trigger minimumvalue must be numeric.";
-		}
-
-		if (trigger.Parameters.TryGetValue("maximumvalue", out var maximumValue) &&
-		    !double.TryParse(maximumValue, out _))
-		{
-			return $"{trigger.TriggerType.DescribeEnum()} trigger maximumvalue must be numeric.";
-		}
-
-		if (trigger.Parameters.TryGetValue("minimumvalue", out minimumValue) &&
-		    trigger.Parameters.TryGetValue("maximumvalue", out maximumValue) &&
-		    double.TryParse(minimumValue, out var minimum) && double.TryParse(maximumValue, out var maximum) &&
-		    minimum > maximum)
-		{
-			return $"{trigger.TriggerType.DescribeEnum()} trigger minimumvalue cannot exceed maximumvalue.";
-		}
-
-		if (trigger.Parameters.TryGetValue("spotdifficulty", out var spotDifficulty) &&
-		    !Enum.TryParse(spotDifficulty, true, out Difficulty _))
-		{
-			return $"{trigger.TriggerType.DescribeEnum()} trigger spotdifficulty must be a difficulty.";
-		}
-
-		if (trigger.Parameters.TryGetValue("avoiddifficulty", out var avoidDifficulty) &&
-		    !Enum.TryParse(avoidDifficulty, true, out Difficulty _))
-		{
-			return $"{trigger.TriggerType.DescribeEnum()} trigger avoiddifficulty must be a difficulty.";
-		}
-
-		if (trigger.Parameters.TryGetValue("maximumproximity", out var maximumProximity) &&
-		    !Enum.TryParse(maximumProximity, true, out Proximity _))
-		{
-			return $"{trigger.TriggerType.DescribeEnum()} trigger maximumproximity must be a proximity.";
-		}
-
-		if (trigger.TriggerType == TrapTriggerType.ExitTraversal)
-		{
-			if (trigger.Parameters.TryGetValue("movementtypes", out var movementTypes) &&
-			    !TryParseMovementTypes(movementTypes, out _))
-			{
-				return "Exit Traversal movementtypes must be a comma-separated list of movement types or All.";
-			}
-
-			if (trigger.Parameters.TryGetValue("minimumsize", out var minimumSize) &&
-			    !minimumSize.TryParseEnum<SizeCategory>(out _))
-			{
-				return "Exit Traversal minimumsize must be a valid size category.";
-			}
-
-			if (trigger.Parameters.TryGetValue("maximumsize", out var maximumSize) &&
-			    !maximumSize.TryParseEnum<SizeCategory>(out _))
-			{
-				return "Exit Traversal maximumsize must be a valid size category.";
-			}
-
-			if (trigger.Parameters.TryGetValue("minimumsize", out minimumSize) &&
-			    trigger.Parameters.TryGetValue("maximumsize", out maximumSize) &&
-			    minimumSize.TryParseEnum<SizeCategory>(out var minimumCategory) &&
-			    maximumSize.TryParseEnum<SizeCategory>(out var maximumCategory) && minimumCategory > maximumCategory)
-			{
-				return "Exit Traversal minimumsize cannot exceed maximumsize.";
-			}
+			return $"{trigger.TriggerType.DescribeEnum()} trigger {parameterError}";
 		}
 
 		if (!trigger.Parameters.TryGetValue("filterprog", out var filterProg))
@@ -305,40 +238,45 @@ public sealed class TrapTemplate : EditableItem, ITrapTemplate
 	public static bool TryParseMovementTypes(string text, out MovementType movementTypes)
 	{
 		movementTypes = MovementType.None;
+		if (!TrapParameterValidation.TryParseMovementTypes(text))
+		{
+			return false;
+		}
+
 		foreach (var value in text.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
 		{
-			if (!Enum.TryParse(value, true, out MovementType parsed) || parsed == MovementType.None)
-			{
-				return false;
-			}
-
+			Enum.TryParse(value, true, out MovementType parsed);
 			movementTypes |= parsed;
 		}
 
-		return movementTypes != MovementType.None;
+		return true;
 	}
 
 	private string? ValidatePayload(ITrapPayload payload)
 	{
-		static bool RequiresPositiveNumber(IReadOnlyDictionary<string, string> parameters, string name) =>
-			parameters.TryGetValue(name, out var value) && double.TryParse(value, out var number) && number > 0.0;
-
-		static bool RequiresPositiveId(IReadOnlyDictionary<string, string> parameters, string name) =>
-			parameters.TryGetValue(name, out var value) && long.TryParse(value, out var id) && id > 0L;
-
 		if (payload.Delay < TimeSpan.Zero)
 		{
 			return $"{payload.PayloadType.DescribeEnum()} payload delay cannot be negative.";
 		}
 
+		if (!Enum.IsDefined(payload.TargetSelector))
+		{
+			return $"{payload.PayloadType.DescribeEnum()} payload target selector is invalid.";
+		}
+
+		if (!TrapPayloadDefinition.TryValidateParameters(payload.PayloadType, payload.Parameters, out var parameterError))
+		{
+			return $"{payload.PayloadType.DescribeEnum()} payload {parameterError}";
+		}
+
 		if (payload.PayloadType == TrapPayloadType.CastSpell)
 		{
-			if (!RequiresPositiveId(payload.Parameters, "spell"))
+			if (!payload.Parameters.TryGetValue("spell", out var spellText))
 			{
-				return "Cast Spell payloads require a positive spell parameter.";
+				return "Cast Spell payloads require a spell parameter.";
 			}
 
-			var spell = Gameworld.MagicSpells.Get(long.Parse(payload.Parameters["spell"]));
+			var spell = Gameworld.MagicSpells.Get(long.Parse(spellText));
 			return spell is null
 				? "Cast Spell payload references an unknown spell."
 				: !spell.ReadyForGame
@@ -348,12 +286,12 @@ public sealed class TrapTemplate : EditableItem, ITrapTemplate
 
 		if (payload.PayloadType == TrapPayloadType.ExecuteProg)
 		{
-			if (!RequiresPositiveId(payload.Parameters, "prog"))
+			if (!payload.Parameters.TryGetValue("prog", out var progText))
 			{
-				return "Execute Prog payloads require a positive prog parameter.";
+				return "Execute Prog payloads require a prog parameter.";
 			}
 
-			var prog = Gameworld.FutureProgs.Get(long.Parse(payload.Parameters["prog"]));
+			var prog = Gameworld.FutureProgs.Get(long.Parse(progText));
 			if (prog is null)
 			{
 				return "Execute Prog payload references an unknown FutureProg.";
@@ -368,21 +306,21 @@ public sealed class TrapTemplate : EditableItem, ITrapTemplate
 
 		if (payload.PayloadType == TrapPayloadType.LiquidDischarge)
 		{
-			return !RequiresPositiveId(payload.Parameters, "liquid")
-				? "Liquid Discharge payloads require a positive liquid parameter."
-				: Gameworld.Liquids.Get(long.Parse(payload.Parameters["liquid"])) is null
+			return !payload.Parameters.TryGetValue("liquid", out var liquidText)
+				? "Liquid Discharge payloads require a liquid parameter."
+				: Gameworld.Liquids.Get(long.Parse(liquidText)) is null
 					? "Liquid Discharge payload references an unknown liquid."
 					: null;
 		}
 
 		if (payload.PayloadType == TrapPayloadType.GasCloud)
 		{
-			if (!RequiresPositiveId(payload.Parameters, "gas"))
+			if (!payload.Parameters.TryGetValue("gas", out var gasText))
 			{
-				return "Gas Cloud payloads require a positive gas parameter.";
+				return "Gas Cloud payloads require a gas parameter.";
 			}
 
-			var gas = Gameworld.Gases.Get(long.Parse(payload.Parameters["gas"]));
+			var gas = Gameworld.Gases.Get(long.Parse(gasText));
 			if (gas is null)
 			{
 				return "Gas Cloud payload references an unknown gas.";
@@ -393,28 +331,19 @@ public sealed class TrapTemplate : EditableItem, ITrapTemplate
 				return "Gas Cloud payloads with a drug require a gas whose drug can be inhaled.";
 			}
 
-			if (payload.Parameters.TryGetValue("dose", out var dose) &&
-			    (!double.TryParse(dose, out var doseValue) || doseValue <= 0.0))
-			{
-				return "Gas Cloud payload dose must be a positive number when supplied.";
-			}
-
-			if (payload.Parameters.TryGetValue("duration", out var duration) &&
-			    (!TimeSpan.TryParse(duration, out var durationValue) || durationValue <= TimeSpan.Zero))
-			{
-				return "Gas Cloud payload duration must be a positive timespan when supplied.";
-			}
-
 			return null;
 		}
 
 		return payload.PayloadType switch
 		{
 			TrapPayloadType.EmitSignal when payload.Parameters.TryGetValue("targetitem", out var targetItem) &&
-			                                  (!long.TryParse(targetItem, out var targetItemId) || targetItemId < 0L) =>
-				"Emit Signal targetitem must be a non-negative item ID when supplied.",
-			TrapPayloadType.DirectDamage when !RequiresPositiveNumber(payload.Parameters, "damage") =>
-				"Direct Damage payloads require a positive damage parameter.",
+			                                  (Gameworld.TryGetItem(long.Parse(targetItem), true) is not { } item ||
+			                                   !item.Components.OfType<ISignalSink>().Any()) =>
+				"Emit Signal targetitem must refer to an existing item with a signal sink.",
+			TrapPayloadType.DirectDamage when !payload.Parameters.ContainsKey("damage") =>
+				"Direct Damage payloads require a damage parameter.",
+			TrapPayloadType.ExplosiveDamage when !payload.Parameters.ContainsKey("damage") =>
+				"Explosive Damage payloads require a damage parameter.",
 			_ => null
 		};
 	}
@@ -679,6 +608,143 @@ public sealed class TrapTemplate : EditableItem, ITrapTemplate
 		return true;
 	}
 
+	private bool TrySetTriggerParameter(TrapTriggerDefinition trigger, string parameterName, string value,
+		out string error)
+	{
+		if (!TrapTriggerDefinition.TryValidateParameter(trigger.TriggerType, parameterName, value, out error))
+		{
+			return false;
+		}
+
+		var parameters = trigger.Parameters.ToDictionary(x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase);
+		if (TrapTriggerDefinition.ParameterFor(trigger.TriggerType, parameterName)?.Optional == true && value.EqualTo("none"))
+		{
+			parameters.Remove(parameterName);
+		}
+		else
+		{
+			parameters[parameterName] = value;
+		}
+
+		if (!TrapTriggerDefinition.TryValidateParameters(trigger.TriggerType, parameters, out error))
+		{
+			return false;
+		}
+
+		if (parameterName.EqualTo("filterprog") && !value.EqualTo("none"))
+		{
+			var prog = Gameworld.FutureProgs.Get(long.Parse(value));
+			if (prog is null || !prog.ReturnType.CompatibleWith(ProgVariableTypes.Boolean))
+			{
+				error = "The filterprog parameter must refer to a boolean FutureProg.";
+				return false;
+			}
+
+			var supportedParameters = trigger.TriggerType == TrapTriggerType.Signal
+				? prog.MatchesParameters([ProgVariableTypes.Perceivable]) ||
+				  prog.MatchesParameters([ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable])
+				: prog.MatchesParameters([ProgVariableTypes.Character]) ||
+				  prog.MatchesParameters([ProgVariableTypes.Character, ProgVariableTypes.Perceivable]);
+			if (!supportedParameters)
+			{
+				error = "The filterprog FutureProg has no supported parameter signature for this trigger.";
+				return false;
+			}
+		}
+
+		trigger.SetParameter(parameterName, value);
+		error = string.Empty;
+		return true;
+	}
+
+	private bool TrySetPayloadParameter(TrapPayloadDefinition payload, string parameterName, string value,
+		out string error)
+	{
+		if (!TrapPayloadDefinition.TryValidateParameter(payload.PayloadType, parameterName, value, out error))
+		{
+			return false;
+		}
+
+		var parameters = payload.Parameters.ToDictionary(x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase);
+		if (TrapPayloadDefinition.ParameterFor(payload.PayloadType, parameterName)?.Optional == true && value.EqualTo("none"))
+		{
+			parameters.Remove(parameterName);
+		}
+		else
+		{
+			parameters[parameterName] = value;
+		}
+
+		if (!TrapPayloadDefinition.TryValidateParameters(payload.PayloadType, parameters, out error))
+		{
+			return false;
+		}
+
+		if (value.EqualTo("none"))
+		{
+			payload.SetParameter(parameterName, value);
+			error = string.Empty;
+			return true;
+		}
+
+		switch (parameterName.CollapseString())
+		{
+			case "spell":
+				var spell = Gameworld.MagicSpells.Get(long.Parse(value));
+				if (spell is null || !spell.ReadyForGame)
+				{
+					error = "The spell parameter must refer to a ready magic spell.";
+					return false;
+				}
+				break;
+			case "prog":
+				var prog = Gameworld.FutureProgs.Get(long.Parse(value));
+				if (prog is null)
+				{
+					error = "The prog parameter must refer to a FutureProg.";
+					return false;
+				}
+
+				if (!prog.MatchesParameters([ProgVariableTypes.Character, ProgVariableTypes.Perceivable]) &&
+				    !prog.MatchesParameters([ProgVariableTypes.Character]) &&
+				    !prog.MatchesParameters([ProgVariableTypes.Perceivable]))
+				{
+					error = "The prog FutureProg must accept character, character and anchor, or anchor parameters.";
+					return false;
+				}
+				break;
+			case "liquid" when Gameworld.Liquids.Get(long.Parse(value)) is null:
+				error = "The liquid parameter must refer to an existing liquid.";
+				return false;
+			case "gas":
+				var gas = Gameworld.Gases.Get(long.Parse(value));
+				if (gas is null)
+				{
+					error = "The gas parameter must refer to an existing gas.";
+					return false;
+				}
+
+				if (gas.Drug is not null && !gas.Drug.DrugVectors.HasFlag(DrugVector.Inhaled))
+				{
+					error = "A gas with a drug must use an inhalable drug.";
+					return false;
+				}
+				break;
+			case "targetitem":
+				var item = Gameworld.TryGetItem(long.Parse(value), true);
+				if (item is null || !item.Components.OfType<ISignalSink>().Any())
+				{
+					error = "The targetitem parameter must refer to an existing item with a signal sink.";
+					return false;
+				}
+				break;
+		}
+
+		payload.SetParameter(parameterName, value);
+		error = string.Empty;
+		return true;
+	}
+
 	private bool BuildingCommandTrigger(ICharacter actor, StringStack command)
 	{
 		if (command.IsFinished)
@@ -758,7 +824,14 @@ public sealed class TrapTemplate : EditableItem, ITrapTemplate
 			actor.Send(TriggerBuildingHelp(actor, triggerIndex));
 			return false;
 		}
-		triggerDefinition.SetParameter(parameterName, command.SafeRemainingArgument);
+
+		if (!TrySetTriggerParameter(triggerDefinition, parameterName, command.SafeRemainingArgument, out var error))
+		{
+			actor.Send(error.ColourError());
+			actor.Send(TriggerBuildingHelp(actor, triggerIndex));
+			return false;
+		}
+
 		Changed = true;
 		actor.Send($"You set the {parameterName.ColourName()} parameter on that trigger.");
 		return true;
@@ -779,10 +852,10 @@ public sealed class TrapTemplate : EditableItem, ITrapTemplate
 		foreach (var parameter in TrapTriggerDefinition.ParametersFor(trigger.TriggerType))
 		{
 			var value = trigger.Parameters.GetValueOrDefault(parameter.Name) ?? parameter.DefaultValue;
-			sb.AppendLine($"\t{parameter.Name.ColourCommand()} = {value.ColourValue()} - {parameter.Description}");
+			sb.AppendLine($"\t{parameter.Name.ColourCommand()} {parameter.Syntax.ColourCommand()} = {value.ColourValue()} - {parameter.Description}");
 		}
 		sb.AppendLine();
-		sb.AppendLine($"Use {"trigger <number> parameter <name> <value>".ColourCommand()} to change a value.");
+		sb.AppendLine($"Use {"trigger <number> parameter <name> <value>".ColourCommand()} to change a value. Use {"none".ColourCommand()} to restore an optional value's default.");
 		return sb.ToString();
 	}
 
@@ -885,11 +958,19 @@ public sealed class TrapTemplate : EditableItem, ITrapTemplate
 				Changed = true;
 				actor.Send($"That payload will now wait {delay.Describe(actor).ColourValue()}.");
 				return true;
-			case "target" when Enum.TryParse(command.PopSpeech(), true, out TrapTargetSelector selector):
+			case "target" when TrapParameterValidation.TryParseDefinedEnum(command.PopSpeech(), out TrapTargetSelector selector) && command.IsFinished:
 				payloadDefinition.SetTargetSelector(selector);
 				Changed = true;
 				actor.Send($"That payload will now target {selector.DescribeEnum().ColourValue()}.");
 				return true;
+			case "delay":
+				actor.Send("The payload delay must be a non-negative timespan, such as 30 seconds or 00:00:30.".ColourError());
+				actor.Send(PayloadBuildingHelp(actor, payloadIndex));
+				return false;
+			case "target":
+				actor.Send($"The payload target must be one of {Enum.GetValues<TrapTargetSelector>().Select(x => x.DescribeEnum().ColourCommand()).ListToString()}, with no trailing text.".ColourError());
+				actor.Send(PayloadBuildingHelp(actor, payloadIndex));
+				return false;
 			case "parameter":
 				if (command.IsFinished)
 				{
@@ -902,7 +983,13 @@ public sealed class TrapTemplate : EditableItem, ITrapTemplate
 					actor.Send(PayloadBuildingHelp(actor, payloadIndex));
 					return false;
 				}
-				payloadDefinition.SetParameter(parameterName, command.SafeRemainingArgument);
+				if (!TrySetPayloadParameter(payloadDefinition, parameterName, command.SafeRemainingArgument, out var error))
+				{
+					actor.Send(error.ColourError());
+					actor.Send(PayloadBuildingHelp(actor, payloadIndex));
+					return false;
+				}
+
 				Changed = true;
 				actor.Send($"You set the {parameterName.ColourName()} parameter on that payload.");
 				return true;
@@ -923,10 +1010,10 @@ public sealed class TrapTemplate : EditableItem, ITrapTemplate
 		foreach (var parameter in TrapPayloadDefinition.ParametersFor(payload.PayloadType))
 		{
 			var value = payload.Parameters.GetValueOrDefault(parameter.Name) ?? parameter.DefaultValue;
-			sb.AppendLine($"\t{parameter.Name.ColourCommand()} = {value.ColourValue()} - {parameter.Description}");
+			sb.AppendLine($"\t{parameter.Name.ColourCommand()} {parameter.Syntax.ColourCommand()} = {value.ColourValue()} - {parameter.Description}");
 		}
 		sb.AppendLine();
-		sb.AppendLine($"Use {"payload <number> parameter <name> <value>".ColourCommand()} to change a parameter.");
+		sb.AppendLine($"Use {"payload <number> parameter <name> <value>".ColourCommand()} to change a parameter. Use {"none".ColourCommand()} to restore an optional value's default.");
 		return sb.ToString();
 	}
 
@@ -1077,5 +1164,5 @@ public sealed class TrapTemplate : EditableItem, ITrapTemplate
 	#3validate#0 - reports whether the template can be submitted
 
 	Common trigger parameters are #3chance#0, #3spotdifficulty#0, #3avoiddifficulty#0, #3filterprog#0 and #3triggerEcho#0.
-	Common payload parameters are #3echo#0, #3spell#0, #3targetitem#0, #3prog#0, #3damage#0, #3damagetype#0, #3liquid#0, #3gas#0, #3amount#0, #3dose#0 and #3duration#0.";
+	Common payload parameters are #3echo#0, #3spell#0, #3targetitem#0, #3prog#0, #3damage#0, #3pain#0, #3stun#0, #3damagetype#0, #3explosionsize#0, #3maximumproximity#0, #3elevation#0, #3liquid#0, #3gas#0, #3amount#0, #3dose#0 and #3duration#0. Direct and Explosive Damage formulas may use #3quality#0 and #3power#0; pain and stun may also use #3damage#0.";
 }


### PR DESCRIPTION
Adds expression-backed DirectDamage and a new ExplosiveDamage trap payload using the existing explosion propagation path. Adds spell-power and quality inputs, separate pain/stun formulas, explosion defaults, syntax help and fail-closed XML/runtime validation, stock magical explosion content, and regression coverage. Validation: MudSharpCore build passed; MudSharpCore Unit Tests passed (2258); DatabaseSeeder Unit Tests passed (687); git diff --check passed.