### PR TITLE
Fix crawling limb checks for sprawled movement

### DIFF
--- a/Design Documents/World/Position_State_System.md
+++ b/Design Documents/World/Position_State_System.md
@@ -113,6 +113,8 @@ On a `SwimToLand` transition, the swimmer uses their most upright available land
 - other states use `TransitionOnMovement` if present, otherwise the current state;
 - zero gravity can replace that with `PositionFloatingInZeroGravity`.
 
+Posture-specific limb checks use that effective movement position. In particular, crawling requires at least one usable arm, leg, appendage, or wing whether the character was already prone or starts movement from a state, such as sprawled, that transitions to prone.
+
 `CouldMove` follows similar rules and finds an available `IMoveSpeed` for the moving position. The ordinary fallback path only tries standing, prostrate, prone, and zero-gravity floating. This is why non-legged actors should generally be modeled with appropriate standing/upright move speeds rather than a new "wheeled" or "tracked" posture state.
 
 Movement display text comes primarily from `IMoveSpeed` (`FirstPersonVerb`, `ThirdPersonVerb`, `PresentParticiple`), not from `IPositionState.DescribeLocationMovement3rd`.

--- a/MudSharpCore Unit Tests/MovementTests.cs
+++ b/MudSharpCore Unit Tests/MovementTests.cs
@@ -117,6 +117,23 @@ public class MovementTests
 			"Reaching dry land must not preserve the swimming position.");
 	}
 
+	[TestMethod]
+	public void CanMoveInternal_SprawledTransitioningToProne_RequiresUsableCrawlingLimb()
+	{
+		var movementSource = File.ReadAllText(GetCoreSourcePath("Character", "CharacterMovement.cs"));
+		var canMoveInternalStart = movementSource.IndexOf("private CanMoveResponse CanMoveInternal(",
+			StringComparison.Ordinal);
+		var canMoveStart = movementSource.IndexOf("public CanMoveResponse CanMove(CanMoveFlags flags)",
+			canMoveInternalStart, StringComparison.Ordinal);
+
+		Assert.IsTrue(canMoveInternalStart >= 0, "Character.CanMoveInternal should exist.");
+		Assert.IsTrue(canMoveStart > canMoveInternalStart,
+			"The public CanMove wrapper should follow CanMoveInternal.");
+		var canMoveInternal = movementSource[canMoveInternalStart..canMoveStart];
+		StringAssert.Contains(canMoveInternal, "movingPosition == PositionProne.Instance");
+		StringAssert.Contains(canMoveInternal, "You need at least one working arm, leg, limb or other appendage to crawl.");
+	}
+
     [TestMethod]
     public void FinalStep_SoloMoverWithQueuedCommand_ExecutesQueuedMove()
     {

--- a/MudSharpCore/Character/CharacterMovement.cs
+++ b/MudSharpCore/Character/CharacterMovement.cs
@@ -847,6 +847,7 @@ public partial class Character
         }
 
         if ((PositionState == PositionProne.Instance ||
+             movingPosition == PositionProne.Instance ||
              movingPosition.TransitionOnMovement == PositionProne.Instance) &&
             !Body.Limbs.Any(x =>
                 x.LimbType.In(LimbType.Leg, LimbType.Arm, LimbType.Appendage, LimbType.Wing) &&


### PR DESCRIPTION
## Summary

- Apply crawling limb requirements to the effective movement position.
- Prevent sprawled characters transitioning to prone from bypassing usable-limb checks.
- Document the posture-specific movement behavior.
- Add regression coverage for the sprawled-to-prone case.

## Testing

- Added a `MudSharpCore Unit Tests` regression test verifying the crawling guard remains present in `CanMoveInternal`.