### PR TITLE
Fix persisted liquid craft inputs

### DIFF
--- a/Design Documents/Crafting/Crafting_System_Runtime_and_Extensibility.md
+++ b/Design Documents/Crafting/Crafting_System_Runtime_and_Extensibility.md
@@ -178,6 +178,8 @@ It also serializes:
 - check outcome
 - reserved input data
 
+Reserved input reload accepts both the standard `Data` payload and the `Input` payload emitted by liquid-use inputs. Each saved payload is loaded once so an interrupted craft retains its consumed-liquid reservation across persistence.
+
 The component decorates the in-progress item's short and full description so the progress item visibly represents the craft.
 
 ### 5. Phase execution
@@ -428,6 +430,8 @@ Subtype-specific prog use also exists in products such as:
 - `ProgProduct`
 - `ProgVariableProduct`
 - `NPCProduct`
+
+`ProgVariableProduct` supplies its variable progs with the consumed inputs as an ordered collection of individual perceivables: single inputs remain single entries, while perceivable groups are expanded to their members.
 
 ### Item system integration
 Crafting leans heavily on the item system.

--- a/Design Documents/Crafting/Crafting_System_Runtime_and_Extensibility.md
+++ b/Design Documents/Crafting/Crafting_System_Runtime_and_Extensibility.md
@@ -178,7 +178,7 @@ It also serializes:
 - check outcome
 - reserved input data
 
-Reserved input reload accepts both the standard `Data` payload and the `Input` payload emitted by liquid-use inputs. Each saved payload is loaded once so an interrupted craft retains its consumed-liquid reservation across persistence.
+Reserved input reload accepts both the standard `Data` payload and the `Input` payload emitted by liquid-use inputs. Each saved payload is loaded once so an interrupted craft retains its consumed-liquid reservation across persistence. Reloaded liquid data also reconstructs its temporary perceivable so resume-time clash solving can safely exclude already consumed inputs.
 
 The component decorates the in-progress item's short and full description so the progress item visibly represents the craft.
 

--- a/Design Documents/Crafting/Crafting_System_Runtime_and_Extensibility.md
+++ b/Design Documents/Crafting/Crafting_System_Runtime_and_Extensibility.md
@@ -178,7 +178,7 @@ It also serializes:
 - check outcome
 - reserved input data
 
-Reserved input reload accepts both the standard `Data` payload and the `Input` payload emitted by liquid-use inputs. Each saved payload is loaded once so an interrupted craft retains its consumed-liquid reservation across persistence. Reloaded liquid data also reconstructs its temporary perceivable so resume-time clash solving can safely exclude already consumed inputs.
+Reserved input reload accepts both the standard `Data` payload and the legacy `Input` payload previously emitted by liquid-use inputs. New liquid saves use the standard `Data` payload. Each saved payload is loaded once so an interrupted craft retains its consumed-liquid reservation across persistence. Reloaded liquid data also reconstructs its temporary perceivable so resume-time clash solving can safely exclude already consumed inputs. Active-craft copies reuse those exact payloads and reconstructed perceivables.
 
 The component decorates the in-progress item's short and full description so the progress item visibly represents the craft.
 
@@ -431,7 +431,7 @@ Subtype-specific prog use also exists in products such as:
 - `ProgVariableProduct`
 - `NPCProduct`
 
-`ProgVariableProduct` supplies its variable progs with the consumed inputs as an ordered collection of individual perceivables: single inputs remain single entries, while perceivable groups are expanded to their members.
+`ProgVariableProduct` supplies its variable progs with consumed inputs in the craft's configured input order. Single inputs remain single entries, while perceivable groups are expanded to their members. A prog accepting a collection of perceivables receives every individual consumed perceivable; a prog accepting a collection of items receives only consumed game items.
 
 ### Item system integration
 Crafting leans heavily on the item system.

--- a/FutureMUDLibrary Unit Tests/PerceivableItemExtensionsTests.cs
+++ b/FutureMUDLibrary Unit Tests/PerceivableItemExtensionsTests.cs
@@ -1,0 +1,35 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Framework;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class PerceivableItemExtensionsTests
+{
+	[TestMethod]
+	public void GetIndividualPerceivables_FlattensMixedSinglesAndGroupsInOrder()
+	{
+		var single = new Mock<IPerceivable>();
+		single.SetupGet(x => x.IsSingleEntity).Returns(true);
+		var liquidDummy = new Mock<IPerceivable>();
+		liquidDummy.SetupGet(x => x.IsSingleEntity).Returns(true);
+		var firstMember = new Mock<IPerceivable>().Object;
+		var secondMember = new Mock<IPerceivable>().Object;
+		var group = new Mock<IPerceivableGroup>();
+		group.SetupGet(x => x.IsSingleEntity).Returns(false);
+		group.SetupGet(x => x.Members).Returns([firstMember, secondMember]);
+
+		var result = new IPerceivable[] { single.Object, liquidDummy.Object, group.Object }
+			.GetIndividualPerceivables()
+			.ToArray();
+
+		CollectionAssert.AreEqual(
+			new IPerceivable[] { single.Object, liquidDummy.Object, firstMember, secondMember },
+			result);
+	}
+}

--- a/FutureMUDLibrary/Framework/PerceivableItemExtensions.cs
+++ b/FutureMUDLibrary/Framework/PerceivableItemExtensions.cs
@@ -12,6 +12,7 @@ namespace MudSharp.Framework
                 if (item.IsSingleEntity)
                 {
                     yield return item;
+                    continue;
                 }
 
                 foreach (IPerceivable subItem in ((IPerceivableGroup)item).Members)

--- a/MudSharpCore Unit Tests/Crafts/CraftInputPersistenceTests.cs
+++ b/MudSharpCore Unit Tests/Crafts/CraftInputPersistenceTests.cs
@@ -7,6 +7,8 @@ using MudSharp.GameItems;
 using MudSharp.GameItems.Components;
 using MudSharp.GameItems.Prototypes;
 using MudSharp.Work.Crafts;
+using MudSharp.Work.Crafts.Inputs;
+using System.Collections.Generic;
 using System.Xml.Linq;
 
 namespace MudSharp_Unit_Tests.Crafts;
@@ -62,6 +64,92 @@ public class CraftInputPersistenceTests
 		standard.Input.Verify(x => x.LoadDataFromXml(It.Is<XElement>(e => XElement.DeepEquals(e, standardXml)), gameworld.Object), Times.Once);
 		liquid.Input.Verify(x => x.LoadDataFromXml(It.Is<XElement>(e => XElement.DeepEquals(e, liquidXml)), gameworld.Object), Times.Once);
 		taggedLiquid.Input.Verify(x => x.LoadDataFromXml(It.Is<XElement>(e => XElement.DeepEquals(e, taggedLiquidXml)), gameworld.Object), Times.Once);
+	}
+
+	[TestMethod]
+	public void ReloadedLiquidUseData_HasPerceivableAndCanEnterResumeClashSolver()
+	{
+		var setup = LiquidWorld();
+		var xml = LiquidXml("Liquid", setup.Liquid.Object.Id, setup.Container.Object.Id);
+
+		var data = new LiquidUseInput.LiquidUseInputData(xml, setup.Gameworld.Object);
+
+		Assert.IsNotNull(data.Perceivable);
+		Assert.AreEqual(setup.Liquid.Object, data.Liquid);
+		Assert.AreEqual(2.0, data.Amount);
+		Assert.AreEqual(1, data.OriginalItems.Count);
+		AssertResumeClashSolverAccepts(data.Perceivable);
+	}
+
+	[TestMethod]
+	public void ReloadedLiquidTagUseData_HasPerceivableAndCanEnterResumeClashSolver()
+	{
+		var setup = LiquidWorld();
+		var tag = new Mock<ITag>();
+		tag.SetupGet(x => x.Id).Returns(99);
+		var tags = new Mock<IUneditableAll<ITag>>();
+		tags.Setup(x => x.Get(99)).Returns(tag.Object);
+		setup.Gameworld.SetupGet(x => x.Tags).Returns(tags.Object);
+		var xml = LiquidXml("TagId", tag.Object.Id, setup.Container.Object.Id);
+
+		var data = new LiquidTagUseInput.LiquidUseInputData(xml, setup.Gameworld.Object);
+
+		Assert.IsNotNull(data.Perceivable);
+		Assert.AreEqual(tag.Object, data.Target);
+		Assert.AreEqual(2.0, data.Amount);
+		Assert.AreEqual(1, data.OriginalItems.Count);
+		AssertResumeClashSolverAccepts(data.Perceivable);
+	}
+
+	private static XElement LiquidXml(string targetElement, long targetId, long containerId)
+	{
+		return new XElement("Input",
+			new XElement(targetElement, targetId),
+			new XElement("Amount", 2.0),
+			new XElement("Quality", (int)ItemQuality.Good),
+			new XElement("Mix", new XElement("Liquid",
+				new XAttribute("id", 14),
+				new XAttribute("amount", 2.0))),
+			new XElement("OriginalItem", containerId));
+	}
+
+	private static (Mock<IFuturemud> Gameworld, Mock<ILiquid> Liquid, Mock<IGameItem> Container) LiquidWorld()
+	{
+		var liquid = new Mock<ILiquid>();
+		liquid.SetupGet(x => x.Id).Returns(14);
+		liquid.SetupGet(x => x.Name).Returns("soapy water");
+		liquid.SetupGet(x => x.MaterialDescription).Returns("soapy water");
+		liquid.SetupGet(x => x.Description).Returns("soapy water");
+		liquid.SetupGet(x => x.Density).Returns(1.0);
+		liquid.SetupGet(x => x.DisplayColour).Returns(Telnet.Cyan);
+		var liquids = new Mock<IUneditableAll<ILiquid>>();
+		liquids.Setup(x => x.Get(14)).Returns(liquid.Object);
+
+		var container = new Mock<IGameItem>();
+		container.SetupGet(x => x.Id).Returns(303);
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.Liquids).Returns(liquids.Object);
+		gameworld.Setup(x => x.TryGetItem(303, false)).Returns(container.Object);
+		return (gameworld, liquid, container);
+	}
+
+	private static void AssertResumeClashSolverAccepts(IPerceivable liquidPerceivable)
+	{
+		var liquidInput = new Mock<ICraftInput>().Object;
+		var otherInput = new Mock<ICraftInput>().Object;
+		var solver = new OptionSolver<ICraftInput, IPerceivable>(
+			new List<IChoice<ICraftInput, IPerceivable>>
+			{
+				new Choice<ICraftInput, IPerceivable>(liquidInput,
+					[new PerceivableOption(liquidPerceivable)]),
+				new Choice<ICraftInput, IPerceivable>(otherInput,
+					[new PerceivableOption(new DummyPerceivable("later input"))])
+			});
+
+		var result = solver.SolveOptions();
+
+		Assert.IsTrue(result.Success);
+		Assert.AreEqual(2, result.Solution.Count);
 	}
 
 	private static (Mock<ICraftInput> Input, TestCraftInputData Data) Input(long id, XElement xml)

--- a/MudSharpCore Unit Tests/Crafts/CraftInputPersistenceTests.cs
+++ b/MudSharpCore Unit Tests/Crafts/CraftInputPersistenceTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Form.Material;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Components;
+using MudSharp.GameItems.Prototypes;
+using MudSharp.Work.Crafts;
+using System.Xml.Linq;
+
+namespace MudSharp_Unit_Tests.Crafts;
+
+[TestClass]
+public class CraftInputPersistenceTests
+{
+	[TestMethod]
+	public void ActiveCraft_RoundTripsStandardAndLiquidConsumedInputData()
+	{
+		var standardXml = new XElement("Data",
+			new XElement("Item", 101),
+			new XElement("Quantity", 2));
+		var liquidXml = new XElement("Input",
+			new XElement("Liquid", 202),
+			new XElement("Amount", 1.25),
+			new XElement("Quality", 7),
+			new XElement("Mix", new XElement("Liquid", new XAttribute("id", 202), 1.25)),
+			new XElement("OriginalItem", 303));
+		var taggedLiquidXml = new XElement("Input",
+			new XElement("TagId", 404),
+			new XElement("Amount", 2.5),
+			new XElement("Quality", 5),
+			new XElement("Mix", new XElement("Liquid", new XAttribute("id", 405), 2.5)),
+			new XElement("OriginalItem", 505),
+			new XElement("OriginalItem", 506));
+
+		var standard = Input(1, standardXml);
+		var liquid = Input(2, liquidXml);
+		var taggedLiquid = Input(3, taggedLiquidXml);
+		var craft = new Mock<ICraft>();
+		craft.SetupGet(x => x.Id).Returns(42);
+		craft.SetupGet(x => x.RevisionNumber).Returns(6);
+		craft.SetupGet(x => x.Inputs).Returns([standard.Input.Object, liquid.Input.Object, taggedLiquid.Input.Object]);
+
+		var crafts = new Mock<IUneditableRevisableAll<ICraft>>();
+		crafts.Setup(x => x.Get(42, 6)).Returns(craft.Object);
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.Crafts).Returns(crafts.Object);
+		var parent = new Mock<IGameItem>();
+		parent.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+
+		var source = new TestActiveCraftComponent(parent.Object) { Craft = craft.Object };
+		source.ConsumedInputs[standard.Input.Object] = (standard.Data.Perceivable, standard.Data);
+		source.ConsumedInputs[liquid.Input.Object] = (liquid.Data.Perceivable, liquid.Data);
+		source.ConsumedInputs[taggedLiquid.Input.Object] = (taggedLiquid.Data.Perceivable, taggedLiquid.Data);
+
+		var saved = XElement.Parse(source.SaveDefinition());
+		var loaded = new TestActiveCraftComponent(parent.Object);
+		loaded.LoadDefinition(saved);
+
+		Assert.AreEqual(3, loaded.ConsumedInputs.Count);
+		standard.Input.Verify(x => x.LoadDataFromXml(It.Is<XElement>(e => XElement.DeepEquals(e, standardXml)), gameworld.Object), Times.Once);
+		liquid.Input.Verify(x => x.LoadDataFromXml(It.Is<XElement>(e => XElement.DeepEquals(e, liquidXml)), gameworld.Object), Times.Once);
+		taggedLiquid.Input.Verify(x => x.LoadDataFromXml(It.Is<XElement>(e => XElement.DeepEquals(e, taggedLiquidXml)), gameworld.Object), Times.Once);
+	}
+
+	private static (Mock<ICraftInput> Input, TestCraftInputData Data) Input(long id, XElement xml)
+	{
+		var perceivable = new Mock<IPerceivable>().Object;
+		var input = new Mock<ICraftInput>();
+		input.SetupGet(x => x.Id).Returns(id);
+		input.Setup(x => x.LoadDataFromXml(It.IsAny<XElement>(), It.IsAny<IFuturemud>()))
+			.Returns((XElement _, IFuturemud _) => new TestCraftInputData(perceivable, new XElement(xml)));
+		return (input, new TestCraftInputData(perceivable, xml));
+	}
+
+	private sealed class TestActiveCraftComponent(IGameItem parent)
+		: ActiveCraftGameItemComponent((ActiveCraftGameItemComponentProto)null!, parent, true)
+	{
+		public string SaveDefinition() => SaveToXml();
+		public void LoadDefinition(XElement root) => LoadFromXml(root);
+	}
+
+	private sealed class TestCraftInputData(IPerceivable perceivable, XElement xml) : ICraftInputData
+	{
+		public XElement SaveToXml() => new(xml);
+		public IPerceivable Perceivable => perceivable;
+		public ItemQuality InputQuality => ItemQuality.Standard;
+		public void FinaliseLoadTimeTasks() { }
+		public void Delete() { }
+		public void Quit() { }
+	}
+}

--- a/MudSharpCore Unit Tests/Crafts/CraftInputPersistenceTests.cs
+++ b/MudSharpCore Unit Tests/Crafts/CraftInputPersistenceTests.cs
@@ -5,6 +5,7 @@ using MudSharp.Framework;
 using MudSharp.Framework.Revision;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Components;
+using MudSharp.GameItems.Interfaces;
 using MudSharp.GameItems.Prototypes;
 using MudSharp.Work.Crafts;
 using MudSharp.Work.Crafts.Inputs;
@@ -17,7 +18,7 @@ namespace MudSharp_Unit_Tests.Crafts;
 public class CraftInputPersistenceTests
 {
 	[TestMethod]
-	public void ActiveCraft_RoundTripsStandardAndLiquidConsumedInputData()
+    public void ActiveCraft_RoundTripsAndCopiesStandardAndLiquidConsumedInputData()
 	{
 		var standardXml = new XElement("Data",
 			new XElement("Item", 101),
@@ -61,9 +62,16 @@ public class CraftInputPersistenceTests
 		loaded.LoadDefinition(saved);
 
 		Assert.AreEqual(3, loaded.ConsumedInputs.Count);
-		standard.Input.Verify(x => x.LoadDataFromXml(It.Is<XElement>(e => XElement.DeepEquals(e, standardXml)), gameworld.Object), Times.Once);
-		liquid.Input.Verify(x => x.LoadDataFromXml(It.Is<XElement>(e => XElement.DeepEquals(e, liquidXml)), gameworld.Object), Times.Once);
-		taggedLiquid.Input.Verify(x => x.LoadDataFromXml(It.Is<XElement>(e => XElement.DeepEquals(e, taggedLiquidXml)), gameworld.Object), Times.Once);
+        standard.Input.Verify(x => x.LoadDataFromXml(It.Is<XElement>(e => XElement.DeepEquals(e, standardXml)), gameworld.Object), Times.Once);
+        liquid.Input.Verify(x => x.LoadDataFromXml(It.Is<XElement>(e => XElement.DeepEquals(e, liquidXml)), gameworld.Object), Times.Once);
+        taggedLiquid.Input.Verify(x => x.LoadDataFromXml(It.Is<XElement>(e => XElement.DeepEquals(e, taggedLiquidXml)), gameworld.Object), Times.Once);
+
+        var copy = (IActiveCraftGameItemComponent)source.Copy(parent.Object, true);
+
+        Assert.AreEqual(3, copy.ConsumedInputs.Count);
+        standard.Input.Verify(x => x.LoadDataFromXml(It.Is<XElement>(e => XElement.DeepEquals(e, standardXml)), gameworld.Object), Times.Exactly(2));
+        liquid.Input.Verify(x => x.LoadDataFromXml(It.Is<XElement>(e => XElement.DeepEquals(e, liquidXml)), gameworld.Object), Times.Exactly(2));
+        taggedLiquid.Input.Verify(x => x.LoadDataFromXml(It.Is<XElement>(e => XElement.DeepEquals(e, taggedLiquidXml)), gameworld.Object), Times.Exactly(2));
 	}
 
 	[TestMethod]
@@ -75,10 +83,11 @@ public class CraftInputPersistenceTests
 		var data = new LiquidUseInput.LiquidUseInputData(xml, setup.Gameworld.Object);
 
 		Assert.IsNotNull(data.Perceivable);
-		Assert.AreEqual(setup.Liquid.Object, data.Liquid);
-		Assert.AreEqual(2.0, data.Amount);
-		Assert.AreEqual(1, data.OriginalItems.Count);
-		AssertResumeClashSolverAccepts(data.Perceivable);
+        Assert.AreEqual(setup.Liquid.Object, data.Liquid);
+        Assert.AreEqual(2.0, data.Amount);
+        Assert.AreEqual(1, data.OriginalItems.Count);
+        Assert.AreEqual("Data", data.SaveToXml().Name.LocalName);
+        AssertResumeClashSolverAccepts(data.Perceivable);
 	}
 
 	[TestMethod]
@@ -95,10 +104,11 @@ public class CraftInputPersistenceTests
 		var data = new LiquidTagUseInput.LiquidUseInputData(xml, setup.Gameworld.Object);
 
 		Assert.IsNotNull(data.Perceivable);
-		Assert.AreEqual(tag.Object, data.Target);
-		Assert.AreEqual(2.0, data.Amount);
-		Assert.AreEqual(1, data.OriginalItems.Count);
-		AssertResumeClashSolverAccepts(data.Perceivable);
+        Assert.AreEqual(tag.Object, data.Target);
+        Assert.AreEqual(2.0, data.Amount);
+        Assert.AreEqual(1, data.OriginalItems.Count);
+        Assert.AreEqual("Data", data.SaveToXml().Name.LocalName);
+        AssertResumeClashSolverAccepts(data.Perceivable);
 	}
 
 	private static XElement LiquidXml(string targetElement, long targetId, long containerId)

--- a/MudSharpCore Unit Tests/Crafts/ProgVariableProductTests.cs
+++ b/MudSharpCore Unit Tests/Crafts/ProgVariableProductTests.cs
@@ -1,0 +1,162 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Construction;
+using MudSharp.Form.Characteristics;
+using MudSharp.Form.Material;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.FutureProg;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.GameItems.Prototypes;
+using MudSharp.Models;
+using MudSharp.PerceptionEngine.Lists;
+using MudSharp.Work.Crafts;
+using MudSharp.Work.Crafts.Products;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+
+namespace MudSharp_Unit_Tests.Crafts;
+
+[TestClass]
+public class ProgVariableProductTests
+{
+	[TestMethod]
+	public void GetIndividualPerceivables_FlattensMixedSinglesAndGroupsInOrder()
+	{
+		var single = new DummyPerceivable("single");
+		var liquidDummy = new DummyPerceivable("liquid");
+		var firstMember = new DummyPerceivable("first member");
+		var secondMember = new DummyPerceivable("second member");
+		var group = new PerceivableGroup([firstMember, secondMember]);
+
+		var result = new IPerceivable[] { single, liquidDummy, group }
+			.GetIndividualPerceivables()
+			.ToArray();
+
+		CollectionAssert.AreEqual(
+			new IPerceivable[] { single, liquidDummy, firstMember, secondMember },
+			result);
+	}
+
+	[TestMethod]
+	public void ProduceProduct_SuppliesFlattenedConsumedPerceivablesToVariableProg()
+	{
+		var single = new DummyPerceivable("single");
+		var liquidDummy = new DummyPerceivable("liquid");
+		var firstMember = new DummyPerceivable("first member");
+		var secondMember = new DummyPerceivable("second member");
+		var group = new PerceivableGroup([firstMember, secondMember]);
+		IReadOnlyList<IPerceivable> supplied = null;
+
+		var prog = new Mock<IFutureProg>();
+		prog.SetupGet(x => x.Id).Returns(900);
+		prog.Setup(x => x.ExecuteLong(0L, It.IsAny<object[]>()))
+			.Callback((long _, object[] arguments) =>
+				supplied = ((IEnumerable<IPerceivable>)arguments.Single()).ToArray())
+			.Returns(300);
+		var progs = UneditableRepository([prog.Object]);
+
+		var definition = new Mock<ICharacteristicDefinition>();
+		definition.SetupGet(x => x.Id).Returns(200);
+		var definitions = UneditableRepository([definition.Object]);
+		var value = new Mock<ICharacteristicValue>();
+		value.SetupGet(x => x.Id).Returns(300);
+		var values = UneditableRepository([value.Object]);
+
+		var output = new Mock<IGameItem>();
+		output.SetupProperty(x => x.RoomLayer, RoomLayer.GroundLevel);
+		output.SetupProperty(x => x.Quality, ItemQuality.Standard);
+		output.SetupProperty(x => x.Material);
+		var proto = new Mock<IGameItemProto>();
+		proto.SetupGet(x => x.Id).Returns(100);
+		proto.Setup(x => x.IsItemType<StackableGameItemComponentProto>()).Returns(false);
+		proto.Setup(x => x.CreateNew(null, null, 1,
+			It.IsAny<IEnumerable<(ICharacteristicDefinition Definition, ICharacteristicValue Value)>>()))
+			.Returns([output.Object]);
+
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.FutureProgs).Returns(progs.Object);
+		gameworld.SetupGet(x => x.Characteristics).Returns(definitions.Object);
+		gameworld.SetupGet(x => x.CharacteristicValues).Returns(values.Object);
+		gameworld.SetupGet(x => x.ItemProtos).Returns(RevisableRepository([proto.Object]).Object);
+		gameworld.SetupGet(x => x.ItemSkins).Returns(RevisableRepository(Array.Empty<IGameItemSkin>()).Object);
+		gameworld.Setup(x => x.GetStaticBool("DisableCraftQualityCalculation")).Returns(false);
+
+		var firstInput = new Mock<ICraftInput>();
+		var secondInput = new Mock<ICraftInput>();
+		var thirdInput = new Mock<ICraftInput>();
+		var consumed = new Dictionary<ICraftInput, (IPerceivable Input, ICraftInputData Data)>
+		{
+			[firstInput.Object] = (single, new TestCraftInputData(single)),
+			[secondInput.Object] = (liquidDummy, new TestCraftInputData(liquidDummy)),
+			[thirdInput.Object] = (group, new TestCraftInputData(group))
+		};
+		var parent = new Mock<IGameItem>();
+		parent.SetupGet(x => x.RoomLayer).Returns(RoomLayer.GroundLevel);
+		var component = new Mock<IActiveCraftGameItemComponent>();
+		component.SetupGet(x => x.Parent).Returns(parent.Object);
+		component.SetupGet(x => x.ConsumedInputs).Returns(consumed);
+
+		Product(gameworld.Object).ProduceProduct(component.Object, ItemQuality.Good);
+
+		CollectionAssert.AreEqual(
+			new IPerceivable[] { single, liquidDummy, firstMember, secondMember },
+			supplied!.ToArray());
+		prog.Verify(x => x.ExecuteLong(0L, It.IsAny<object[]>()), Times.Once);
+	}
+
+	private static ProgVariableProduct Product(IFuturemud gameworld)
+	{
+		var product = new CraftProduct
+		{
+			Id = 1,
+			ProductType = "ProgVariableProduct",
+			Definition = new XElement("Definition",
+				new XElement("ProductProducedId", 100),
+				new XElement("Quantity", 1),
+				new XElement("Skin", 0),
+				new XElement("Variable", new XAttribute("prog", 900), 200)).ToString(),
+			OriginalAdditionTime = DateTime.UtcNow
+		};
+		return (ProgVariableProduct)Activator.CreateInstance(
+			typeof(ProgVariableProduct),
+			BindingFlags.Instance | BindingFlags.NonPublic,
+			null,
+			[product, new Mock<ICraft>().Object, gameworld],
+			null)!;
+	}
+
+	private static Mock<IUneditableAll<T>> UneditableRepository<T>(IEnumerable<T> items)
+		where T : class, IFrameworkItem
+	{
+		var list = items.ToList();
+		var mock = new Mock<IUneditableAll<T>>();
+		mock.As<IEnumerable<T>>().Setup(x => x.GetEnumerator()).Returns(() => list.GetEnumerator());
+		mock.Setup(x => x.Get(It.IsAny<long>())).Returns((long id) => list.FirstOrDefault(x => x.Id == id));
+		return mock;
+	}
+
+	private static Mock<IUneditableRevisableAll<T>> RevisableRepository<T>(IEnumerable<T> items)
+		where T : class, IRevisableItem
+	{
+		var list = items.ToList();
+		var mock = new Mock<IUneditableRevisableAll<T>>();
+		mock.As<IEnumerable<T>>().Setup(x => x.GetEnumerator()).Returns(() => list.GetEnumerator());
+		mock.Setup(x => x.Get(It.IsAny<long>())).Returns((long id) => list.FirstOrDefault(x => x.Id == id));
+		return mock;
+	}
+
+	private sealed class TestCraftInputData(IPerceivable perceivable) : ICraftInputData
+	{
+		public XElement SaveToXml() => new("Data");
+		public IPerceivable Perceivable => perceivable;
+		public ItemQuality InputQuality => ItemQuality.Standard;
+		public void FinaliseLoadTimeTasks() { }
+		public void Delete() { }
+		public void Quit() { }
+	}
+}

--- a/MudSharpCore Unit Tests/Crafts/ProgVariableProductTests.cs
+++ b/MudSharpCore Unit Tests/Crafts/ProgVariableProductTests.cs
@@ -10,7 +10,6 @@ using MudSharp.GameItems;
 using MudSharp.GameItems.Interfaces;
 using MudSharp.GameItems.Prototypes;
 using MudSharp.Models;
-using MudSharp.PerceptionEngine.Lists;
 using MudSharp.Work.Crafts;
 using MudSharp.Work.Crafts.Products;
 using System;
@@ -25,40 +24,44 @@ namespace MudSharp_Unit_Tests.Crafts;
 public class ProgVariableProductTests
 {
 	[TestMethod]
-	public void GetIndividualPerceivables_FlattensMixedSinglesAndGroupsInOrder()
+	public void ProduceProduct_SuppliesCraftOrderedInputsThatMatchEachVariableProgContract()
 	{
-		var single = new DummyPerceivable("single");
+		var single = new Mock<IGameItem>();
+		single.SetupGet(x => x.IsSingleEntity).Returns(true);
 		var liquidDummy = new DummyPerceivable("liquid");
-		var firstMember = new DummyPerceivable("first member");
-		var secondMember = new DummyPerceivable("second member");
-		var group = new PerceivableGroup([firstMember, secondMember]);
+		var firstMember = new Mock<IGameItem>();
+		firstMember.SetupGet(x => x.IsSingleEntity).Returns(true);
+		var secondMember = new Mock<IGameItem>();
+		secondMember.SetupGet(x => x.IsSingleEntity).Returns(true);
+		var group = new Mock<IPerceivableGroup>();
+		group.SetupGet(x => x.IsSingleEntity).Returns(false);
+		group.SetupGet(x => x.Members).Returns([firstMember.Object, secondMember.Object]);
+		IReadOnlyList<IPerceivable> perceivablesSupplied = null;
+		IReadOnlyList<IPerceivable> itemsSupplied = null;
+		IReadOnlyList<IPerceivable> anyParametersSupplied = null;
 
-		var result = new IPerceivable[] { single, liquidDummy, group }
-			.GetIndividualPerceivables()
-			.ToArray();
-
-		CollectionAssert.AreEqual(
-			new IPerceivable[] { single, liquidDummy, firstMember, secondMember },
-			result);
-	}
-
-	[TestMethod]
-	public void ProduceProduct_SuppliesFlattenedConsumedPerceivablesToVariableProg()
-	{
-		var single = new DummyPerceivable("single");
-		var liquidDummy = new DummyPerceivable("liquid");
-		var firstMember = new DummyPerceivable("first member");
-		var secondMember = new DummyPerceivable("second member");
-		var group = new PerceivableGroup([firstMember, secondMember]);
-		IReadOnlyList<IPerceivable> supplied = null;
-
-		var prog = new Mock<IFutureProg>();
-		prog.SetupGet(x => x.Id).Returns(900);
-		prog.Setup(x => x.ExecuteLong(0L, It.IsAny<object[]>()))
+		var perceivableProg = new Mock<IFutureProg>();
+		perceivableProg.SetupGet(x => x.Id).Returns(900);
+		perceivableProg.SetupGet(x => x.Parameters).Returns([ProgVariableTypes.Collection | ProgVariableTypes.Perceivable]);
+		perceivableProg.Setup(x => x.ExecuteLong(0L, It.IsAny<object[]>()))
 			.Callback((long _, object[] arguments) =>
-				supplied = ((IEnumerable<IPerceivable>)arguments.Single()).ToArray())
+				perceivablesSupplied = ((IEnumerable<IPerceivable>)arguments.Single()).ToArray())
 			.Returns(300);
-		var progs = UneditableRepository([prog.Object]);
+		var itemProg = new Mock<IFutureProg>();
+		itemProg.SetupGet(x => x.Id).Returns(901);
+		itemProg.SetupGet(x => x.Parameters).Returns([ProgVariableTypes.Collection | ProgVariableTypes.Item]);
+		itemProg.Setup(x => x.ExecuteLong(0L, It.IsAny<object[]>()))
+			.Callback((long _, object[] arguments) =>
+				itemsSupplied = ((IEnumerable<IPerceivable>)arguments.Single()).ToArray())
+			.Returns(300);
+		var anyParametersProg = new Mock<IFutureProg>();
+		anyParametersProg.SetupGet(x => x.Id).Returns(902);
+		anyParametersProg.SetupGet(x => x.AcceptsAnyParameters).Returns(true);
+		anyParametersProg.Setup(x => x.ExecuteLong(0L, It.IsAny<object[]>()))
+			.Callback((long _, object[] arguments) =>
+				anyParametersSupplied = ((IEnumerable<IPerceivable>)arguments.Single()).ToArray())
+			.Returns(300);
+		var progs = UneditableRepository([perceivableProg.Object, itemProg.Object, anyParametersProg.Object]);
 
 		var definition = new Mock<ICharacteristicDefinition>();
 		definition.SetupGet(x => x.Id).Returns(200);
@@ -89,11 +92,13 @@ public class ProgVariableProductTests
 		var firstInput = new Mock<ICraftInput>();
 		var secondInput = new Mock<ICraftInput>();
 		var thirdInput = new Mock<ICraftInput>();
+		var craft = new Mock<ICraft>();
+		craft.SetupGet(x => x.Inputs).Returns([firstInput.Object, secondInput.Object, thirdInput.Object]);
 		var consumed = new Dictionary<ICraftInput, (IPerceivable Input, ICraftInputData Data)>
 		{
-			[firstInput.Object] = (single, new TestCraftInputData(single)),
+			[thirdInput.Object] = (group.Object, new TestCraftInputData(group.Object)),
 			[secondInput.Object] = (liquidDummy, new TestCraftInputData(liquidDummy)),
-			[thirdInput.Object] = (group, new TestCraftInputData(group))
+			[firstInput.Object] = (single.Object, new TestCraftInputData(single.Object))
 		};
 		var parent = new Mock<IGameItem>();
 		parent.SetupGet(x => x.RoomLayer).Returns(RoomLayer.GroundLevel);
@@ -101,15 +106,25 @@ public class ProgVariableProductTests
 		component.SetupGet(x => x.Parent).Returns(parent.Object);
 		component.SetupGet(x => x.ConsumedInputs).Returns(consumed);
 
-		Product(gameworld.Object).ProduceProduct(component.Object, ItemQuality.Good);
+		Product(gameworld.Object, craft.Object, perceivableProg.Object.Id).ProduceProduct(component.Object, ItemQuality.Good);
+		Product(gameworld.Object, craft.Object, itemProg.Object.Id).ProduceProduct(component.Object, ItemQuality.Good);
+		Product(gameworld.Object, craft.Object, anyParametersProg.Object.Id).ProduceProduct(component.Object, ItemQuality.Good);
 
 		CollectionAssert.AreEqual(
-			new IPerceivable[] { single, liquidDummy, firstMember, secondMember },
-			supplied!.ToArray());
-		prog.Verify(x => x.ExecuteLong(0L, It.IsAny<object[]>()), Times.Once);
+			new IPerceivable[] { single.Object, liquidDummy, firstMember.Object, secondMember.Object },
+			perceivablesSupplied!.ToArray());
+		CollectionAssert.AreEqual(
+			new IPerceivable[] { single.Object, firstMember.Object, secondMember.Object },
+			itemsSupplied!.ToArray());
+		CollectionAssert.AreEqual(
+			new IPerceivable[] { single.Object, liquidDummy, firstMember.Object, secondMember.Object },
+			anyParametersSupplied!.ToArray());
+		perceivableProg.Verify(x => x.ExecuteLong(0L, It.IsAny<object[]>()), Times.Once);
+		itemProg.Verify(x => x.ExecuteLong(0L, It.IsAny<object[]>()), Times.Once);
+		anyParametersProg.Verify(x => x.ExecuteLong(0L, It.IsAny<object[]>()), Times.Once);
 	}
 
-	private static ProgVariableProduct Product(IFuturemud gameworld)
+	private static ProgVariableProduct Product(IFuturemud gameworld, ICraft craft, long progId)
 	{
 		var product = new CraftProduct
 		{
@@ -119,14 +134,14 @@ public class ProgVariableProductTests
 				new XElement("ProductProducedId", 100),
 				new XElement("Quantity", 1),
 				new XElement("Skin", 0),
-				new XElement("Variable", new XAttribute("prog", 900), 200)).ToString(),
+				new XElement("Variable", new XAttribute("prog", progId), 200)).ToString(),
 			OriginalAdditionTime = DateTime.UtcNow
 		};
 		return (ProgVariableProduct)Activator.CreateInstance(
 			typeof(ProgVariableProduct),
 			BindingFlags.Instance | BindingFlags.NonPublic,
 			null,
-			[product, new Mock<ICraft>().Object, gameworld],
+			[product, craft, gameworld],
 			null)!;
 	}
 

--- a/MudSharpCore/GameItems/Components/ActiveCraftGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/ActiveCraftGameItemComponent.cs
@@ -117,9 +117,8 @@ public class ActiveCraftGameItemComponent : GameItemComponent, IActiveCraftGameI
         _checkOutcome = rhs._checkOutcome;
         foreach (KeyValuePair<ICraftInput, (IPerceivable Input, ICraftInputData Data)> input in rhs.ConsumedInputs)
         {
-            ConsumedInputs[input.Key] =
-                (input.Value.Input, input.Key.LoadDataFromXml(new XElement("Dummy", input.Value.Data.SaveToXml()),
-                    Gameworld));
+            ICraftInputData data = input.Key.LoadDataFromXml(input.Value.Data.SaveToXml(), Gameworld);
+            ConsumedInputs[input.Key] = (data.Perceivable, data);
         }
     }
 

--- a/MudSharpCore/GameItems/Components/ActiveCraftGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/ActiveCraftGameItemComponent.cs
@@ -139,7 +139,7 @@ public class ActiveCraftGameItemComponent : GameItemComponent, IActiveCraftGameI
         foreach (XElement item in root.Element("Consumed").Elements())
         {
             ICraftInput input = Craft.Inputs.First(x => x.Id == long.Parse(item.Attribute("inputid").Value));
-            XElement data = item.Element("Data");
+            XElement data = item.Element("Data") ?? item.Element("Input");
             if (data != null)
             {
                 ICraftInputData loadedData = input.LoadDataFromXml(data, Gameworld);

--- a/MudSharpCore/Work/Crafts/Inputs/LiquidTagUseInput.cs
+++ b/MudSharpCore/Work/Crafts/Inputs/LiquidTagUseInput.cs
@@ -269,7 +269,7 @@ public class LiquidTagUseInput : BaseInput, ICraftInputConsumeLiquid
 
         public XElement SaveToXml()
         {
-            return new XElement("Input",
+            return new XElement("Data",
                 new XElement("TagId", Target.Id),
                 new XElement("Amount", Amount),
                 new XElement("Quality", (int)Quality),

--- a/MudSharpCore/Work/Crafts/Inputs/LiquidTagUseInput.cs
+++ b/MudSharpCore/Work/Crafts/Inputs/LiquidTagUseInput.cs
@@ -263,6 +263,8 @@ public class LiquidTagUseInput : BaseInput, ICraftInputConsumeLiquid
                     OriginalItems.Add(gitem);
                 }
             }
+            _perceivable = new DummyPerceivable(ConsumedMixture.ColouredLiquidDescription,
+                ConsumedMixture.LiquidDescription);
         }
 
         public XElement SaveToXml()

--- a/MudSharpCore/Work/Crafts/Inputs/LiquidUseInput.cs
+++ b/MudSharpCore/Work/Crafts/Inputs/LiquidUseInput.cs
@@ -72,6 +72,11 @@ public class LiquidUseInput : BaseInput, ICraftInputConsumeLiquid
                     OriginalItems.Add(gitem);
                 }
             }
+            _perceivable = new DummyPerceivable(
+                voyeur =>
+                    $"{voyeur.Gameworld.UnitManager.DescribeMostSignificantExact(Amount, UnitType.FluidVolume, voyeur)} of {Liquid.Name}",
+                voyeur =>
+                    $"{voyeur.Gameworld.UnitManager.DescribeMostSignificantExact(Amount, UnitType.FluidVolume, voyeur)} of {Liquid.Name}");
         }
 
         public XElement SaveToXml()

--- a/MudSharpCore/Work/Crafts/Inputs/LiquidUseInput.cs
+++ b/MudSharpCore/Work/Crafts/Inputs/LiquidUseInput.cs
@@ -81,7 +81,7 @@ public class LiquidUseInput : BaseInput, ICraftInputConsumeLiquid
 
         public XElement SaveToXml()
         {
-            return new XElement("Input",
+            return new XElement("Data",
                 new XElement("Liquid", Liquid.Id),
                 new XElement("Amount", Amount),
                 new XElement("Quality", (int)Quality),

--- a/MudSharpCore/Work/Crafts/Products/ProgVariableProduct.cs
+++ b/MudSharpCore/Work/Crafts/Products/ProgVariableProduct.cs
@@ -179,10 +179,21 @@ namespace MudSharp.Work.Crafts.Products
                 throw new ApplicationException("Couldn't find a valid proto for craft product to load.");
             }
 
+            List<IPerceivable> consumedInputs = Craft.Inputs
+                                                      .Where(component.ConsumedInputs.ContainsKey)
+                                                      .Select(x => component.ConsumedInputs[x].Data.Perceivable)
+                                                      .OfType<IPerceivable>()
+                                                      .GetIndividualPerceivables()
+                                                      .ToList();
             List<(ICharacteristicDefinition Definition, ICharacteristicValue Value)> variables = new();
             foreach ((ICharacteristicDefinition definition, IFutureProg prog) in Characteristics)
             {
-                ICharacteristicValue value = Gameworld.CharacteristicValues.Get(prog.ExecuteLong(0L, new List<IPerceivable>(component.ConsumedInputs.Values.SelectNotNull(x => x.Data.Perceivable).GetIndividualPerceivables())));
+                IEnumerable<IPerceivable> inputsForProg = !prog.AcceptsAnyParameters &&
+                                                          prog.Parameters.Single() ==
+                                                          (ProgVariableTypes.Collection | ProgVariableTypes.Item)
+                    ? consumedInputs.OfType<IGameItem>()
+                    : consumedInputs;
+                ICharacteristicValue value = Gameworld.CharacteristicValues.Get(prog.ExecuteLong(0L, inputsForProg.ToList()));
                 value ??= definition.GetRandomValue();
                 variables.Add((definition, value));
             }


### PR DESCRIPTION
## Summary

- reload consumed craft inputs from both the standard `<Data>` payload and legacy `<Input>` payloads emitted by prior liquid inputs
- reconstruct non-null temporary perceivables when `LiquidUse` and `LiquidTagUse` data are loaded from XML
- normalize new liquid saves to the standard `<Data>` payload while preserving legacy-load compatibility
- preserve single perceivables while expanding groups for `ProgVariableProduct`
- supply variable progs in configured craft-input order, respecting `Collection<Item>`, `Collection<Perceivable>`, and permissive parameter contracts
- ensure active-craft copies reload the same input payload contract
- keep the shared perceivable-flattening regression in the FutureMUDLibrary test suite

## Root cause

Active craft persistence wrapped each consumed input's own XML payload, but reload only looked for a nested `<Data>` element. Liquid inputs historically save a nested `<Input>` element, so their reservations disappeared after restart. Those liquid loaders also left their temporary perceivable unset, allowing null values into resume-time clash solving. Separately, mixed perceivable flattening cast single entities as groups.

## Validation

- focused Craft persistence/product regressions: 4 passed
- FutureMUDLibrary unit suite: 431 passed
- MudSharpCore unit suite: 2,297 passed
- `git diff --check` passed
