### PR TITLE
Prevent mutable FutureProg signatures from crashing craft production

### DIFF
--- a/Design Documents/Crafting/Crafting_System_Runtime_and_Extensibility.md
+++ b/Design Documents/Crafting/Crafting_System_Runtime_and_Extensibility.md
@@ -431,7 +431,7 @@ Subtype-specific prog use also exists in products such as:
 - `ProgVariableProduct`
 - `NPCProduct`
 
-`ProgVariableProduct` supplies its variable progs with consumed inputs in the craft's configured input order. Single inputs remain single entries, while perceivable groups are expanded to their members. A prog accepting a collection of perceivables receives every individual consumed perceivable; a prog accepting a collection of items receives only consumed game items.
+`ProgVariableProduct` supplies its variable progs with consumed inputs in the craft's configured input order. Single inputs remain single entries, while perceivable groups are expanded to their members. A prog accepting a collection of perceivables receives every individual consumed perceivable; a prog accepting a collection of items receives only consumed game items. Input selection uses the prog's current `MatchesParameters` contract, so a later builder edit to a referenced prog's signature cannot cause craft completion to assume a singleton parameter list; the product's validity check reports a no-longer-matching signature for correction.
 
 ### Item system integration
 Crafting leans heavily on the item system.

--- a/MudSharpCore Unit Tests/Crafts/ProgVariableProductTests.cs
+++ b/MudSharpCore Unit Tests/Crafts/ProgVariableProductTests.cs
@@ -43,6 +43,9 @@ public class ProgVariableProductTests
 		var perceivableProg = new Mock<IFutureProg>();
 		perceivableProg.SetupGet(x => x.Id).Returns(900);
 		perceivableProg.SetupGet(x => x.Parameters).Returns([ProgVariableTypes.Collection | ProgVariableTypes.Perceivable]);
+		perceivableProg.Setup(x => x.MatchesParameters(It.IsAny<IEnumerable<ProgVariableTypes>>()))
+			.Returns((IEnumerable<ProgVariableTypes> parameters) => parameters.SequenceEqual(
+				[ProgVariableTypes.Collection | ProgVariableTypes.Perceivable]));
 		perceivableProg.Setup(x => x.ExecuteLong(0L, It.IsAny<object[]>()))
 			.Callback((long _, object[] arguments) =>
 				perceivablesSupplied = ((IEnumerable<IPerceivable>)arguments.Single()).ToArray())
@@ -50,6 +53,9 @@ public class ProgVariableProductTests
 		var itemProg = new Mock<IFutureProg>();
 		itemProg.SetupGet(x => x.Id).Returns(901);
 		itemProg.SetupGet(x => x.Parameters).Returns([ProgVariableTypes.Collection | ProgVariableTypes.Item]);
+		itemProg.Setup(x => x.MatchesParameters(It.IsAny<IEnumerable<ProgVariableTypes>>()))
+			.Returns((IEnumerable<ProgVariableTypes> parameters) => parameters.SequenceEqual(
+				[ProgVariableTypes.Collection | ProgVariableTypes.Item]));
 		itemProg.Setup(x => x.ExecuteLong(0L, It.IsAny<object[]>()))
 			.Callback((long _, object[] arguments) =>
 				itemsSupplied = ((IEnumerable<IPerceivable>)arguments.Single()).ToArray())
@@ -122,6 +128,85 @@ public class ProgVariableProductTests
 		perceivableProg.Verify(x => x.ExecuteLong(0L, It.IsAny<object[]>()), Times.Once);
 		itemProg.Verify(x => x.ExecuteLong(0L, It.IsAny<object[]>()), Times.Once);
 		anyParametersProg.Verify(x => x.ExecuteLong(0L, It.IsAny<object[]>()), Times.Once);
+	}
+
+	[TestMethod]
+	public void ProduceProduct_ProgSignatureChangesAfterConfiguration_DoesNotThrow()
+	{
+		var zeroParameterProgParameters = new List<ProgVariableTypes>
+		{
+			ProgVariableTypes.Collection | ProgVariableTypes.Item
+		};
+		var multipleParameterProgParameters = new List<ProgVariableTypes>
+		{
+			ProgVariableTypes.Collection | ProgVariableTypes.Item
+		};
+		var zeroParameterProg = MutableSignatureProg(900, zeroParameterProgParameters);
+		var multipleParameterProg = MutableSignatureProg(901, multipleParameterProgParameters);
+		var progs = UneditableRepository([zeroParameterProg.Object, multipleParameterProg.Object]);
+
+		var definition = new Mock<ICharacteristicDefinition>();
+		definition.SetupGet(x => x.Id).Returns(200);
+		var definitions = UneditableRepository([definition.Object]);
+		var value = new Mock<ICharacteristicValue>();
+		value.SetupGet(x => x.Id).Returns(300);
+		var values = UneditableRepository([value.Object]);
+
+		var output = new Mock<IGameItem>();
+		output.SetupProperty(x => x.RoomLayer, RoomLayer.GroundLevel);
+		output.SetupProperty(x => x.Quality, ItemQuality.Standard);
+		output.SetupProperty(x => x.Material);
+		var proto = new Mock<IGameItemProto>();
+		proto.SetupGet(x => x.Id).Returns(100);
+		proto.Setup(x => x.IsItemType<StackableGameItemComponentProto>()).Returns(false);
+		proto.Setup(x => x.CreateNew(null, null, 1,
+			It.IsAny<IEnumerable<(ICharacteristicDefinition Definition, ICharacteristicValue Value)>>()))
+			.Returns([output.Object]);
+
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.FutureProgs).Returns(progs.Object);
+		gameworld.SetupGet(x => x.Characteristics).Returns(definitions.Object);
+		gameworld.SetupGet(x => x.CharacteristicValues).Returns(values.Object);
+		gameworld.SetupGet(x => x.ItemProtos).Returns(RevisableRepository([proto.Object]).Object);
+		gameworld.SetupGet(x => x.ItemSkins).Returns(RevisableRepository(Array.Empty<IGameItemSkin>()).Object);
+		gameworld.Setup(x => x.GetStaticBool("DisableCraftQualityCalculation")).Returns(false);
+
+		var craft = new Mock<ICraft>();
+		craft.SetupGet(x => x.Inputs).Returns([]);
+		var parent = new Mock<IGameItem>();
+		parent.SetupGet(x => x.RoomLayer).Returns(RoomLayer.GroundLevel);
+		var component = new Mock<IActiveCraftGameItemComponent>();
+		component.SetupGet(x => x.Parent).Returns(parent.Object);
+		component.SetupGet(x => x.ConsumedInputs).Returns(new Dictionary<ICraftInput, (IPerceivable Input, ICraftInputData Data)>());
+
+		var zeroParameterProduct = Product(gameworld.Object, craft.Object, zeroParameterProg.Object.Id);
+		var multipleParameterProduct = Product(gameworld.Object, craft.Object, multipleParameterProg.Object.Id);
+		Assert.IsTrue(zeroParameterProduct.IsValid());
+		Assert.IsTrue(multipleParameterProduct.IsValid());
+
+		zeroParameterProgParameters.Clear();
+		multipleParameterProgParameters.Add(ProgVariableTypes.Number);
+
+		Assert.IsFalse(zeroParameterProduct.IsValid());
+		Assert.IsFalse(multipleParameterProduct.IsValid());
+
+		zeroParameterProduct.ProduceProduct(component.Object, ItemQuality.Good);
+		multipleParameterProduct.ProduceProduct(component.Object, ItemQuality.Good);
+
+		zeroParameterProg.Verify(x => x.ExecuteLong(0L, It.IsAny<object[]>()), Times.Once);
+		multipleParameterProg.Verify(x => x.ExecuteLong(0L, It.IsAny<object[]>()), Times.Once);
+	}
+
+	private static Mock<IFutureProg> MutableSignatureProg(long id, List<ProgVariableTypes> parameters)
+	{
+		var prog = new Mock<IFutureProg>();
+		prog.SetupGet(x => x.Id).Returns(id);
+		prog.SetupGet(x => x.Parameters).Returns(() => parameters);
+		prog.SetupGet(x => x.ReturnType).Returns(ProgVariableTypes.Number);
+		prog.Setup(x => x.MatchesParameters(It.IsAny<IEnumerable<ProgVariableTypes>>()))
+			.Returns((IEnumerable<ProgVariableTypes> suppliedParameters) => parameters.SequenceEqual(suppliedParameters));
+		prog.Setup(x => x.ExecuteLong(0L, It.IsAny<object[]>())).Returns(300);
+		return prog;
 	}
 
 	private static ProgVariableProduct Product(IFuturemud gameworld, ICraft craft, long progId)

--- a/MudSharpCore/Work/Crafts/Products/ProgVariableProduct.cs
+++ b/MudSharpCore/Work/Crafts/Products/ProgVariableProduct.cs
@@ -8,6 +8,16 @@ namespace MudSharp.Work.Crafts.Products
 {
     internal class ProgVariableProduct : SimpleProduct
     {
+        private static readonly ProgVariableTypes[] ItemCollectionParameters =
+        [
+            ProgVariableTypes.Item | ProgVariableTypes.Collection
+        ];
+
+        private static readonly ProgVariableTypes[] PerceivableCollectionParameters =
+        [
+            ProgVariableTypes.Perceivable | ProgVariableTypes.Collection
+        ];
+
         protected ProgVariableProduct(Models.CraftProduct product, ICraft craft, IFuturemud gameworld) : base(product, craft,
         gameworld)
         {
@@ -131,14 +141,8 @@ namespace MudSharp.Work.Crafts.Products
 
         private static bool ProgMatchesParameters(IFutureProg prog)
         {
-            return prog.MatchesParameters(new[]
-                   {
-                       ProgVariableTypes.Item | ProgVariableTypes.Collection
-                   }) ||
-                   prog.MatchesParameters(new[]
-                   {
-                       ProgVariableTypes.Perceivable | ProgVariableTypes.Collection
-                   });
+            return prog.MatchesParameters(ItemCollectionParameters) ||
+                   prog.MatchesParameters(PerceivableCollectionParameters);
         }
 
         public override string WhyNotValid()
@@ -189,8 +193,7 @@ namespace MudSharp.Work.Crafts.Products
             foreach ((ICharacteristicDefinition definition, IFutureProg prog) in Characteristics)
             {
                 IEnumerable<IPerceivable> inputsForProg = !prog.AcceptsAnyParameters &&
-                                                          prog.Parameters.Single() ==
-                                                          (ProgVariableTypes.Collection | ProgVariableTypes.Item)
+                                                          prog.MatchesParameters(ItemCollectionParameters)
                     ? consumedInputs.OfType<IGameItem>()
                     : consumedInputs;
                 ICharacteristicValue value = Gameworld.CharacteristicValues.Get(prog.ExecuteLong(0L, inputsForProg.ToList()));


### PR DESCRIPTION
## Summary

- Re-evaluate variable product parameter compatibility against the current FutureProg signature.
- Prevent craft completion from assuming a stale singleton parameter list after builder edits.
- Add regression coverage for mutable signatures and document the runtime behavior.

## Testing

- Added unit coverage confirming invalidated signatures do not throw during production and that execution remains controlled.