### PR TITLE
Fix clinch removal lifecycle leaks

### DIFF
--- a/Design Documents/Combat/Combat_Strategy_Runtime.md
+++ b/Design Documents/Combat/Combat_Strategy_Runtime.md
@@ -139,7 +139,7 @@ Expected active no-move cases mirror `StandardMelee`.
 
 A melee strategy that tries to enter and fight in clinch range. It starts a clinch when upright, not cooling down, and able to clinch the target. Once clinching, it rolls between clinch weapon attacks and unarmed clinch attacks. It suppresses the base clinch-breaking behaviour because clinch is the desired state.
 
-Each pairwise clinch expires when either linked participant leaves combat, including departure caused by death or incapacitation. Other clinches in a multi-holder combat remain independent.
+Each pairwise clinch expires when either linked participant leaves combat, including departure caused by death or incapacitation. Every direct clinch-removal path also runs the effect removal lifecycle so that both participant event subscriptions detach immediately. Other clinches in a multi-holder combat remain independent.
 
 If it discovers it has no viable clinch attacks but has viable normal melee attacks, it switches back to `StandardMelee`.
 

--- a/MudSharpCore Unit Tests/ClinchEffectTests.cs
+++ b/MudSharpCore Unit Tests/ClinchEffectTests.cs
@@ -7,12 +7,20 @@ using MudSharp.Combat;
 using MudSharp.Effects;
 using MudSharp.Effects.Concrete;
 using MudSharp.Framework;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace MudSharp_Unit_Tests;
 
 [TestClass]
 public class ClinchEffectTests
 {
+	private static readonly Regex ClinchRemovalCall = new(
+		@"RemoveAllEffects\s*(?:<\s*ClinchEffect\s*>)?\s*\(.*?\);",
+		RegexOptions.Singleline | RegexOptions.Compiled);
+
 	[TestMethod]
 	public void ClincherLeavesCombat_ExpiresEffect()
 	{
@@ -59,6 +67,47 @@ public class ClinchEffectTests
 
 		holder.Verify(x => x.RemoveEffect(firstEffect, true), Times.Once);
 		holder.Verify(x => x.RemoveEffect(secondEffect, true), Times.Never);
+	}
+
+	[TestMethod]
+	public void RemovalEffect_UnsubscribesParticipants()
+	{
+		var (effect, clincher, target) = CreateFixture();
+
+		effect.RemovalEffect();
+		clincher.Raise(x => x.OnLeaveCombat += null!, clincher.Object);
+		target.Raise(x => x.OnLeaveCombat += null!, target.Object);
+
+		clincher.Verify(x => x.RemoveEffect(effect, true), Times.Never);
+		clincher.VerifyRemove(x => x.OnLeaveCombat -= It.IsAny<PerceivableEvent>(), Times.Once);
+		target.VerifyRemove(x => x.OnLeaveCombat -= It.IsAny<PerceivableEvent>(), Times.Once);
+	}
+
+	[TestMethod]
+	public void ClinchRemovalPaths_FireRemovalEffect()
+	{
+		var corePath = Path.GetFullPath(Path.Combine(
+			AppContext.BaseDirectory,
+			"..",
+			"..",
+			"..",
+			"..",
+			"MudSharpCore"));
+		var removalCalls = Directory
+			.EnumerateFiles(corePath, "*.cs", SearchOption.AllDirectories)
+			.SelectMany(path => ClinchRemovalCall
+				.Matches(File.ReadAllText(path))
+				.Select(match => (Path: path, Call: match.Value)))
+			.Where(x => x.Call.Contains("ClinchEffect"))
+			.ToList();
+
+		Assert.IsTrue(removalCalls.Any(), "Expected at least one direct clinch-removal path.");
+		foreach (var removalCall in removalCalls)
+		{
+			Assert.IsTrue(
+				Regex.IsMatch(removalCall.Call, @"(?:,\s*true|fireRemovalAction\s*:\s*true)\s*\);$"),
+				$"Clinch removal must fire its removal lifecycle: {removalCall.Path}");
+		}
 	}
 
 	private static (ClinchEffect Effect, Mock<ICharacter> Clincher, Mock<ICharacter> Target) CreateFixture()

--- a/MudSharpCore/Combat/Moves/BreakClinchMove.cs
+++ b/MudSharpCore/Combat/Moves/BreakClinchMove.cs
@@ -107,8 +107,8 @@ public class BreakClinchMove : CombatMoveBase
                 new EmoteOutput(
                     new Emote($"{attackEmote}{dodgeEmote}".Fullstop(), Assailant, Assailant, CharacterTarget),
                     style: OutputStyle.CombatMessage, flags: OutputFlags.InnerWrap));
-            Assailant.RemoveAllEffects(x => x.GetSubtype<ClinchEffect>()?.Target == CharacterTarget);
-            CharacterTarget.RemoveAllEffects(x => x.GetSubtype<ClinchEffect>()?.Target == Assailant);
+            Assailant.RemoveAllEffects(x => x.GetSubtype<ClinchEffect>()?.Target == CharacterTarget, true);
+            CharacterTarget.RemoveAllEffects(x => x.GetSubtype<ClinchEffect>()?.Target == Assailant, true);
             CharacterTarget.AddEffect(new ClinchCooldown(CharacterTarget, CharacterTarget.Combat),
                 TimeSpan.FromSeconds(30 * CombatBase.CombatSpeedMultiplier));
             return new CombatMoveResult
@@ -149,8 +149,8 @@ public class BreakClinchMove : CombatMoveBase
             new EmoteOutput(
                 new Emote($"{attackEmote}, and $1 $1|are|is unable to stop &0.", Assailant, Assailant,
                     CharacterTarget), style: OutputStyle.CombatMessage, flags: OutputFlags.InnerWrap));
-        Assailant.RemoveAllEffects(x => x.GetSubtype<ClinchEffect>()?.Target == CharacterTarget);
-        CharacterTarget.RemoveAllEffects(x => x.GetSubtype<ClinchEffect>()?.Target == Assailant);
+        Assailant.RemoveAllEffects(x => x.GetSubtype<ClinchEffect>()?.Target == CharacterTarget, true);
+        CharacterTarget.RemoveAllEffects(x => x.GetSubtype<ClinchEffect>()?.Target == Assailant, true);
         CharacterTarget.AddEffect(new ClinchCooldown(CharacterTarget, CharacterTarget.Combat),
             TimeSpan.FromSeconds(30 * CombatBase.CombatSpeedMultiplier));
         return new CombatMoveResult { RecoveryDifficulty = Difficulty.Automatic };

--- a/MudSharpCore/Combat/Moves/FleeMove.cs
+++ b/MudSharpCore/Combat/Moves/FleeMove.cs
@@ -259,12 +259,12 @@ public class FleeMove : CombatMoveBase
                     style: OutputStyle.CombatMessage, flags: OutputFlags.InnerWrap));
 
             Assailant.MeleeRange = false;
-            Assailant.RemoveAllEffects<ClinchEffect>();
+            Assailant.RemoveAllEffects<ClinchEffect>(fireRemovalAction: true);
             foreach (IPerceiver opponent in Assailant.Combat.Combatants.Where(x => x.CombatTarget == Assailant && x.MeleeRange)
                                               .ToList())
             {
                 opponent.MeleeRange = false;
-                opponent.RemoveAllEffects<ClinchEffect>(x => x.Target == Assailant);
+                opponent.RemoveAllEffects<ClinchEffect>(x => x.Target == Assailant, true);
             }
 
 			RouteCombatMovementUtilities.TryRetreatAlongRoute(Assailant, pursuers);

--- a/MudSharpCore/Combat/Moves/StaggeringBlowMove.cs
+++ b/MudSharpCore/Combat/Moves/StaggeringBlowMove.cs
@@ -102,10 +102,10 @@ public class StaggeringBlowMove : MeleeWeaponAttack
         if (cr.Outcome.IsFail())
         {
             Target.RemoveAllEffects(x =>
-                x.GetSubtype<ClinchEffect>() is ClinchEffect ce && ce.Clincher == Target && ce.Target == Assailant);
+                x.GetSubtype<ClinchEffect>() is ClinchEffect ce && ce.Clincher == Target && ce.Target == Assailant, true);
             Target.RemoveAllEffects(x => x.GetSubtype<Grappling>() is Grappling gr && gr.Target == Assailant);
             Assailant.RemoveAllEffects(x =>
-                x.GetSubtype<ClinchEffect>() is ClinchEffect ce && ce.Clincher == Assailant && ce.Target == Target);
+                x.GetSubtype<ClinchEffect>() is ClinchEffect ce && ce.Clincher == Assailant && ce.Target == Target, true);
             Assailant.RemoveAllEffects(x => x.GetSubtype<Grappling>() is Grappling gr && gr.Target == Target);
             if (Target.Combat != null)
             {

--- a/MudSharpCore/Combat/Moves/StaggeringBlowUnarmedMove.cs
+++ b/MudSharpCore/Combat/Moves/StaggeringBlowUnarmedMove.cs
@@ -111,10 +111,10 @@ public class StaggeringBlowUnarmedMove : NaturalAttackMove
         if (cr.Outcome.IsFail())
         {
             Target.RemoveAllEffects(x =>
-                x.GetSubtype<ClinchEffect>() is ClinchEffect ce && ce.Clincher == Target && ce.Target == Assailant);
+                x.GetSubtype<ClinchEffect>() is ClinchEffect ce && ce.Clincher == Target && ce.Target == Assailant, true);
             Target.RemoveAllEffects(x => x.GetSubtype<Grappling>() is Grappling gr && gr.Target == Assailant);
             Assailant.RemoveAllEffects(x =>
-                x.GetSubtype<ClinchEffect>() is ClinchEffect ce && ce.Clincher == Assailant && ce.Target == Target);
+                x.GetSubtype<ClinchEffect>() is ClinchEffect ce && ce.Clincher == Assailant && ce.Target == Target, true);
             Assailant.RemoveAllEffects(x => x.GetSubtype<Grappling>() is Grappling gr && gr.Target == Target);
             Target.AddEffect(new ClinchCooldown(Target, Target.Combat),
                 TimeSpan.FromSeconds(30 * CombatBase.CombatSpeedMultiplier));

--- a/MudSharpCore/Combat/Moves/UnbalancingBlowMove.cs
+++ b/MudSharpCore/Combat/Moves/UnbalancingBlowMove.cs
@@ -117,10 +117,10 @@ public class UnbalancingBlowMove : MeleeWeaponAttack
         if (cr.Outcome.IsFail())
         {
             Target.RemoveAllEffects(x =>
-                x.GetSubtype<ClinchEffect>() is ClinchEffect ce && ce.Clincher == Target && ce.Target == Assailant);
+                x.GetSubtype<ClinchEffect>() is ClinchEffect ce && ce.Clincher == Target && ce.Target == Assailant, true);
             Target.RemoveAllEffects(x => x.GetSubtype<Grappling>() is Grappling gr && gr.Target == Assailant);
             Assailant.RemoveAllEffects(x =>
-                x.GetSubtype<ClinchEffect>() is ClinchEffect ce && ce.Clincher == Assailant && ce.Target == Target);
+                x.GetSubtype<ClinchEffect>() is ClinchEffect ce && ce.Clincher == Assailant && ce.Target == Target, true);
             Assailant.RemoveAllEffects(x => x.GetSubtype<Grappling>() is Grappling gr && gr.Target == Target);
             Target.AddEffect(new ClinchCooldown(Target, Target.Combat),
                 TimeSpan.FromSeconds(30 * CombatBase.CombatSpeedMultiplier));

--- a/MudSharpCore/Combat/Moves/UnbalancingBlowUnarmedMove.cs
+++ b/MudSharpCore/Combat/Moves/UnbalancingBlowUnarmedMove.cs
@@ -119,10 +119,10 @@ public class UnbalancingBlowUnarmedMove : NaturalAttackMove
         if (cr.Outcome.IsFail())
         {
             Target.RemoveAllEffects(x =>
-                x.GetSubtype<ClinchEffect>() is ClinchEffect ce && ce.Clincher == Target && ce.Target == Assailant);
+                x.GetSubtype<ClinchEffect>() is ClinchEffect ce && ce.Clincher == Target && ce.Target == Assailant, true);
             Target.RemoveAllEffects(x => x.GetSubtype<Grappling>() is Grappling gr && gr.Target == Assailant);
             Assailant.RemoveAllEffects(x =>
-                x.GetSubtype<ClinchEffect>() is ClinchEffect ce && ce.Clincher == Assailant && ce.Target == Target);
+                x.GetSubtype<ClinchEffect>() is ClinchEffect ce && ce.Clincher == Assailant && ce.Target == Target, true);
             Assailant.RemoveAllEffects(x => x.GetSubtype<Grappling>() is Grappling gr && gr.Target == Target);
             Target.AddEffect(new ClinchCooldown(Target, Target.Combat),
                 TimeSpan.FromSeconds(30 * CombatBase.CombatSpeedMultiplier));


### PR DESCRIPTION
## Summary

- Ensure every direct clinch-removal path fires the effect removal lifecycle.
- Detach participant combat-event subscriptions when a clinch ends.
- Update combat strategy documentation to describe the cleanup guarantee.
- Add regression coverage for subscription cleanup and removal-call enforcement.

## Testing

- Added unit tests covering effect removal and all direct clinch-removal call sites.