### PR TITLE
Harden command help, alert formatting, board output, and regnal date parsing

### DIFF
--- a/MudSharpCore Unit Tests/AlertCommandSourceIntegrationTests.cs
+++ b/MudSharpCore Unit Tests/AlertCommandSourceIntegrationTests.cs
@@ -6,6 +6,7 @@ using MudSharp.Events;
 using MudSharp.Framework;
 using System;
 using System.IO;
+using System.Linq;
 
 namespace MudSharp_Unit_Tests;
 
@@ -42,6 +43,10 @@ public class AlertCommandSourceIntegrationTests
 		StringAssert.Contains(source, "actor.CustomDistantAlertEmote = emoteText;");
 		StringAssert.Contains(source, "AlertUtilities.ValidateStoredAlertEmote(emoteText, actor, out var error)");
 		StringAssert.Contains(source, "AlertUtilities.ValidateStoredDistantAlertEmote(emoteText, actor, out var error)");
+		var alertSetStart = source.IndexOf("private static void AlertSet(", StringComparison.Ordinal);
+		var alertSetEnd = source.IndexOf("private static void AlertSetDistant(", alertSetStart, StringComparison.Ordinal);
+		StringAssert.Contains(source[alertSetStart..alertSetEnd],
+			"AlertUtilities.ValidateStoredAlertEmote(emoteText, actor, out var error)");
 	}
 
 	[TestMethod]
@@ -72,6 +77,26 @@ public class AlertCommandSourceIntegrationTests
 		StringAssert.Contains(localError, AlertUtilities.MaximumStoredAlertEmoteLength.ToString("N0"));
 		Assert.IsFalse(AlertUtilities.ValidateStoredDistantAlertEmote(longDistant, perceiver, out var distantError));
 		StringAssert.Contains(distantError, AlertUtilities.MaximumStoredAlertEmoteLength.ToString("N0"));
+	}
+
+	[TestMethod]
+	public void DistantAlertValidator_RejectsAlignmentFormatItems()
+	{
+		var perceiver = new DummyPerceiver();
+
+		Assert.IsFalse(AlertUtilities.ValidateDistantAlertEmote(
+			"A sharp alert can be heard {0}{0,9999}.", perceiver, out var error));
+		StringAssert.Contains(error, "Use only {0}");
+	}
+
+	[TestMethod]
+	public void DistantAlertValidator_RejectsExcessiveFormattedOutput()
+	{
+		var perceiver = new DummyPerceiver();
+		var emoteText = string.Concat(Enumerable.Repeat("{0}", 50));
+
+		Assert.IsFalse(AlertUtilities.ValidateDistantAlertEmote(emoteText, perceiver, out var error));
+		StringAssert.Contains(error, "1,000");
 	}
 
 	[TestMethod]

--- a/MudSharpCore Unit Tests/BoardPresentationSecurityTests.cs
+++ b/MudSharpCore Unit Tests/BoardPresentationSecurityTests.cs
@@ -1,0 +1,31 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class BoardPresentationSecurityTests
+{
+	[TestMethod]
+	public void BoardPostListing_TerminatesTitleAnsiState()
+	{
+		var source = File.ReadAllText(GetSourcePath("MudSharpCore", "Commands", "Modules",
+			"CommunicationsModule.cs"));
+
+		StringAssert.Contains(source, "ColourIfNotColoured(Telnet.BoldWhite)}{Telnet.RESET}");
+	}
+
+	private static string GetSourcePath(params string[] parts)
+	{
+		return Path.GetFullPath(Path.Combine(
+			AppContext.BaseDirectory,
+			"..",
+			"..",
+			"..",
+			"..",
+			Path.Combine(parts)));
+	}
+}

--- a/MudSharpCore Unit Tests/CommandHelpSecurityTests.cs
+++ b/MudSharpCore Unit Tests/CommandHelpSecurityTests.cs
@@ -1,0 +1,31 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Commands.Modules;
+using System.Linq;
+using System.Reflection;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class CommandHelpSecurityTests
+{
+	[TestMethod]
+	public void ShowCommand_HelpInfo_SeparatesPlayerGuideAndAdministratorTopics()
+	{
+		var command = typeof(ShowModule).GetMethod("Show", BindingFlags.Static | BindingFlags.NonPublic)!;
+		Assert.IsNotNull(command);
+		var helpInfo = command.GetCustomAttribute<HelpInfo>()!;
+		Assert.IsNotNull(helpInfo);
+		var guideHelp = command.GetCustomAttributes<ConditionalHelpInfo>()
+			.Single(x => x.PredicateMethodName == "CanSeeGuideShowHelp");
+
+		foreach (var privilegedTopic in new[] { "#3account <account>#0", "#3accounts", "#3character <id>#0",
+			         "#3permissions#0", "#3staticconfig <which>#0", "#3staticstring <which>#0" })
+		{
+			Assert.IsFalse(helpInfo.DefaultHelp.Contains(privilegedTopic));
+			Assert.IsFalse(guideHelp.HelpText.Contains(privilegedTopic));
+			Assert.IsTrue(helpInfo.AdminHelp.Contains(privilegedTopic));
+		}
+	}
+}

--- a/MudSharpCore Unit Tests/MudDateTimeTests.cs
+++ b/MudSharpCore Unit Tests/MudDateTimeTests.cs
@@ -272,6 +272,21 @@ public class MudDateTimeTests
     }
 
     [TestMethod]
+    public void Calendar_TryGetDate_RejectsOversizedRegnalYearsWithoutThrowing()
+    {
+        var calendar = CreateRegnalCalendar();
+        var oversizedYear = new string('9', 30);
+
+        Assert.IsFalse(calendar.TryGetDate($"regnal:charles-iii:{oversizedYear}:month5:3", out _,
+            out var structuredError));
+        StringAssert.Contains(structuredError, "regnal year");
+
+        Assert.IsFalse(calendar.TryGetDate($"month5 3rd RY{oversizedYear} @charles-iii", out _,
+            out var canonicalError));
+        StringAssert.Contains(canonicalError, "regnal year");
+    }
+
+    [TestMethod]
     public void MudDateTime_TryParse_AcceptsRegnalDateInput()
     {
         var calendar = CreateRegnalCalendar();

--- a/MudSharpCore/Commands/Modules/CommunicationsModule.cs
+++ b/MudSharpCore/Commands/Modules/CommunicationsModule.cs
@@ -1192,7 +1192,7 @@ Your in-room emote uses normal emote syntax. If you omit the #6@#0 token, your s
         }
 
         var emoteText = ss.SafeRemainingArgument;
-        if (!AlertUtilities.ValidateAlertEmote(emoteText, actor, out var error))
+        if (!AlertUtilities.ValidateStoredAlertEmote(emoteText, actor, out var error))
         {
             actor.OutputHandler.Send(error);
             return;
@@ -1567,7 +1567,7 @@ You can use the following syntax with this command:
         foreach (IBoardPost post in boardItem.Board.Posts.OrderBy(x => x.PostTime)
                                        .ThenBy(x => x.Id))
         {
-            sb.AppendLine($"\t{i++.ToString("N0", actor)}) {post.Title.SubstituteANSIColour().ColourIfNotColoured(Telnet.BoldWhite)}");
+            sb.AppendLine($"\t{i++.ToString("N0", actor)}) {post.Title.SubstituteANSIColour().ColourIfNotColoured(Telnet.BoldWhite)}{Telnet.RESET}");
         }
 
         actor.OutputHandler.Send(sb.ToString());

--- a/MudSharpCore/Commands/Modules/ShowModule.cs
+++ b/MudSharpCore/Commands/Modules/ShowModule.cs
@@ -188,15 +188,20 @@ public class ShowModule : Module<ICharacter>
 	#3weatherevent <id|name>#0 - shows a specific weather event
 	#3writingstyles#0 - shows writing styles";
 
-    private const string ShowHelpText = @"The #3show#0 command is the read-only catalogue browser for engine data. The available topics vary with your permissions; use it to inspect an individual object by ID or name where the listed topic accepts a #6<which>#0 argument.
+    private const string ShowHelpIntroduction = @"The #3show#0 command is the read-only catalogue browser for engine data. The available topics vary with your permissions; use it to inspect an individual object by ID or name where the listed topic accepts a #6<which>#0 argument.
 
-Using #3show#0 on its own displays the topic list appropriate to your current permission level. The administrative list below includes the full command surface.
+Using #3show#0 on its own displays the topic list appropriate to your current permission level.
 
-" + AdminShowDefaultText;
+";
+
+    private const string PlayerShowHelpText = ShowHelpIntroduction + PlayerShowDefaultText;
+    private const string GuideShowHelpText = ShowHelpIntroduction + GuideShowDefaultText;
+    private const string AdminShowHelpText = ShowHelpIntroduction + AdminShowDefaultText;
 
     [PlayerCommand("Show", "show")]
     [CustomModuleName("Game")]
-    [HelpInfo("show", ShowHelpText, AutoHelp.HelpArg)]
+    [HelpInfo("show", PlayerShowHelpText, AutoHelp.HelpArg, AdminShowHelpText)]
+    [ConditionalHelpInfo(nameof(CanSeeGuideShowHelp), GuideShowHelpText)]
     protected static void Show(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -543,6 +548,11 @@ Using #3show#0 on its own displays the topic list appropriate to your current pe
 
                 return;
         }
+    }
+
+    private static bool CanSeeGuideShowHelp(ICharacter actor)
+    {
+        return actor.PermissionLevel == PermissionLevel.Guide;
     }
 
     private static void Show_BloodTypes(ICharacter actor, StringStack ss)

--- a/MudSharpCore/Communication/AlertUtilities.cs
+++ b/MudSharpCore/Communication/AlertUtilities.cs
@@ -8,6 +8,7 @@ using MudSharp.Form.Audio;
 using MudSharp.NPC;
 using MudSharp.NPC.AI;
 using MudSharp.RPG.Checks;
+using System.Text;
 
 namespace MudSharp.Communication;
 
@@ -16,6 +17,7 @@ public static class AlertUtilities
 	public const uint AlertRoomRange = 2;
 	public const AudioVolume AlertVolume = AudioVolume.ExtremelyLoud;
 	public const int MaximumStoredAlertEmoteLength = 500;
+	private const int MaximumFormattedDistantAlertEmoteLength = 1_000;
 	private const string SampleDirectionText = "immediately to the north";
 
 	public static bool ValidateAlertEmote(string emoteText, IPerceiver source, out string error)
@@ -33,12 +35,6 @@ public static class AlertUtilities
 
 	public static bool ValidateDistantAlertEmote(string emoteText, IPerceiver source, out string error)
 	{
-		if (!emoteText.Contains("{0}", StringComparison.InvariantCulture))
-		{
-			error = "The distant alert emote must include {0} where the direction and distance text should appear.";
-			return false;
-		}
-
 		if (!TryFormatDistantAlertEmote(emoteText, SampleDirectionText, out var formattedText, out error))
 		{
 			return false;
@@ -295,18 +291,66 @@ public static class AlertUtilities
 	private static bool TryFormatDistantAlertEmote(string emoteText, string directionText, out string formattedText,
 		out string error)
 	{
-		try
+		formattedText = string.Empty;
+		var builder = new StringBuilder();
+		var hasDirectionPlaceholder = false;
+		for (var i = 0; i < emoteText.Length; i++)
 		{
-			formattedText = string.Format(emoteText, directionText);
-			error = string.Empty;
-			return true;
+			var isDirectionPlaceholder = emoteText[i] == '{' &&
+			                             i + 2 < emoteText.Length &&
+			                             emoteText[i + 1] == '0' &&
+			                             emoteText[i + 2] == '}';
+			var isEscapedOpeningBrace = emoteText[i] == '{' &&
+			                            i + 1 < emoteText.Length &&
+			                            emoteText[i + 1] == '{';
+			var isEscapedClosingBrace = emoteText[i] == '}' &&
+			                            i + 1 < emoteText.Length &&
+			                            emoteText[i + 1] == '}';
+			var text = isDirectionPlaceholder
+				? directionText
+				: isEscapedOpeningBrace
+					? "{"
+					: isEscapedClosingBrace
+						? "}"
+						: emoteText[i] switch
+			{
+				'{' or '}' => null,
+				_ => emoteText[i].ToString()
+			};
+
+			if (text is null)
+			{
+				error = "That distant alert emote has invalid format placeholders. Use only {0} for the direction and distance.";
+				return false;
+			}
+
+			if (builder.Length + text.Length > MaximumFormattedDistantAlertEmoteLength)
+			{
+				error = $"That distant alert emote expands to more than {MaximumFormattedDistantAlertEmoteLength.ToString("N0")} characters.";
+				return false;
+			}
+
+			builder.Append(text);
+			if (isDirectionPlaceholder)
+			{
+				hasDirectionPlaceholder = true;
+				i += 2;
+			}
+			else if (isEscapedOpeningBrace || isEscapedClosingBrace)
+			{
+				i++;
+			}
 		}
-		catch (FormatException)
+
+		if (!hasDirectionPlaceholder)
 		{
-			formattedText = string.Empty;
-			error = "That distant alert emote has invalid format placeholders. Use only {0} for the direction and distance.";
+			error = "The distant alert emote must include {0} where the direction and distance text should appear.";
 			return false;
 		}
+
+		formattedText = builder.ToString();
+		error = string.Empty;
+		return true;
 	}
 
 	private static bool ValidateStoredAlertLength(string emoteText, out string error)

--- a/MudSharpCore/TimeAndDate/Date/Calendar.cs
+++ b/MudSharpCore/TimeAndDate/Date/Calendar.cs
@@ -1439,8 +1439,14 @@ public class Calendar : SaveableItem, ICalendar
         if (structured.Success)
         {
             var day = structured.Groups["day"].Value.GetIntFromOrdinal() ?? 0;
+            if (!int.TryParse(structured.Groups["year"].Value, out var year))
+            {
+                error = "The regnal year must be a valid whole number.";
+                return false;
+            }
+
             return TryGetDateFromRegnalDate(structured.Groups["key"].Value,
-                int.Parse(structured.Groups["year"].Value), day, structured.Groups["month"].Value,
+                year, day, structured.Groups["month"].Value,
                 allowProjected, out date, out error);
         }
 
@@ -1454,8 +1460,14 @@ public class Calendar : SaveableItem, ICalendar
                 return false;
             }
 
+            if (!int.TryParse(canonical.Groups["year"].Value, out var year))
+            {
+                error = "The regnal year must be a valid whole number.";
+                return false;
+            }
+
             return TryGetDateFromRegnalDate(canonical.Groups["key"].Value,
-                int.Parse(canonical.Groups["year"].Value), day, month,
+                year, day, month,
                 allowProjected, out date, out error);
         }
 


### PR DESCRIPTION
## Summary

- Separate player, guide, and administrator `show` help topics.
- Validate stored alert emotes and safely constrain distant-alert formatting.
- Reset ANSI state after board post titles.
- Reject oversized regnal years without throwing exceptions.
- Add regression and source-integrity tests for the security fixes.

## Testing

- Added targeted unit and integration coverage for alert validation, command-help disclosure, board ANSI cleanup, and oversized regnal-year parsing.
- Not run (not requested)