### PR TITLE
Bound bank transaction history loading to idle-time batches

### DIFF
--- a/Design Documents/Economy/Economy_System_Runtime.md
+++ b/Design Documents/Economy/Economy_System_Runtime.md
@@ -36,7 +36,7 @@ The economy system is loaded late in the boot sequence, after the world, future 
 - `LoadJobs()` runs after `LoadEconomy()`.
 - new character materialisation is explicitly blocked during boot until `LoadNPCs()` begins, so pre-NPC loaders must not force a fresh `TryGetCharacter(...)` from the database.
 - economy or other pre-NPC loaders that genuinely need character-dependent resolution must defer that work through `IPostCharacterLoadFinalisable.FinaliseLoading()`, which now runs immediately after `LoadNPCs()`.
-- bank accounts load their durable balance and owner references during `LoadEconomy()`, but transaction history remains demand-loaded by `Transactions`. Startup must not prewarm every open account's transaction history; account commands and transaction operations already call the same one-shot loader when history is actually required.
+- bank accounts load their durable balance and owner references during `LoadEconomy()`, but do not prewarm transaction history. The first player `bank transactions` request loads only its newest-recorded display window of 100 rows, then queues the account for idle-time history hydration. Each idle callback loads at most 100 older rows, returns control, and requeues itself when more remain. Balance-changing operations record only their new transaction and never synchronously hydrate historical rows.
 
 ### Verified current scheduled runtime hooks
 - market populations receive an hourly heartbeat through the scheduler
@@ -144,6 +144,8 @@ Account types are especially important because they hold much of the policy:
 - fees, interest, overdraw rules, and payment-item allowances
 
 Banks and bank accounts also register FutureProg variable support, so the system is designed to be scripted as well as built.
+
+Bank transaction history presentation is intentionally bounded at 100 most recently recorded entries. The first player-facing `bank transactions` request starts a demand-driven idle loader that hydrates older persisted records in 100-row database batches and requeues after each batch. The command always renders its bounded display cache rather than sorting the growing hydrated collection, so the command path remains bounded. This is a presentation/history window, not an accounting retention policy: all transaction records remain persisted.
 
 ### Virtual Establishment Balances and Ledgers
 Several economy systems can now operate without a live settlement bank account by using a persisted virtual cash reserve. Player-facing cash remains physical currency items at the character edge; establishment cash is stored as `VirtualCashBalance` rows keyed by owner type, owner id, and currency.

--- a/Design Documents/Economy/Economy_System_Workflows_and_Integration.md
+++ b/Design Documents/Economy/Economy_System_Workflows_and_Integration.md
@@ -32,6 +32,8 @@ Most economy content is authored as world data, not hard-coded content. The engi
 - market category tags
 - bank accounts and payment items
 
+Player and administrator `bank transactions` requests show the 100 most recently recorded entries for the selected account. The first request also starts demand-driven idle hydration of older records in 100-row batches; each batch yields back to the game loop and requeues only when more remain. The cap is deliberate: command output never hydrates or renders an unbounded ledger synchronously.
+
 The current stock seeder path now covers two useful starting points:
 
 - `CurrencySeeder` for currencies, divisions, coins, and parsing/description patterns

--- a/FutureMUDLibrary/Economy/IBankAccount.cs
+++ b/FutureMUDLibrary/Economy/IBankAccount.cs
@@ -48,6 +48,11 @@ public interface IBankAccount : IFrameworkItem, ISaveable, IProgVariable
 
     MudDateTime AccountCreationDate { get; }
     BankAccountStatus AccountStatus { get; }
+
+    /// <summary>
+    /// Returns the transaction history currently hydrated for this account. Calling the player-facing history
+    /// command starts idle-time hydration of remaining persisted records in bounded batches.
+    /// </summary>
     IEnumerable<IBankAccountTransaction> Transactions { get; }
 
     IBankAccount NominatedBenefactor { get; }

--- a/MudSharpCore Unit Tests/Economy/BankAccountTransactionHistoryTests.cs
+++ b/MudSharpCore Unit Tests/Economy/BankAccountTransactionHistoryTests.cs
@@ -1,0 +1,91 @@
+#nullable enable
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Database;
+using MudSharp.Economy.Banking;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class BankAccountTransactionHistoryTests
+{
+	[TestMethod]
+	public void LoadMostRecent_ReturnsOnlyTheMostRecentBoundedHistoryForTheRequestedAccount()
+	{
+		using var context = BuildContext();
+		context.BankAccountTransactions.AddRange(
+			Enumerable.Range(1, 150)
+				.Select(id => Transaction(id, 1L))
+				.Concat(Enumerable.Range(151, 150)
+					.Select(id => Transaction(id, 2L))));
+		context.SaveChanges();
+
+		var history = BankAccountTransactionHistory.LoadMostRecent(context.BankAccountTransactions, 1L);
+
+		Assert.AreEqual(BankAccountTransactionHistory.MaximumTransactionHistoryEntries, history.Count);
+		CollectionAssert.AreEqual(Enumerable.Range(51, 100).Reverse().ToList(), history.Select(x => (int)x.Id).ToList());
+		Assert.IsTrue(history.All(x => x.BankAccountId == 1L));
+	}
+
+	[TestMethod]
+	public void LoadOlderThan_ReturnsTheNextBoundedHistoryChunkForTheRequestedAccount()
+	{
+		using var context = BuildContext();
+		context.BankAccountTransactions.AddRange(Enumerable.Range(1, 250).Select(id => Transaction(id, 1L)));
+		context.SaveChanges();
+
+		var history = BankAccountTransactionHistory.LoadOlderThan(context.BankAccountTransactions, 1L, 201L);
+
+		Assert.AreEqual(BankAccountTransactionHistory.MaximumTransactionHistoryEntries, history.Count);
+		CollectionAssert.AreEqual(Enumerable.Range(101, 100).Reverse().ToList(), history.Select(x => (int)x.Id).ToList());
+	}
+
+	[TestMethod]
+	public void BankAccountTransactionHistoryCommand_QueuesBoundedBackgroundHydration()
+	{
+		string source = File.ReadAllText(GetSourcePath("MudSharpCore", "Economy", "Banking", "BankAccount.cs"));
+
+		Assert.IsFalse(source.Contains("LoadTransactions", StringComparison.Ordinal));
+		StringAssert.Contains(source, "IBankAccount, ILazyLoadDuringIdleTime");
+		StringAssert.Contains(source, "RecordTransaction(new BankAccountTransaction");
+		StringAssert.Contains(source, "RequestTransactionHistoryLazyLoad();");
+		StringAssert.Contains(source, "LoadOlderThan(FMDB.Context.BankAccountTransactions");
+		StringAssert.Contains(source, "Gameworld.SaveManager.AddLazyLoad(this);");
+		StringAssert.Contains(source, "from transaction in _displayedTransactions");
+	}
+
+	private static MudSharp.Models.BankAccountTransaction Transaction(int id, long bankAccountId)
+	{
+		return new MudSharp.Models.BankAccountTransaction
+		{
+			Id = id,
+			BankAccountId = bankAccountId,
+			TransactionType = 0,
+			TransactionTime = "2000-01-01 00:00:00",
+			TransactionDescription = "Test transaction"
+		};
+	}
+
+	private static FuturemudDatabaseContext BuildContext()
+	{
+		var options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.Options;
+		return new FuturemudDatabaseContext(options);
+	}
+
+	private static string GetSourcePath(params string[] parts)
+	{
+		return Path.GetFullPath(Path.Combine(
+			AppContext.BaseDirectory,
+			"..",
+			"..",
+			"..",
+			"..",
+			Path.Combine(parts)));
+	}
+}

--- a/MudSharpCore/Commands/Modules/EconomyModule.cs
+++ b/MudSharpCore/Commands/Modules/EconomyModule.cs
@@ -4953,7 +4953,7 @@ The syntax for using banks is as follows:
 	#3bank preview <type>#0 - previews the fees/interest of a bank account type
 	#3bank close <account#>#0 - permanently closes a bank account
 	#3bank show <account#>#0 - shows information about an account
-	#3bank transactions <account#>#0 - shows transaction history for a bank account
+	#3bank transactions <account#>#0 - shows the 100 most recently recorded transactions for a bank account
 	#3bank deposit <account#> <amount>#0 - deposits money into an account
 	#3bank withdraw <account#> <amount>#0 - withdraws money from an account
 	#3bank transfer <fromaccount#> <toaccount#> <amount>#0 - transfers money to another account
@@ -4977,7 +4977,7 @@ The syntax for using banks is as follows:
 	#3bank preview <type>#0 - previews the fees/interest of a bank account type
 	#3bank close <account#>#0 - permanently closes a bank account
 	#3bank show <account#>#0 - shows information about an account
-	#3bank transactions <account#>#0 - shows transaction history for a bank account
+	#3bank transactions <account#>#0 - shows the 100 most recently recorded transactions for a bank account
 	#3bank deposit <account#> <amount>#0 - deposits money into an account
 	#3bank withdraw <account#> <amount>#0 - withdraws money from an account
 	#3bank transfer <fromaccount#>#0 <toaccount#> <amount>#0 - transfers money to another account
@@ -5066,7 +5066,7 @@ Syntax Option 1:
 	#3bank alias <account#>#0 - sets the alias of a bank account
 	#3bank closeaccount <account#>#0 - permanently closes a bank account
 	#3bank showaccount <account#>#0 - shows information about an account
-	#3bank transactions <account#>#0 - shows transaction history for a bank account
+	#3bank transactions <account#>#0 - shows the 100 most recently recorded transactions for a bank account
 	#3bank deposit <account#> <amount>#0 - deposits money into an account
 	#3bank withdraw <account#> <amount>#0 - withdraws money from an account
 	#3bank transfer <fromaccount#> <toaccount#> <amount>#0 - transfers money to another account
@@ -5084,7 +5084,7 @@ Syntax Option 2:
 	#3bank account alias <account#>#0 - sets the alias of a bank account
 	#3bank account close <account#>#0 - permanently closes a bank account
 	#3bank account show <account#>#0 - shows information about an account
-	#3bank account transactions <account#>#0 - shows transaction history for a bank account
+	#3bank account transactions <account#>#0 - shows the 100 most recently recorded transactions for a bank account
 	#3bank account deposit <account#> <amount>#0 - deposits money into an account
 	#3bank account withdraw <account#> <amount>#0 - withdraws money from an account
 	#3bank account transfer <fromaccount#> <toaccount#> <amount>#0 - transfers money to another account
@@ -5414,7 +5414,7 @@ Use #3bank tasks actions#0 and #3bank tasks conditions#0 for the full action and
 	#3bank account alias <account#>#0 - sets the alias of a bank account
 	#3bank account close <account#>#0 - permanently closes a bank account
 	#3bank account show <account#>#0 - shows information about an account
-	#3bank account transactions <account#>#0 - shows transaction history for an account
+	#3bank account transactions <account#>#0 - shows the 100 most recently recorded transactions for an account
 	#3bank account deposit <account#> <amount>#0 - deposits money into an account
 	#3bank account preview <type>#0 - previews an account type
 	#3bank account withdraw <account#> <amount>#0 - withdraws money from an account

--- a/MudSharpCore/Economy/Banking/BankAccount.cs
+++ b/MudSharpCore/Economy/Banking/BankAccount.cs
@@ -242,37 +242,139 @@ public class BankAccount : SaveableItem, IBankAccount, ILazyLoadDuringIdleTime
 
     public MudDateTime AccountCreationDate { get; set; }
     public BankAccountStatus AccountStatus { get; set; }
-    private bool _transactionsLoaded;
-    private readonly List<IBankAccountTransaction> _transactions = new();
+    private readonly List<IBankAccountTransaction> _recentTransactions = new();
+    private readonly List<IBankAccountTransaction> _loadedTransactions = new();
+    private readonly List<IBankAccountTransaction> _displayedTransactions = new();
+    private readonly HashSet<long> _loadedTransactionIds = new();
+    private bool _transactionHistoryLoadRequested;
+    private bool _transactionHistoryLoadQueued;
+    private long? _nextTransactionHistoryId;
 
-    public IEnumerable<IBankAccountTransaction> Transactions
+    public IEnumerable<IBankAccountTransaction> Transactions => _transactionHistoryLoadRequested
+        ? _loadedTransactions.ToList()
+        : GetRecentTransactions();
+
+    private IEnumerable<IBankAccountTransaction> GetRecentTransactions()
     {
-        get
-        {
-            if (!_transactionsLoaded)
-            {
-                LoadTransactions();
-            }
+        List<IBankAccountTransaction> transactions = _recentTransactions.ToList();
+        HashSet<long> recentTransactionIds = new(_recentTransactions
+            .Where(x => x.Id != 0L)
+            .Select(x => x.Id));
 
-            return _transactions;
+        using (new FMDB())
+        {
+            transactions.AddRange(BankAccountTransactionHistory
+                .LoadMostRecent(FMDB.Context.BankAccountTransactions, Id)
+                .Where(x => !recentTransactionIds.Contains(x.Id))
+                .Select(x => new BankAccountTransaction(x, this)));
         }
+
+        return transactions
+            .OrderByDescending(x => x.TransactionTime)
+            .ThenByDescending(x => x.Id)
+            .Take(BankAccountTransactionHistory.MaximumTransactionHistoryEntries)
+            .ToList();
     }
 
-    private void LoadTransactions()
+    private void RequestTransactionHistoryLazyLoad()
     {
-        if (_transactionsLoaded)
+        if (_transactionHistoryLoadRequested)
         {
             return;
         }
 
-        _transactionsLoaded = true;
+        List<IBankAccountTransaction> persistedTransactions;
         using (new FMDB())
         {
-            Models.BankAccountTransaction[] transactions = FMDB.Context.BankAccountTransactions.Where(x => x.BankAccountId == Id).ToArray();
-            foreach (Models.BankAccountTransaction transaction in transactions)
+            persistedTransactions = BankAccountTransactionHistory
+                .LoadMostRecent(FMDB.Context.BankAccountTransactions, Id)
+                .Select(x => (IBankAccountTransaction)new BankAccountTransaction(x, this))
+                .ToList();
+        }
+
+        _transactionHistoryLoadRequested = true;
+        foreach (IBankAccountTransaction transaction in persistedTransactions)
+        {
+            AddLoadedTransaction(transaction);
+        }
+
+        foreach (IBankAccountTransaction transaction in _recentTransactions)
+        {
+            AddLoadedTransaction(transaction);
+        }
+
+        AddDisplayedTransactions(persistedTransactions.Concat(_recentTransactions));
+        _nextTransactionHistoryId = persistedTransactions.Count == BankAccountTransactionHistory.MaximumTransactionHistoryEntries
+            ? persistedTransactions[^1].Id
+            : null;
+        QueueNextTransactionHistoryLoad();
+    }
+
+    private void QueueNextTransactionHistoryLoad()
+    {
+        if (!_nextTransactionHistoryId.HasValue || _transactionHistoryLoadQueued)
+        {
+            return;
+        }
+
+        _transactionHistoryLoadQueued = true;
+        Gameworld.SaveManager.AddLazyLoad(this);
+    }
+
+    private void AddLoadedTransaction(IBankAccountTransaction transaction)
+    {
+        if (transaction.Id != 0L && !_loadedTransactionIds.Add(transaction.Id))
+        {
+            return;
+        }
+
+        if (transaction.Id == 0L && _loadedTransactions.Contains(transaction))
+        {
+            return;
+        }
+
+        _loadedTransactions.Add(transaction);
+    }
+
+    private void AddDisplayedTransactions(IEnumerable<IBankAccountTransaction> transactions)
+    {
+        foreach (IBankAccountTransaction transaction in transactions)
+        {
+            if (transaction.Id != 0L && _displayedTransactions.Any(x => x.Id == transaction.Id))
             {
-                _transactions.Add(new BankAccountTransaction(transaction, this));
+                continue;
             }
+
+            if (transaction.Id == 0L && _displayedTransactions.Contains(transaction))
+            {
+                continue;
+            }
+
+            _displayedTransactions.Add(transaction);
+        }
+
+        List<IBankAccountTransaction> displayed = _displayedTransactions
+            .OrderByDescending(x => x.TransactionTime)
+            .ThenByDescending(x => x.Id)
+            .Take(BankAccountTransactionHistory.MaximumTransactionHistoryEntries)
+            .ToList();
+        _displayedTransactions.Clear();
+        _displayedTransactions.AddRange(displayed);
+    }
+
+    private void RecordTransaction(BankAccountTransaction transaction)
+    {
+        _recentTransactions.Add(transaction);
+        if (_recentTransactions.Count > BankAccountTransactionHistory.MaximumTransactionHistoryEntries)
+        {
+            _recentTransactions.RemoveRange(0,
+                _recentTransactions.Count - BankAccountTransactionHistory.MaximumTransactionHistoryEntries);
+        }
+
+        if (_transactionHistoryLoadRequested)
+        {
+            AddLoadedTransaction(transaction);
+            AddDisplayedTransactions([transaction]);
         }
     }
 
@@ -317,8 +419,7 @@ public class BankAccount : SaveableItem, IBankAccount, ILazyLoadDuringIdleTime
     public void Withdraw(decimal amount)
     {
         MudDateTime time = Bank.EconomicZone.ZoneForTimePurposes.DateTime(Bank.EconomicZone.FinancialPeriodReferenceCalendar);
-        LoadTransactions();
-        _transactions.Add(new BankAccountTransaction(this, BankTransactionType.Withdrawal, amount,
+        RecordTransaction(new BankAccountTransaction(this, BankTransactionType.Withdrawal, amount,
             CurrentBalance - amount, time,
             $"Withdraw {Currency.Describe(amount, CurrencyDescriptionPatternType.ShortDecimal)} at branch"));
         if (CurrentBalance < amount)
@@ -338,8 +439,7 @@ public class BankAccount : SaveableItem, IBankAccount, ILazyLoadDuringIdleTime
     public void WithdrawFromTransaction(decimal amount, string transactionReference)
     {
         MudDateTime time = Bank.EconomicZone.ZoneForTimePurposes.DateTime(Bank.EconomicZone.FinancialPeriodReferenceCalendar);
-        LoadTransactions();
-        _transactions.Add(new BankAccountTransaction(this, BankTransactionType.WithdrawalFromTransaction, amount,
+        RecordTransaction(new BankAccountTransaction(this, BankTransactionType.WithdrawalFromTransaction, amount,
             CurrentBalance - amount, time,
             $"Withdraw {Currency.Describe(amount, CurrencyDescriptionPatternType.ShortDecimal)} from transaction{(!string.IsNullOrEmpty(transactionReference) ? $" - {transactionReference}" : "")}"));
         if (CurrentBalance < amount)
@@ -359,8 +459,7 @@ public class BankAccount : SaveableItem, IBankAccount, ILazyLoadDuringIdleTime
     public void WithdrawFromTransfer(decimal amount, string toBankCode, int toAccount, string transferReference)
     {
         MudDateTime time = Bank.EconomicZone.ZoneForTimePurposes.DateTime(Bank.EconomicZone.FinancialPeriodReferenceCalendar);
-        LoadTransactions();
-        _transactions.Add(new BankAccountTransaction(this, BankTransactionType.WithdrawalFromTransfer, amount,
+        RecordTransaction(new BankAccountTransaction(this, BankTransactionType.WithdrawalFromTransfer, amount,
             CurrentBalance - amount, time,
             $"Withdraw {Currency.Describe(amount, CurrencyDescriptionPatternType.ShortDecimal)} from {toAccount} ({toBankCode}){(!string.IsNullOrEmpty(transferReference) ? $" - {transferReference}" : "")}"));
         if (CurrentBalance < amount)
@@ -387,9 +486,8 @@ public class BankAccount : SaveableItem, IBankAccount, ILazyLoadDuringIdleTime
 
     public void Deposit(decimal amount)
     {
-        LoadTransactions();
         MudDateTime time = Bank.EconomicZone.ZoneForTimePurposes.DateTime(Bank.EconomicZone.FinancialPeriodReferenceCalendar);
-        _transactions.Add(new BankAccountTransaction(this, BankTransactionType.Deposit, amount, CurrentBalance + amount,
+        RecordTransaction(new BankAccountTransaction(this, BankTransactionType.Deposit, amount, CurrentBalance + amount,
             time, $"Deposit {Currency.Describe(amount, CurrencyDescriptionPatternType.ShortDecimal)} at branch"));
         CurrentBalance += amount;
         BankAccountType.DoTransactionFeesDeposit(this, amount);
@@ -398,9 +496,8 @@ public class BankAccount : SaveableItem, IBankAccount, ILazyLoadDuringIdleTime
 
     public void DepositFromTransfer(decimal amount, string fromBankCode, int fromAccount, string transferReference)
     {
-        LoadTransactions();
         MudDateTime time = Bank.EconomicZone.ZoneForTimePurposes.DateTime(Bank.EconomicZone.FinancialPeriodReferenceCalendar);
-        _transactions.Add(new BankAccountTransaction(this, BankTransactionType.DepositFromTransfer, amount,
+        RecordTransaction(new BankAccountTransaction(this, BankTransactionType.DepositFromTransfer, amount,
             CurrentBalance + amount, time,
             $"Deposit {Currency.Describe(amount, CurrencyDescriptionPatternType.ShortDecimal)} from {fromAccount} ({fromBankCode}){(!string.IsNullOrEmpty(transferReference) ? $" - {transferReference}" : "")}"));
         CurrentBalance += amount;
@@ -410,9 +507,8 @@ public class BankAccount : SaveableItem, IBankAccount, ILazyLoadDuringIdleTime
 
     public void DepositFromTransaction(decimal amount, string transactionReference)
     {
-        LoadTransactions();
         MudDateTime time = Bank.EconomicZone.ZoneForTimePurposes.DateTime(Bank.EconomicZone.FinancialPeriodReferenceCalendar);
-        _transactions.Add(new BankAccountTransaction(this, BankTransactionType.DepositFromTransaction, amount,
+        RecordTransaction(new BankAccountTransaction(this, BankTransactionType.DepositFromTransaction, amount,
             CurrentBalance + amount, time,
             $"Deposit {Currency.Describe(amount, CurrencyDescriptionPatternType.ShortDecimal)} from transaction{(!string.IsNullOrEmpty(transactionReference) ? $" - {transactionReference}" : "")}"));
         CurrentBalance += amount;
@@ -422,9 +518,8 @@ public class BankAccount : SaveableItem, IBankAccount, ILazyLoadDuringIdleTime
 
     public void DoAccountCredit(decimal amount, string reason)
     {
-        LoadTransactions();
         MudDateTime time = Bank.EconomicZone.ZoneForTimePurposes.DateTime(Bank.EconomicZone.FinancialPeriodReferenceCalendar);
-        _transactions.Add(new BankAccountTransaction(this, BankTransactionType.DepositFromTransfer, amount,
+        RecordTransaction(new BankAccountTransaction(this, BankTransactionType.DepositFromTransfer, amount,
             CurrentBalance + amount, time,
             $"Credit {Currency.Describe(amount, CurrencyDescriptionPatternType.ShortDecimal)} - {reason}"));
         CurrentBalance += amount;
@@ -450,22 +545,20 @@ public class BankAccount : SaveableItem, IBankAccount, ILazyLoadDuringIdleTime
         CurrentBalance = 0.0M;
         CurrentMonthInterest = 0.0M;
         CurrentMonthFees = 0.0M;
-        LoadTransactions();
         MudDateTime time = Bank.EconomicZone.ZoneForTimePurposes.DateTime(Bank.EconomicZone.FinancialPeriodReferenceCalendar);
-        _transactions.Add(new BankAccountTransaction(this, BankTransactionType.Withdrawal, change, 0.0M, time,
+        RecordTransaction(new BankAccountTransaction(this, BankTransactionType.Withdrawal, change, 0.0M, time,
             $"Account Rolled Over and Finalised"));
         Changed = true;
     }
 
     public void FinaliseMonth()
     {
-        LoadTransactions();
         MudDateTime time = Bank.EconomicZone.ZoneForTimePurposes.DateTime(Bank.EconomicZone.FinancialPeriodReferenceCalendar);
         CurrentBalance -= CurrentMonthFees;
-        _transactions.Add(new BankAccountTransaction(this, BankTransactionType.ServiceFee, CurrentMonthFees,
+        RecordTransaction(new BankAccountTransaction(this, BankTransactionType.ServiceFee, CurrentMonthFees,
             CurrentBalance, time, $"Monthly Account Fees"));
         CurrentBalance += CurrentMonthInterest;
-        _transactions.Add(new BankAccountTransaction(this, BankTransactionType.InterestEarned, CurrentMonthInterest,
+        RecordTransaction(new BankAccountTransaction(this, BankTransactionType.InterestEarned, CurrentMonthInterest,
             CurrentBalance, time, $"Interest Earned"));
         CurrentMonthFees = 0.0M;
         CurrentMonthInterest = 0.0M;
@@ -474,7 +567,6 @@ public class BankAccount : SaveableItem, IBankAccount, ILazyLoadDuringIdleTime
 
     public void ChargeFee(decimal amount, BankTransactionType transactionType, string feeDescription)
     {
-        LoadTransactions();
         MudDateTime time = Bank.EconomicZone.ZoneForTimePurposes.DateTime(Bank.EconomicZone.FinancialPeriodReferenceCalendar);
         string feeType = "Other Fee";
         switch (transactionType)
@@ -518,7 +610,7 @@ public class BankAccount : SaveableItem, IBankAccount, ILazyLoadDuringIdleTime
         }
 
         CurrentBalance -= amount;
-        _transactions.Add(new BankAccountTransaction(this, BankTransactionType.ServiceFee, amount, CurrentBalance, time,
+        RecordTransaction(new BankAccountTransaction(this, BankTransactionType.ServiceFee, amount, CurrentBalance, time,
             $"{feeType}: {Currency.Describe(amount, CurrencyDescriptionPatternType.ShortDecimal)}"));
         Changed = true;
     }
@@ -600,6 +692,7 @@ public class BankAccount : SaveableItem, IBankAccount, ILazyLoadDuringIdleTime
 
     public string ShowTransactions(ICharacter actor)
     {
+        RequestTransactionHistoryLazyLoad();
         StringBuilder sb = new();
         if (actor.IsAdministrator())
         {
@@ -611,8 +704,9 @@ public class BankAccount : SaveableItem, IBankAccount, ILazyLoadDuringIdleTime
         }
 
         sb.AppendLine();
+        sb.AppendLine($"Showing up to {BankAccountTransactionHistory.MaximumTransactionHistoryEntries.ToString("N0", actor)} most recently recorded transactions.");
         sb.Append(StringUtilities.GetTextTable(
-            from transaction in Transactions.OrderByDescending(x => x.TransactionTime)
+            from transaction in _displayedTransactions
             select new List<string>
             {
                 transaction.TransactionTime.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short),
@@ -699,7 +793,30 @@ public class BankAccount : SaveableItem, IBankAccount, ILazyLoadDuringIdleTime
 
     public void DoLoad()
     {
-        LoadTransactions();
+        _transactionHistoryLoadQueued = false;
+        if (!_transactionHistoryLoadRequested || !_nextTransactionHistoryId.HasValue)
+        {
+            return;
+        }
+
+        List<IBankAccountTransaction> transactions;
+        using (new FMDB())
+        {
+            transactions = BankAccountTransactionHistory
+                .LoadOlderThan(FMDB.Context.BankAccountTransactions, Id, _nextTransactionHistoryId.Value)
+                .Select(x => (IBankAccountTransaction)new BankAccountTransaction(x, this))
+                .ToList();
+        }
+
+        foreach (IBankAccountTransaction transaction in transactions)
+        {
+            AddLoadedTransaction(transaction);
+        }
+
+        _nextTransactionHistoryId = transactions.Count == BankAccountTransactionHistory.MaximumTransactionHistoryEntries
+            ? transactions[^1].Id
+            : null;
+        QueueNextTransactionHistoryLoad();
     }
 
     #endregion

--- a/MudSharpCore/Economy/Banking/BankAccountTransactionHistory.cs
+++ b/MudSharpCore/Economy/Banking/BankAccountTransactionHistory.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace MudSharp.Economy.Banking;
+
+public static class BankAccountTransactionHistory
+{
+	public const int MaximumTransactionHistoryEntries = 100;
+
+	public static List<Models.BankAccountTransaction> LoadMostRecent(
+		IQueryable<Models.BankAccountTransaction> transactions, long bankAccountId)
+	{
+		return transactions
+			.AsNoTracking()
+			.Where(x => x.BankAccountId == bankAccountId)
+			.OrderByDescending(x => x.Id)
+			.Take(MaximumTransactionHistoryEntries)
+			.ToList();
+	}
+
+	public static List<Models.BankAccountTransaction> LoadOlderThan(
+		IQueryable<Models.BankAccountTransaction> transactions, long bankAccountId, long transactionId)
+	{
+		return transactions
+			.AsNoTracking()
+			.Where(x => x.BankAccountId == bankAccountId && x.Id < transactionId)
+			.OrderByDescending(x => x.Id)
+			.Take(MaximumTransactionHistoryEntries)
+			.ToList();
+	}
+}


### PR DESCRIPTION
## Summary

- Limit player-facing bank transaction history to the 100 most recent records.
- Load older history asynchronously during idle time in bounded batches.
- Prevent balance-changing operations from synchronously hydrating historical transactions.
- Update economy documentation and command help to describe the bounded history window.
- Add coverage for recent-history and paged older-history loading.

## Testing

- Added unit tests for bounded account filtering, ordering, and batch pagination.
- Added source-level regression coverage for lazy history hydration and transaction recording behavior.