### PR TITLE
Fix hospital implant service consent and patient flow

### DIFF
--- a/DatabaseSeeder/BlankDatabaseSnapshot.manifest.json
+++ b/DatabaseSeeder/BlankDatabaseSnapshot.manifest.json
@@ -1,5 +1,5 @@
 {
   "ProductVersion": "3.1.0.0",
-  "LatestMigrationId": "20260810130800_AddTrapTemplates",
-  "GeneratedUtc": "2026-08-10T21:49:01.9765493Z"
+  "LatestMigrationId": "20260816012516_HospitalServiceConsentPolicy",
+  "GeneratedUtc": "2026-08-16T01:25:16Z"
 }

--- a/DatabaseSeeder/BlankDatabaseSnapshot.sql
+++ b/DatabaseSeeder/BlankDatabaseSnapshot.sql
@@ -14880,3 +14880,19 @@ CREATE TABLE IF NOT EXISTS `propertysalesorders` (
 
 -- Dump completed on 2026-08-11 07:49:01
 -- Total time: 0:0:0:1:642 (d:h:m:s:ms)
+
+-- EF-generated idempotent delta: 20260816012516_HospitalServiceConsentPolicy
+DROP PROCEDURE IF EXISTS MigrationsScript;
+DELIMITER //
+CREATE PROCEDURE MigrationsScript()
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM `__efmigrationshistory` WHERE `MigrationId` = '20260816012516_HospitalServiceConsentPolicy') THEN
+        ALTER TABLE `hospitalservices` ADD `ConsentPolicy` int(11) NOT NULL DEFAULT 0;
+        UPDATE `hospitalservices` SET `ConsentPolicy` = 1 WHERE `ServiceType` = 10;
+        INSERT INTO `__efmigrationshistory` (`MigrationId`, `ProductVersion`)
+        VALUES ('20260816012516_HospitalServiceConsentPolicy', '9.0.11');
+    END IF;
+END //
+DELIMITER ;
+CALL MigrationsScript();
+DROP PROCEDURE MigrationsScript;

--- a/Design Documents/Economy/Economy_System_Runtime.md
+++ b/Design Documents/Economy/Economy_System_Runtime.md
@@ -661,3 +661,11 @@ When adding future economy features, the safest path is usually:
 4. expose the feature through builder commands rather than relying on manual database setup
 
 That sequence is inferred from current implementation style rather than enforced by one base class, but it matches the design of the existing subsystem well.
+
+## Hospital Security and Integrity
+
+`HospitalService.ConsentPolicy` persists either `InformedConsentRequired` or `EmergencyPresumedConsent`. Informed consent is the default; a third party cannot create that service for a helpless patient. Conscious third parties continue through the normal acceptance proposal. Stabilisation is the sole existing service backfilled to emergency presumed consent by `20260816012516_HospitalServiceConsentPolicy`, and managers set the policy with `hospital service set <service> consent informed|emergency`.
+
+Availability calculates the same explicit-equipment, implicit wound-care, and implicit IV/blood supply plan that task creation uses. If those supplies are not fully staged, an able, unassigned worker with both `PrepareMedicalSupplies` and `CanPrepareHospitalSupplies` is required before any cash, debt, request, or task is created. A medical worker may acknowledge an already staged bundle. Edits to equipment used by an Active or Satisfied hospital stock goal additionally require the goal's complete authority set, except for administrators.
+
+Cancellation is exact-request scoped. Hospital-started `SurgicalProcedureEffect` instances carry their originating hospital request id and only matching effects are aborted. Blood cleanup uses the linked task's assigned worker plus its persisted current/used IV container ids; it moves no untracked theatre, container, employee, or cancelling-player bag.

--- a/Design Documents/Economy/Economy_System_Seeder_State_and_Gaps.md
+++ b/Design Documents/Economy/Economy_System_Seeder_State_and_Gaps.md
@@ -350,3 +350,7 @@ When extending the seeder side of the economy:
 - avoid seeding world-specific retail or property content until the seeder has a clean story for cells, items, and institutions
 - treat probate and morgue seeding as a world-integration problem rather than a missing runtime feature
 - keep the economy design docs updated whenever new seeder support changes the practical setup path
+
+### Hospital persistence note
+
+The blank-database snapshot and manifest include migration `20260816012516_HospitalServiceConsentPolicy`. It adds the non-null `HospitalServices.ConsentPolicy` column, defaults services to informed consent, and backfills existing Stabilisation rows to emergency presumed consent. Hospital stock content remains world-specific; when seeded later, its manager-goal authority requirements must be delegated deliberately alongside service-equipment editing rights.

--- a/Design Documents/Economy/Economy_System_Workflows_and_Integration.md
+++ b/Design Documents/Economy/Economy_System_Workflows_and_Integration.md
@@ -524,3 +524,11 @@ When extending the economy:
 4. integrate with existing factories, loaders, or editable-item helpers where possible
 5. expose builder-facing workflows rather than requiring raw database edits
 6. update the economy design docs when runtime behavior or command surface changes
+
+## Hospital Security and Integrity Workflow
+
+Configure every service's consent policy with `hospital service set <service> consent informed|emergency`. The default informed policy requires an accepting conscious patient and prohibits a third party from enrolling a helpless patient. Emergency presumed consent permits that request; the migration classifies only Stabilisation this way by default.
+
+Before billing, hospital availability validates the complete supply action plan. Loose explicit equipment, implicit treatment items, and IV/blood supplies require an available orderly or another worker with both supply authority and the hospital-supply capability. A doctor can progress a fully staged theatre bundle without that capability. Equipment mutation remains a hospital-manager operation, but a manager must also hold the combined authority required by each affected Active or Satisfied automated stock goal.
+
+On terminal completion or cancellation, resource cleanup is derived from the persisted request task, not the cancelling player. Only request-recorded IV container ids return to storage. Likewise, cancellation terminates only staged surgical effects tagged with the exact request id, never a different request or ordinary surgery for the same patient.

--- a/Design Documents/Health/Health_Medical_Interactions.md
+++ b/Design Documents/Health/Health_Medical_Interactions.md
@@ -307,3 +307,9 @@ The strongest current extension pressure points are:
 
 - more stock drugs that use the remaining runtime drug framework, including concrete stock examples for rage, magic-facing, and more niche specialist effects
 - more complete stock support for implant and defibrillator workflows
+
+## Hospital Security and Integrity
+
+Hospital services explicitly choose informed or emergency presumed consent. Informed services cannot be requested by a third party for a helpless patient; conscious third parties still accept normally. Stabilisation is the migration default emergency service. The request and its payment are created only after a complete medical and supply-executor preflight succeeds.
+
+Hospital-staged surgical effects record the originating request id, so cancellation can abort only that request's procedure. A service-supplied implant is request-owned pending state: parameter resolution, procedure validation, exposure preparation, and procedure start must all succeed, otherwise normal item deletion removes it from the employee, location, and game world. Successful implant procedures retain it through power and interface follow-up stages.

--- a/Design Documents/Items/Item_System_Runtime_Model.md
+++ b/Design Documents/Items/Item_System_Runtime_Model.md
@@ -649,3 +649,7 @@ Physical hand requirements use functioning `IWield` body locations rather than `
 `SignalInstrument` shares the same physical-use and skill rules. A per-character, per-item cooldown effect prevents repeated calls. Failed calls use neutral garbled audio and suppress `OnSignalProg`.
 
 `MilitaryStandard` instance XML stores optional identity/design/association overrides, planted state, custody, and capture count. Copies retain identity overrides but reset planted state and capture history. Durable ownership remains on the item: an authorised carrier produces `Friendly` custody, an unauthorised carrier produces one `Captured` transition and count increment, and hostile-to-hostile transfers do not increment again. An authorised recovery returns the state to `Friendly`; dropping or planting preserves custody.
+
+## Hospital IV Lifecycle Integrity
+
+Hospital IV workflows persist the currently connected container id and every used container id in their employment operational payload. Completion, failure, and cancellation resolve those ids through the request's assigned worker and return only disconnected, tracked IV containers. No ambient theatre, contained, held, or cancelling-player item is inferred to be workflow-owned merely because it is IV-capable.

--- a/FutureMUDLibrary/Economy/IHospital.cs
+++ b/FutureMUDLibrary/Economy/IHospital.cs
@@ -54,6 +54,12 @@ public enum HospitalServiceOfferingMode
 	CombinedOnly
 }
 
+public enum HospitalServiceConsentPolicy
+{
+	InformedConsentRequired,
+	EmergencyPresumedConsent
+}
+
 public enum HospitalServiceRequestStatus
 {
 	PendingConsent,
@@ -105,6 +111,7 @@ public interface IHospitalService : IFrameworkItem, ISaveable, IKeywordedItem
 	bool AllowDebt { get; set; }
 	bool PreferOperatingTheatre { get; set; }
 	HospitalServiceOfferingMode OfferingMode { get; set; }
+	HospitalServiceConsentPolicy ConsentPolicy { get; set; }
 	int SortOrder { get; set; }
 	ISurgicalProcedure? SurgicalProcedure { get; set; }
 	IGameItemProto? ImplantItemPrototype { get; set; }

--- a/MudSharpCore Unit Tests/Economy/Employment/UnifiedEmploymentDispatchTests.cs
+++ b/MudSharpCore Unit Tests/Economy/Employment/UnifiedEmploymentDispatchTests.cs
@@ -535,7 +535,6 @@ public class UnifiedEmploymentDispatchTests
 		service.SetupGet(x => x.RequiredEquipment).Returns([
 			new HospitalServiceEquipmentRequirement(1, EmploymentItemSelector.ForPrototype(500))
 		]);
-
 		var result = HospitalServiceAvailability.Evaluate(hospital.Object, service.Object);
 
 		Assert.IsFalse(result.Available);
@@ -543,9 +542,13 @@ public class UnifiedEmploymentDispatchTests
 	}
 
 	[TestMethod]
-	public void HospitalServiceAvailability_AllowsServiceWhenRequiredEquipmentIsStocked()
+	public void HospitalServiceAvailability_AllowsServiceWhenCompleteRequirementBundleIsStocked()
 	{
-		var supplyItems = new List<IGameItem> { Item(9000, "bandage roll", prototypeId: 500).Object };
+		var traumaTreatment = new Mock<ITreatment>();
+		traumaTreatment.Setup(x => x.IsTreatmentType(TreatmentType.Trauma)).Returns(true);
+		var bandage = Item(9000, "bandage roll", prototypeId: 500);
+		bandage.Setup(x => x.GetItemType<ITreatment>()).Returns(traumaTreatment.Object);
+		var supplyItems = new List<IGameItem> { bandage.Object };
 		var hospital = new Mock<IHospital>();
 		hospital.SetupGet(x => x.Name).Returns("central clinic");
 		hospital.SetupGet(x => x.IsTrading).Returns(true);
@@ -558,10 +561,158 @@ public class UnifiedEmploymentDispatchTests
 		service.SetupGet(x => x.RequiredEquipment).Returns([
 			new HospitalServiceEquipmentRequirement(1, EmploymentItemSelector.ForPrototype(500))
 		]);
+		HospitalSupplyPreparationActionStep.RequiresSupplyPreparation(hospital.Object, service.Object, null,
+			out var treatmentLocations);
+		Assert.IsTrue(HospitalSupplyPreparationActionStep.TreatmentLocationSuppliesAreReady(hospital.Object,
+			service.Object, null, treatmentLocations));
 
 		var result = HospitalServiceAvailability.Evaluate(hospital.Object, service.Object);
 
 		Assert.IsTrue(result.Available, result.Reason);
+	}
+
+	[TestMethod]
+	public void HospitalServiceAvailability_BlocksLooseImplicitSuppliesWithoutEligibleSupplyWorker()
+	{
+		var currency = Currency();
+		var treatment = new Mock<ITreatment>();
+		treatment.Setup(x => x.IsTreatmentType(It.IsAny<TreatmentType>())).Returns(true);
+		var treatmentItem = Item(9004, "trauma kit");
+		treatmentItem.Setup(x => x.GetItemType<ITreatment>()).Returns(treatment.Object);
+		var supplyRoom = PhysicalCell(9005, "supply room", [treatmentItem.Object]);
+		var theatre = PhysicalCell(9006, "operating theatre", []);
+		var (hospital, state) = HospitalEmploymentHost(9007, "central clinic", currency.Object,
+			[supplyRoom.Object], [theatre.Object], 100.0M);
+		var doctor = NpcCharacter(9008, "Doctor",
+			[EmploymentWorkerAi(EmploymentAICapability.CanPerformMedicalServices)]);
+		doctor.SetupGet(x => x.Location).Returns(theatre.Object);
+		state.Hire(doctor.Object, Offer(currency.Object, EmploymentRole.MedicalWorker,
+			EmploymentAuthority.PerformMedicalServices), null);
+		var service = new Mock<IHospitalService>();
+		service.SetupGet(x => x.IsActive).Returns(true);
+		service.SetupGet(x => x.ServiceType).Returns(HospitalServiceType.Stabilisation);
+		service.SetupGet(x => x.RequiredEquipment).Returns([]);
+
+		var result = HospitalServiceAvailability.Evaluate(hospital.Object, service.Object);
+
+		Assert.IsFalse(result.Available);
+		StringAssert.Contains(result.Reason, "supply employee");
+	}
+
+	[TestMethod]
+	public void HospitalServiceAvailability_AllowsStagedImplicitSuppliesWithoutSupplyWorker()
+	{
+		var currency = Currency();
+		var treatment = new Mock<ITreatment>();
+		treatment.Setup(x => x.IsTreatmentType(It.IsAny<TreatmentType>())).Returns(true);
+		var treatmentItem = Item(9009, "staged trauma kit");
+		treatmentItem.Setup(x => x.GetItemType<ITreatment>()).Returns(treatment.Object);
+		var theatre = PhysicalCell(9010, "operating theatre", [treatmentItem.Object]);
+		var (hospital, state) = HospitalEmploymentHost(9011, "central clinic", currency.Object, [],
+			[theatre.Object], 100.0M);
+		var doctor = NpcCharacter(9012, "Doctor",
+			[EmploymentWorkerAi(EmploymentAICapability.CanPerformMedicalServices)]);
+		doctor.SetupGet(x => x.Location).Returns(theatre.Object);
+		state.Hire(doctor.Object, Offer(currency.Object, EmploymentRole.MedicalWorker,
+			EmploymentAuthority.PerformMedicalServices), null);
+		var service = new Mock<IHospitalService>();
+		service.SetupGet(x => x.IsActive).Returns(true);
+		service.SetupGet(x => x.ServiceType).Returns(HospitalServiceType.Stabilisation);
+		service.SetupGet(x => x.RequiredEquipment).Returns([]);
+
+		var result = HospitalServiceAvailability.Evaluate(hospital.Object, service.Object);
+
+		Assert.IsTrue(result.Available, result.Reason);
+	}
+
+	[TestMethod]
+	public void HospitalServiceAvailability_AllowsEligibleSupplyWorkerToStageImplicitSupplies()
+	{
+		var currency = Currency();
+		var treatment = new Mock<ITreatment>();
+		treatment.Setup(x => x.IsTreatmentType(It.IsAny<TreatmentType>())).Returns(true);
+		var treatmentItem = Item(9013, "trauma kit");
+		treatmentItem.Setup(x => x.GetItemType<ITreatment>()).Returns(treatment.Object);
+		var supplyRoom = PhysicalCell(9014, "supply room", [treatmentItem.Object]);
+		var theatre = PhysicalCell(9015, "operating theatre", []);
+		var (hospital, state) = HospitalEmploymentHost(9016, "central clinic", currency.Object,
+			[supplyRoom.Object], [theatre.Object], 100.0M);
+		var doctor = NpcCharacter(9017, "Doctor",
+			[EmploymentWorkerAi(EmploymentAICapability.CanPerformMedicalServices)]);
+		doctor.SetupGet(x => x.Location).Returns(theatre.Object);
+		state.Hire(doctor.Object, Offer(currency.Object, EmploymentRole.MedicalWorker,
+			EmploymentAuthority.PerformMedicalServices), null);
+		var orderly = NpcCharacter(9018, "Orderly",
+			[EmploymentWorkerAi(EmploymentAICapability.CanPrepareHospitalSupplies)]);
+		orderly.SetupGet(x => x.Location).Returns(supplyRoom.Object);
+		state.Hire(orderly.Object, Offer(currency.Object, EmploymentRole.HospitalOrderly,
+			EmploymentAuthority.PrepareMedicalSupplies), null);
+		var service = new Mock<IHospitalService>();
+		service.SetupGet(x => x.IsActive).Returns(true);
+		service.SetupGet(x => x.ServiceType).Returns(HospitalServiceType.Stabilisation);
+		service.SetupGet(x => x.RequiredEquipment).Returns([]);
+
+		var result = HospitalServiceAvailability.Evaluate(hospital.Object, service.Object);
+
+		Assert.IsTrue(result.Available, result.Reason);
+	}
+
+	[TestMethod]
+	public void HospitalServiceAvailability_IgnoresSuppliesStagedInATheatreReservedByAnotherRequest()
+	{
+		var currency = Currency();
+		var treatment = new Mock<ITreatment>();
+		treatment.Setup(x => x.IsTreatmentType(It.IsAny<TreatmentType>())).Returns(true);
+		var treatmentItem = Item(9019, "staged trauma kit");
+		treatmentItem.Setup(x => x.GetItemType<ITreatment>()).Returns(treatment.Object);
+		var reservedTheatre = PhysicalCell(9020, "reserved operating theatre", [treatmentItem.Object]);
+		var availableTheatre = PhysicalCell(9021, "available operating theatre", []);
+		var (hospital, state) = HospitalEmploymentHost(9022, "central clinic", currency.Object, [],
+			[reservedTheatre.Object, availableTheatre.Object], 100.0M);
+		var doctor = NpcCharacter(9023, "Doctor",
+			[EmploymentWorkerAi(EmploymentAICapability.CanPerformMedicalServices)]);
+		doctor.SetupGet(x => x.Location).Returns(availableTheatre.Object);
+		state.Hire(doctor.Object, Offer(currency.Object, EmploymentRole.MedicalWorker,
+			EmploymentAuthority.PerformMedicalServices), null);
+		var existingRequest = new Mock<IHospitalServiceRequest>();
+		existingRequest.SetupGet(x => x.Id).Returns(9024);
+		existingRequest.SetupGet(x => x.OperatingTheatreCellId).Returns(reservedTheatre.Object.Id);
+		hospital.SetupGet(x => x.ActiveServiceRequests).Returns([existingRequest.Object]);
+		var service = new Mock<IHospitalService>();
+		service.SetupGet(x => x.IsActive).Returns(true);
+		service.SetupGet(x => x.ServiceType).Returns(HospitalServiceType.Stabilisation);
+		service.SetupGet(x => x.RequiredEquipment).Returns([]);
+
+		var result = HospitalServiceAvailability.Evaluate(hospital.Object, service.Object);
+
+		Assert.IsFalse(result.Available);
+		StringAssert.Contains(result.Reason, "supply employee");
+	}
+
+	[TestMethod]
+	public void HospitalSupplyPreparation_PreflightRejectsAnUnreachableTreatmentLocation()
+	{
+		var currency = Currency();
+		var treatment = new Mock<ITreatment>();
+		treatment.Setup(x => x.IsTreatmentType(It.IsAny<TreatmentType>())).Returns(true);
+		var treatmentItem = Item(9025, "trauma kit");
+		treatmentItem.Setup(x => x.GetItemType<ITreatment>()).Returns(treatment.Object);
+		var supplyRoom = PhysicalCell(9026, "supply room", [treatmentItem.Object]);
+		var theatre = PhysicalCell(9027, "operating theatre", []);
+		var (hospital, _) = HospitalEmploymentHost(9028, "central clinic", currency.Object,
+			[supplyRoom.Object], [theatre.Object], 100.0M);
+		var orderly = NpcCharacter(9029, "Orderly",
+			[EmploymentWorkerAi(EmploymentAICapability.CanPrepareHospitalSupplies)]);
+		orderly.SetupGet(x => x.Location).Returns(supplyRoom.Object);
+		var service = new Mock<IHospitalService>();
+		service.SetupGet(x => x.ServiceType).Returns(HospitalServiceType.Stabilisation);
+		service.SetupGet(x => x.RequiredEquipment).Returns([]);
+		var context = new EmploymentTaskContext(hospital.Object, usePhysicalItemMovement: true);
+		context.SetPathBlocked(theatre.Object);
+
+		Assert.IsFalse(HospitalSupplyPreparationActionStep.CanPrepareRequiredSupplies(hospital.Object, service.Object,
+			null, orderly.Object, [theatre.Object], context, out var reason));
+		StringAssert.Contains(reason, "can reach");
 	}
 
 	[TestMethod]
@@ -591,6 +742,7 @@ public class UnifiedEmploymentDispatchTests
 		hospital.SetupGet(x => x.SupplyRooms).Returns([supplyRoom.Object]);
 		hospital.SetupGet(x => x.Locations).Returns([supplyRoom.Object]);
 		SetupAvailableMedicalEmployee(hospital);
+		SetupAvailableSupplyEmployee(hospital, supplyRoom.Object);
 
 		var service = new Mock<IHospitalService>();
 		service.SetupGet(x => x.IsActive).Returns(true);
@@ -641,6 +793,7 @@ public class UnifiedEmploymentDispatchTests
 		hospital.SetupGet(x => x.SupplyRooms).Returns([supplyRoom.Object]);
 		hospital.SetupGet(x => x.Locations).Returns([supplyRoom.Object]);
 		SetupAvailableMedicalEmployee(hospital);
+		SetupAvailableSupplyEmployee(hospital, supplyRoom.Object);
 
 		var service = new Mock<IHospitalService>();
 		service.SetupGet(x => x.IsActive).Returns(true);
@@ -790,12 +943,14 @@ public class UnifiedEmploymentDispatchTests
 				gameworld.Object, 0.25));
 		var cannula = CannulaItem(9104, "cannula", bodyProto.Object);
 		var drip = DripItem(9105, "iv drip");
+		var supplyRoom = PhysicalCell(9103, "supply room", [firstBag.Object, secondBag.Object, cannula.Object, drip.Object]);
 		var hospital = new Mock<IHospital>();
 		hospital.SetupGet(x => x.Name).Returns("central clinic");
 		hospital.SetupGet(x => x.IsTrading).Returns(true);
 		hospital.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
-		hospital.SetupGet(x => x.SupplyRooms).Returns([PhysicalCell(9103, "supply room", [firstBag.Object, secondBag.Object, cannula.Object, drip.Object]).Object]);
+		hospital.SetupGet(x => x.SupplyRooms).Returns([supplyRoom.Object]);
 		SetupAvailableMedicalEmployee(hospital);
+		SetupAvailableSupplyEmployee(hospital, supplyRoom.Object);
 
 		var service = new Mock<IHospitalService>();
 		service.SetupGet(x => x.IsActive).Returns(true);
@@ -892,6 +1047,88 @@ public class UnifiedEmploymentDispatchTests
 		CollectionAssert.Contains(switchCalls.ToArray(), "drain");
 		theatre.Verify(x => x.HandleRoomEcho(It.IsAny<IEmoteOutput>(), It.IsAny<RoomLayer?>()), Times.Once);
 		request.Verify(x => x.MarkStatus(HospitalServiceRequestStatus.Completed, It.IsAny<string>()), Times.Never);
+	}
+
+	[TestMethod]
+	public void HospitalMedicalServiceRunner_ReturnsBagSelectedByFailedInitialBloodWorkflow()
+	{
+		var unitManager = new Mock<MudSharp.Framework.Units.IUnitManager>();
+		unitManager.SetupGet(x => x.BaseFluidToLitres).Returns(1.0);
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.UnitManager).Returns(unitManager.Object);
+		gameworld.SetupGet(x => x.SurgicalProcedures).Returns(new All<ISurgicalProcedure>());
+		var bodyProto = BodyPrototype();
+		var bag = IvContainer(9159, "empty blood bag", gameworld.Object, capacity: 0.25);
+		var bagConnection = (IConnectable)bag.Object.GetItemType<ILiquidContainer>();
+		Mock.Get(bagConnection).Setup(x => x.CanConnect(It.IsAny<ICharacter?>(), It.IsAny<IConnectable>()))
+		    .Returns(false);
+		var drip = DripItem(9160, "iv drip");
+		var cannulaItem = CannulaItem(9161, "installed cannula", bodyProto.Object);
+		var cannula = cannulaItem.Object.GetItemType<ICannula>();
+		var theatreItems = new List<IGameItem> { bag.Object, drip.Object };
+		var supplyItems = new List<IGameItem>();
+		var theatre = PhysicalCell(9162, "operating theatre", theatreItems);
+		var supplyRoom = PhysicalCell(9163, "supply room", supplyItems);
+
+		var bloodLiquid = new Mock<ILiquid>();
+		bloodLiquid.SetupGet(x => x.Density).Returns(1.0);
+		var bloodtype = new Mock<IBloodtype>();
+		bloodtype.SetupGet(x => x.Id).Returns(1);
+		bloodtype.SetupGet(x => x.Name).Returns("O+");
+		var body = new Mock<MudSharp.Body.IBody>();
+		body.SetupGet(x => x.BloodLiquid).Returns(bloodLiquid.Object);
+		body.SetupGet(x => x.Bloodtype).Returns(bloodtype.Object);
+		body.SetupGet(x => x.TotalBloodVolumeLitres).Returns(5.0);
+		body.SetupGet(x => x.CurrentBloodVolumeLitres).Returns(5.0);
+		body.SetupGet(x => x.Prototype).Returns(bodyProto.Object);
+		body.SetupGet(x => x.Implants).Returns([cannula]);
+
+		var doctor = Character(9164, "Doctor", gameworld: gameworld.Object);
+		var donor = Character(9165, "Donor", gameworld: gameworld.Object);
+		doctor.SetupGet(x => x.Location).Returns(theatre.Object);
+		doctor.Setup(x => x.ColocatedWith(donor.Object)).Returns(true);
+		donor.SetupGet(x => x.Body).Returns(body.Object);
+		donor.SetupGet(x => x.Location).Returns(theatre.Object);
+
+		var service = new Mock<IHospitalService>();
+		service.SetupGet(x => x.Id).Returns(9166);
+		service.SetupGet(x => x.Name).Returns("Blood Donation");
+		service.SetupGet(x => x.ServiceType).Returns(HospitalServiceType.BloodDonation);
+		service.SetupGet(x => x.RequiredEquipment).Returns([]);
+		service.SetupGet(x => x.BloodVolumeLitres).Returns(0.5);
+
+		var hospital = new Mock<IHospital>();
+		hospital.SetupGet(x => x.Id).Returns(9167);
+		hospital.SetupGet(x => x.Name).Returns("central clinic");
+		hospital.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		hospital.SetupGet(x => x.Locations).Returns([theatre.Object, supplyRoom.Object]);
+		hospital.SetupGet(x => x.OperatingTheatres).Returns([theatre.Object]);
+		hospital.SetupGet(x => x.SupplyRooms).Returns([supplyRoom.Object]);
+		hospital.SetupGet(x => x.EmploymentRegister).Returns(new Mock<IEmploymentRegister>().Object);
+
+		var request = new Mock<IHospitalServiceRequest>();
+		request.SetupGet(x => x.Id).Returns(9168);
+		request.SetupGet(x => x.Hospital).Returns(hospital.Object);
+		request.SetupGet(x => x.Service).Returns(service.Object);
+		request.SetupGet(x => x.Status).Returns(HospitalServiceRequestStatus.Queued);
+		request.SetupGet(x => x.PatientId).Returns(donor.Object.Id);
+		request.SetupGet(x => x.Patient).Returns(donor.Object);
+		request.SetupGet(x => x.OperatingTheatreCellId).Returns(theatre.Object.Id);
+		request.SetupGet(x => x.SupplyPrepared).Returns(true);
+
+		var task = new EmploymentActiveTask(hospital.Object, "Donate blood",
+			new EmploymentActionPlan([new HospitalServiceActionStep(hospital.Object, request.Object)]), Guid.NewGuid());
+		task.Assign(doctor.Object);
+		task.MarkStep(0, EmploymentActionStepStatus.InProgress);
+		var context = new EmploymentTaskContext(hospital.Object);
+		context.HydrateTaskState(task, 0);
+
+		var result = HospitalMedicalServiceRunner.ExecuteServiceRequest(context, doctor.Object, hospital.Object,
+			request.Object);
+
+		Assert.IsFalse(result.Success);
+		CollectionAssert.Contains(supplyItems, bag.Object);
+		CollectionAssert.DoesNotContain(theatreItems, bag.Object);
 	}
 
 	[TestMethod]
@@ -1018,7 +1255,7 @@ public class UnifiedEmploymentDispatchTests
 	}
 
 	[TestMethod]
-	public void HospitalMedicalServiceRunner_ReturnsFullAndUnusedBloodBagsToSupplyRoom()
+	public void HospitalMedicalServiceRunner_ReturnsOnlyTrackedBloodBagsToSupplyRoom()
 	{
 		var gameworld = new Mock<IFuturemud>();
 		var fullBag = IvContainer(9185, "full blood bag", gameworld.Object, capacity: 0.25, volume: 0.25);
@@ -1044,17 +1281,19 @@ public class UnifiedEmploymentDispatchTests
 		var context = new EmploymentTaskContext(hospital.Object);
 
 		var returned = HospitalMedicalServiceRunner.ReturnBloodBagsToSupplyRoom(context, employee.Object,
-			request.Object);
+			request.Object, [fullBag.Object.Id]);
 
-		Assert.AreEqual(2, returned);
-		Assert.AreEqual(0, theatreItems.Count);
-		CollectionAssert.AreEquivalent(new[] { fullBag.Object, unusedBag.Object }, supplyItems);
+		Assert.AreEqual(1, returned);
+		CollectionAssert.Contains(theatreItems, unusedBag.Object);
+		CollectionAssert.Contains(supplyItems, fullBag.Object);
+		CollectionAssert.DoesNotContain(supplyItems, unusedBag.Object);
 		theatre.Verify(x => x.HandleRoomEcho(It.IsAny<IEmoteOutput>(), It.IsAny<RoomLayer?>()), Times.Once);
 
 		var combinedServiceBag = IvContainer(9191, "combined-service blood bag", gameworld.Object);
 		theatreItems.Add(combinedServiceBag.Object);
 		service.SetupGet(x => x.ServiceType).Returns(HospitalServiceType.FullTreatment);
-		returned = HospitalMedicalServiceRunner.ReturnBloodBagsToSupplyRoom(context, employee.Object, request.Object);
+		returned = HospitalMedicalServiceRunner.ReturnBloodBagsToSupplyRoom(context, employee.Object, request.Object,
+			[combinedServiceBag.Object.Id]);
 
 		Assert.AreEqual(1, returned);
 		CollectionAssert.Contains(supplyItems, combinedServiceBag.Object);
@@ -8773,6 +9012,15 @@ public class UnifiedEmploymentDispatchTests
 		doctor.SetupGet(x => x.Location).Returns(doctorCell.Object);
 		state.Hire(doctor.Object, Offer(Currency().Object, EmploymentRole.MedicalWorker,
 			EmploymentAuthority.PerformMedicalServices), null);
+	}
+
+	private static void SetupAvailableSupplyEmployee(Mock<IHospital> hospital, ICell location)
+	{
+		var orderly = NpcCharacter(7920, "Orderly",
+			[EmploymentWorkerAi(EmploymentAICapability.CanPrepareHospitalSupplies)]);
+		orderly.SetupGet(x => x.Location).Returns(location);
+		hospital.Object.Employment.Hire(orderly.Object, Offer(Currency().Object, EmploymentRole.HospitalOrderly,
+			EmploymentAuthority.PrepareMedicalSupplies), null);
 	}
 
 	private static EmploymentWorkerAI EmploymentWorkerAi(params EmploymentAICapability[] capabilities)

--- a/MudSharpCore/Commands/Modules/EconomyModule.Hospitals.cs
+++ b/MudSharpCore/Commands/Modules/EconomyModule.Hospitals.cs
@@ -52,7 +52,7 @@ Hospital managers and proprietors standing in the hospital can use #3hospital he
 	#3hospital maxdebt <amount>#0 - sets the default debt ceiling for new patients
 	#3hospital room add|remove <waiting|theatre|supply|recovery|staff> [here|<direction>|<#>]#0 - flags hospital rooms
 	#3hospital service add <type> <price> <name>#0 - creates a service
-	#3hospital service set <service> price|active|debt|theatre|recovery|offering|blood|equipment|procedure|implant|implantpower|implantinterface|anesthesia|cannulation|parameters|name|desc <value>#0 - edits a service; equipment add accepts optional consumable|reusable after quantity
+	#3hospital service set <service> price|active|debt|theatre|recovery|offering|consent|blood|equipment|procedure|implant|implantpower|implantinterface|anesthesia|cannulation|parameters|name|desc <value>#0 - edits a service; equipment add accepts optional consumable|reusable after quantity
 	#3hospital bloodstock [show|set|clear] ...#0 - manages blood type target stock and donor prices
 	#3hospital deposit <amount>#0 - deposits held cash into the hospital's virtual cash balance
 	#3hospital withdraw <amount>#0 - withdraws cash from the hospital's virtual cash balance
@@ -448,7 +448,7 @@ Administrators can also use:
 
 		if (ss.IsFinished)
 		{
-			actor.OutputHandler.Send("Which property do you want to set? Options are price, active, debt, theatre, recovery, offering, blood, equipment, procedure, implant, implantpower, implantinterface, anesthesia, cannulation, parameters, name, and desc.");
+			actor.OutputHandler.Send("Which property do you want to set? Options are price, active, debt, theatre, recovery, offering, consent, blood, equipment, procedure, implant, implantpower, implantinterface, anesthesia, cannulation, parameters, name, and desc.");
 			return;
 		}
 
@@ -514,6 +514,10 @@ Administrators can also use:
 			case "mode":
 			case "visibility":
 				HospitalServiceSetOfferingMode(actor, service, ss);
+				return;
+			case "consent":
+			case "consentpolicy":
+				HospitalServiceSetConsentPolicy(actor, service, ss);
 				return;
 			case "blood":
 			case "bloodvolume":
@@ -599,6 +603,36 @@ Administrators can also use:
 		actor.OutputHandler.Send($"{service.Name.ColourName()} will use {amount.ToString("N2", actor).ColourValue()}L for blood donation/transfusion procedures.");
 	}
 
+	private static void HospitalServiceSetConsentPolicy(ICharacter actor, IHospitalService service, StringStack ss)
+	{
+		if (ss.IsFinished || !TryParseHospitalServiceConsentPolicy(ss.PopSpeech(), out var policy))
+		{
+			actor.OutputHandler.Send("Which consent policy should this service use? Valid policies are informed and emergency.");
+			return;
+		}
+
+		service.ConsentPolicy = policy;
+		actor.OutputHandler.Send($"{service.Name.ColourName()} now uses the {policy.DescribeEnum().ColourName()} policy.");
+	}
+
+	private static bool TryParseHospitalServiceConsentPolicy(string text, out HospitalServiceConsentPolicy policy)
+	{
+		switch (text.CollapseString().ToLowerInvariant())
+		{
+			case "informed":
+			case "consent":
+			case "required":
+				policy = HospitalServiceConsentPolicy.InformedConsentRequired;
+				return true;
+			case "emergency":
+			case "presumed":
+				policy = HospitalServiceConsentPolicy.EmergencyPresumedConsent;
+				return true;
+		}
+
+		return text.TryParseEnum(out policy);
+	}
+
 	private static void HospitalServiceSetOfferingMode(ICharacter actor, IHospitalService service, StringStack ss)
 	{
 		if (ss.IsFinished || !TryParseHospitalServiceOfferingMode(ss.PopSpeech(), out var mode))
@@ -658,6 +692,13 @@ Administrators can also use:
 		{
 			case "clear":
 			case "none":
+				if (!CanEditHospitalServiceEquipment(actor, service,
+				        service.RequiredEquipment.Select(x => x.ItemType), out var clearMessage))
+				{
+					actor.OutputHandler.Send(clearMessage);
+					return;
+				}
+
 				service.ClearRequiredEquipment();
 				actor.OutputHandler.Send($"{service.Name.ColourName()} no longer requires prepared equipment.");
 				return;
@@ -666,6 +707,13 @@ Administrators can also use:
 				if (ss.IsFinished || !int.TryParse(ss.PopSpeech(), out var index) || index < 1 || index > service.RequiredEquipment.Count)
 				{
 					actor.OutputHandler.Send("Which equipment requirement number do you want to remove?");
+					return;
+				}
+
+				if (!CanEditHospitalServiceEquipment(actor, service,
+				        [service.RequiredEquipment[index - 1].ItemType], out var removeMessage))
+				{
+					actor.OutputHandler.Send(removeMessage);
 					return;
 				}
 
@@ -699,6 +747,12 @@ Administrators can also use:
 					return;
 				}
 
+				if (!CanEditHospitalServiceEquipment(actor, service, [itemType], out var addMessage))
+				{
+					actor.OutputHandler.Send(addMessage);
+					return;
+				}
+
 				service.AddRequiredEquipment(new HospitalServiceEquipmentRequirement(quantity, selector, itemType));
 				actor.OutputHandler.Send($"{service.Name.ColourName()} now requires {quantity.ToString("N0", actor).ColourValue()}x {EmploymentItemSelectorResolver.Describe(selector).ColourCommand()} as {itemType.DescribeEnum().ColourName()} to be prepared.");
 				return;
@@ -706,6 +760,41 @@ Administrators can also use:
 				actor.OutputHandler.Send("Hospital service equipment syntax is equipment show|clear|remove <#>|add <quantity> [consumable|reusable] <prototype id|*item id|&tag|keyword>.");
 				return;
 		}
+	}
+
+	private static bool CanEditHospitalServiceEquipment(ICharacter actor, IHospitalService service,
+		IEnumerable<HospitalServiceSupplyItemType> itemTypes, out string message)
+	{
+		message = string.Empty;
+		if (actor.IsAdministrator())
+		{
+			return true;
+		}
+
+		var affectedItemTypes = itemTypes.Distinct().ToHashSet();
+		if (!affectedItemTypes.Any())
+		{
+			return true;
+		}
+
+		var goals = service.Hospital.ManagerGoalBoard.Goals
+			.Where(x => x.Status is ManagerGoalStatus.Active or ManagerGoalStatus.Satisfied)
+			.Where(x => HospitalSupplyStockGoalPlanner.IsHospitalStockGoal(x.GoalType))
+			.Where(x => affectedItemTypes.Contains(HospitalSupplyStockGoalPlanner.ItemTypeForGoal(x.GoalType)))
+			.OrderBy(x => x.Id)
+			.ToList();
+		foreach (var goal in goals)
+		{
+			if (service.Hospital.HasAuthority(actor, goal.RequiredAuthority.Authorities))
+			{
+				continue;
+			}
+
+			message = $"You cannot change equipment used by active hospital stock goal #{goal.Id.ToString("N0", actor).ColourValue()} without its delegated {goal.RequiredAuthority.Authorities.DescribeEnum().ColourName()} authority.";
+			return false;
+		}
+
+		return true;
 	}
 
 	private static void ShowServiceEquipment(ICharacter actor, IHospitalService service)
@@ -1425,7 +1514,19 @@ Administrators can also use:
 			actor.OutputHandler.Send(message);
 		}
 
-		if (!CharacterInstanceIdentityComparer.SamePhysicalInstance(actor, patient) && !patient.IsHelpless)
+		if (!CharacterInstanceIdentityComparer.SamePhysicalInstance(actor, patient) && patient.IsHelpless)
+		{
+			if (service.ConsentPolicy != HospitalServiceConsentPolicy.EmergencyPresumedConsent)
+			{
+				actor.OutputHandler.Send($"{service.Name.ColourName()} requires the patient's informed consent and cannot be requested for a helpless patient by another person.");
+				return;
+			}
+
+			CreateRequest();
+			return;
+		}
+
+		if (!CharacterInstanceIdentityComparer.SamePhysicalInstance(actor, patient))
 		{
 			patient.AddEffect(new Accept(patient, new GenericProposal(
 				text =>
@@ -1549,7 +1650,7 @@ Administrators can also use:
 		var task = HospitalTaskForRequest(hospital, request);
 		var abortedProcedures = CancelHospitalSurgicalEffects(hospital, request, task);
 		var cleanedBloodWorkflow = HospitalMedicalServiceRunner.CleanupBloodWorkflowForTerminalRequest(hospital, request,
-			task, actor);
+			task);
 		var reason = $"Cancelled by {actor.HowSeen(actor, colour: false)}.";
 		request.MarkStatus(HospitalServiceRequestStatus.Cancelled,
 			$"{reason} Amounts already paid or charged remain on the request; cancellation does not refund completed or partially completed work.");
@@ -1581,20 +1682,17 @@ Administrators can also use:
 	private static int CancelHospitalSurgicalEffects(IHospital hospital, IHospitalServiceRequest request,
 		IEmploymentActiveTask? task)
 	{
-		var patient = request.Patient;
 		var employees = hospital.ActiveEmploymentContracts()
 		                        .Select(x => x.Employee)
 		                        .Concat(task?.AssignedEmployee is null ? [] : [task.AssignedEmployee])
 		                        .Where(x => x is not null)
 		                        .DistinctPhysicalInstances()
 		                        .ToList();
-		var procedures = HospitalServiceProcedures(hospital, request.Service).Select(x => x.Id).ToHashSet();
 		var count = 0;
 		foreach (var employee in employees)
 		{
 			var effects = (employee.CombinedEffectsOfType<SurgicalProcedureEffect>() ?? [])
-			              .Where(x => patient is null || CharacterInstanceIdentityComparer.SameIdentity(x.Patient, patient))
-			              .Where(x => !procedures.Any() || procedures.Contains(x.Procedure.Id))
+			              .Where(x => x.HospitalRequestId == request.Id)
 			              .ToList();
 			foreach (var effect in effects)
 			{
@@ -1605,36 +1703,6 @@ Administrators can also use:
 		}
 
 		return count;
-	}
-
-	private static IEnumerable<ISurgicalProcedure> HospitalServiceProcedures(IHospital hospital, IHospitalService service)
-	{
-		if (service.SurgicalProcedure is not null)
-		{
-			yield return service.SurgicalProcedure;
-		}
-		else if (HospitalMedicalServiceRunner.ServiceTypeToSurgicalProcedureType(service.ServiceType) is { } procedureType)
-		{
-			foreach (var procedure in hospital.Gameworld.SurgicalProcedures.Where(x => x.Procedure == procedureType))
-			{
-				yield return procedure;
-			}
-		}
-
-		if (service.AnesthesiaCannulationProcedure is not null)
-		{
-			yield return service.AnesthesiaCannulationProcedure;
-		}
-
-		if (service.ImplantPowerProcedure is not null)
-		{
-			yield return service.ImplantPowerProcedure;
-		}
-
-		if (service.ImplantInterfaceProcedure is not null)
-		{
-			yield return service.ImplantInterfaceProcedure;
-		}
 	}
 
 	private static bool TryCreateHospitalRequest(ICharacter requester, IHospital hospital, IHospitalService service,

--- a/MudSharpCore/Economy/Employment/EmploymentActionSteps.cs
+++ b/MudSharpCore/Economy/Employment/EmploymentActionSteps.cs
@@ -4640,41 +4640,141 @@ public sealed class HospitalSupplyPreparationActionStep : EmploymentActionStepBa
 			return false;
 		}
 
-		var needsConfiguredSupplies = request.Service.RequiredEquipment.Any() &&
-		                             !TreatmentLocationAlreadyHasConfiguredSupplies(hospital, request);
-		if (!needsConfiguredSupplies && !HospitalMedicalServiceRunner.UsesCommandRoutedWoundCare(request.Service) &&
-		    !RequiresImplicitBloodSupply(request))
+		return RequiresSupplyPreparation(hospital, request.Service, request.Patient,
+			TreatmentLocationCandidates(hospital, request));
+	}
+
+	/// <summary>
+	/// Determines whether the supplied service needs a worker to stage hospital supplies. This is deliberately
+	/// shared by availability checks and task construction so that a request is never paid for when its first
+	/// required action cannot be assigned to an eligible supply worker.
+	/// </summary>
+	public static bool RequiresSupplyPreparation(IHospital hospital, IHospitalService service, ICharacter? patient)
+	{
+		return RequiresSupplyPreparation(hospital, service, patient, out _);
+	}
+
+	/// <summary>
+	/// Determines whether a new request needs supplies staged and returns the exact treatment location candidates
+	/// that the request would use. Availability checks use these candidates so stock in a reserved or occupied
+	/// theatre cannot make a different request appear executable.
+	/// </summary>
+	public static bool RequiresSupplyPreparation(IHospital hospital, IHospitalService service, ICharacter? patient,
+		out IReadOnlyCollection<ICell> treatmentLocations)
+	{
+		treatmentLocations = PreflightTreatmentLocationCandidates(hospital, service, patient).ToList();
+		return RequiresSupplyPreparation(hospital, service, patient, treatmentLocations);
+	}
+
+	/// <summary>
+	/// Confirms that an eligible supply employee can reach both a suitable supply room and the treatment location
+	/// for the preflight supply plan. This mirrors the locations used by the supply preparation action before a
+	/// request is charged or persisted.
+	/// </summary>
+	public static bool CanPrepareRequiredSupplies(IHospital hospital, IHospitalService service, ICharacter? patient,
+		ICharacter employee, IReadOnlyCollection<ICell> treatmentLocations, IEmploymentTaskContext context,
+		out string reason)
+	{
+		var treatmentTypes = HospitalMedicalServiceRunner.ImplicitTreatmentSupplyTypes(service).ToList();
+		var requiresBloodSupplies = RequiresImplicitBloodSupply(service, patient);
+		if (!treatmentLocations.Any())
+		{
+			reason = "there is no available treatment location for the required supplies";
+			return false;
+		}
+
+		foreach (var theatre in treatmentLocations)
+		{
+			foreach (var room in hospital.SupplyRooms ?? Enumerable.Empty<ICell>())
+			{
+				if (!SuppliesSatisfyService(hospital, (room.GameItems ?? Enumerable.Empty<IGameItem>())
+					.Concat(theatre.GameItems ?? Enumerable.Empty<IGameItem>()), service, patient, treatmentTypes,
+					requiresBloodSupplies))
+				{
+					continue;
+				}
+
+				if (!context.CanPath(employee, room) || !context.CanPath(employee, theatre))
+				{
+					continue;
+				}
+
+				reason = string.Empty;
+				return true;
+			}
+		}
+
+		reason = "no available supply employee can reach a suitable hospital supply room and treatment location";
+		return false;
+	}
+
+	/// <summary>
+	/// Returns whether every explicit and implicit supply requirement is already staged in one of the selected
+	/// treatment locations. Unlike <see cref="RequiresSupplyPreparation"/>, this remains false when stock is
+	/// absent altogether, allowing request preflight to reject the service before charging the patient.
+	/// </summary>
+	public static bool TreatmentLocationSuppliesAreReady(IHospital hospital, IHospitalService service,
+		ICharacter? patient, IReadOnlyCollection<ICell> treatmentLocations)
+	{
+		var treatmentTypes = HospitalMedicalServiceRunner.ImplicitTreatmentSupplyTypes(service).ToList();
+		var requiresBloodSupplies = RequiresImplicitBloodSupply(service, patient);
+		if (!service.RequiredEquipment.Any() && !treatmentTypes.Any() && !requiresBloodSupplies)
+		{
+			return true;
+		}
+
+		if (!treatmentLocations.Any())
+		{
+			return hospital.SupplyRooms.Any(room => SuppliesSatisfyService(hospital,
+				room.GameItems ?? Enumerable.Empty<IGameItem>(), service, patient, treatmentTypes,
+				requiresBloodSupplies));
+		}
+
+		return treatmentLocations.Any(theatre => SuppliesSatisfyService(hospital,
+			theatre.GameItems ?? Enumerable.Empty<IGameItem>(), service, patient, treatmentTypes,
+			requiresBloodSupplies));
+	}
+
+	private static bool RequiresSupplyPreparation(IHospital hospital, IHospitalService service, ICharacter? patient,
+		IEnumerable<ICell> treatmentLocations)
+	{
+		var treatmentTypes = HospitalMedicalServiceRunner.ImplicitTreatmentSupplyTypes(service).ToList();
+		var requiresBloodSupplies = RequiresImplicitBloodSupply(service, patient);
+		if (!service.RequiredEquipment.Any() && !treatmentTypes.Any() && !requiresBloodSupplies)
 		{
 			return false;
 		}
 
-		var treatmentTypes = HospitalMedicalServiceRunner.ImplicitTreatmentSupplyTypes(request.Service).ToList();
-		var needsTreatmentSupplies = treatmentTypes.Any() &&
-		                             !TreatmentLocationAlreadyHasImplicitTreatmentSupplies(hospital, request, treatmentTypes);
-		var needsBloodSupplies = RequiresImplicitBloodSupply(request) &&
-		                         !TreatmentLocationAlreadyHasImplicitBloodSupplies(hospital, request);
-		if (!needsConfiguredSupplies && !needsTreatmentSupplies && !needsBloodSupplies)
+		var treatmentLocationList = treatmentLocations.DistinctBy(x => x.Id).ToList();
+		if (!treatmentLocationList.Any())
+		{
+			return hospital.SupplyRooms.Any(room => SuppliesSatisfyService(hospital,
+				room.GameItems ?? Enumerable.Empty<IGameItem>(), service, patient, treatmentTypes, requiresBloodSupplies));
+		}
+
+		if (TreatmentLocationSuppliesAreReady(hospital, service, patient, treatmentLocationList))
 		{
 			return false;
 		}
 
-		var stagedItems = TreatmentLocationCandidates(hospital, request)
-			.SelectMany(theatre => theatre.GameItems ?? Enumerable.Empty<IGameItem>())
+		return hospital.SupplyRooms.Any(room => treatmentLocationList.Any(theatre =>
+			SuppliesSatisfyService(hospital, (room.GameItems ?? Enumerable.Empty<IGameItem>())
+				.Concat(theatre.GameItems ?? Enumerable.Empty<IGameItem>()), service, patient, treatmentTypes,
+				requiresBloodSupplies)));
+	}
+
+	private static bool SuppliesSatisfyService(IHospital hospital, IEnumerable<IGameItem> items, IHospitalService service,
+		ICharacter? patient, IReadOnlyCollection<TreatmentType> treatmentTypes, bool requiresBloodSupplies)
+	{
+		var available = items
 			.SelectMany(DeepItemsOrSelf)
 			.DistinctBy(x => x.Id)
 			.ToList();
-		return hospital.SupplyRooms.Any(room =>
-		{
-			var available = (room.GameItems ?? Enumerable.Empty<IGameItem>())
-				.SelectMany(DeepItemsOrSelf)
-				.Concat(stagedItems)
-				.DistinctBy(x => x.Id)
-				.ToList();
-			return (!needsConfiguredSupplies || RequirementsSatisfiedByItems(available, request.Service.RequiredEquipment)) &&
-			       (!needsTreatmentSupplies || treatmentTypes.All(type => available.Any(item =>
-				       item.GetItemType<ITreatment>() is { } treatment && treatment.IsTreatmentType(type)))) &&
-			       (!needsBloodSupplies || TryFindImplicitBloodSupplyItems(available, request, out _));
-		});
+		return (!service.RequiredEquipment.Any() || RequirementsSatisfiedByItems(available, service.RequiredEquipment)) &&
+		       (!treatmentTypes.Any() || treatmentTypes.All(type => available.Any(item =>
+			       item.GetItemType<ITreatment>() is { } treatment && treatment.IsTreatmentType(type)))) &&
+		       (!requiresBloodSupplies || TryFindImplicitBloodSupplyItems(available, hospital, service, patient,
+			       out _));
 	}
 	public override bool CanExecute(IEmploymentTaskContext context, ICharacter actor, out string reason)
 	{
@@ -5045,6 +5145,24 @@ public sealed class HospitalSupplyPreparationActionStep : EmploymentActionStepBa
 		               .Take(1);
 	}
 
+	private static IEnumerable<ICell> PreflightTreatmentLocationCandidates(IHospital hospital, IHospitalService service,
+		ICharacter? patient)
+	{
+		if (!HospitalMedicalServiceRunner.ShouldUseTreatmentTheatre(service))
+		{
+			return patient?.Location is { } patientLocation
+				? [patientLocation]
+				: (hospital.WaitingRooms ?? Enumerable.Empty<ICell>())
+					.Concat(hospital.OperatingTheatres ?? Enumerable.Empty<ICell>())
+					.Concat(hospital.SupplyRooms ?? Enumerable.Empty<ICell>())
+					.Take(1);
+		}
+
+		return (hospital.OperatingTheatres ?? Enumerable.Empty<ICell>())
+		       .Where(theatre => HospitalPatientFlow.IsTheatreAvailableForNewRequest(hospital, patient, theatre, out _))
+		       .Take(1);
+	}
+
 	private IEnumerable<IGameItem> TreatmentLocationSupplyItems(IEmploymentTaskContext context, ICell theatre)
 	{
 		return context.AvailableItems(theatre)
@@ -5199,12 +5317,17 @@ public sealed class HospitalSupplyPreparationActionStep : EmploymentActionStepBa
 	}
 	private static bool RequiresImplicitBloodSupply(IHospitalServiceRequest request)
 	{
-		return request.Service.ServiceType switch
+		return RequiresImplicitBloodSupply(request.Service, request.Patient);
+	}
+
+	private static bool RequiresImplicitBloodSupply(IHospitalService service, ICharacter? patient)
+	{
+		return service.ServiceType switch
 		{
 			HospitalServiceType.BloodDonation or HospitalServiceType.BloodTransfusion => true,
-			HospitalServiceType.Stabilisation => request.Patient?.Body is { TotalBloodVolumeLitres: > 0.0 } body &&
+			HospitalServiceType.Stabilisation => patient?.Body is { TotalBloodVolumeLitres: > 0.0 } body &&
 			                                     body.CurrentBloodVolumeLitres < body.TotalBloodVolumeLitres * 0.75,
-			HospitalServiceType.FullTreatment => request.Patient?.Body is { TotalBloodVolumeLitres: > 0.0 } body &&
+			HospitalServiceType.FullTreatment => patient?.Body is { TotalBloodVolumeLitres: > 0.0 } body &&
 			                                    body.CurrentBloodVolumeLitres < body.TotalBloodVolumeLitres,
 			_ => false
 		};
@@ -5213,11 +5336,18 @@ public sealed class HospitalSupplyPreparationActionStep : EmploymentActionStepBa
 	private static bool TryFindImplicitBloodSupplyItems(IReadOnlyCollection<IGameItem> available,
 		IHospitalServiceRequest request, out IReadOnlyCollection<IGameItem> items)
 	{
+		return TryFindImplicitBloodSupplyItems(available, request.Hospital, request.Service, request.Patient,
+			out items);
+	}
+
+	private static bool TryFindImplicitBloodSupplyItems(IReadOnlyCollection<IGameItem> available,
+		IHospital hospital, IHospitalService service, ICharacter? patient, out IReadOnlyCollection<IGameItem> items)
+	{
 		items = [];
 		var selected = new List<IGameItem>();
 		var used = new HashSet<long>();
-		var switchMode = request.Service.ServiceType == HospitalServiceType.BloodDonation ? "drain" : "drip";
-		if (!TryFindBloodAccessItems(available, request, switchMode, selected, used))
+		var switchMode = service.ServiceType == HospitalServiceType.BloodDonation ? "drain" : "drip";
+		if (!TryFindBloodAccessItems(available, patient, switchMode, selected, used))
 		{
 			return false;
 		}
@@ -5229,10 +5359,10 @@ public sealed class HospitalSupplyPreparationActionStep : EmploymentActionStepBa
 		                 .Where(x => x.Container is not null)
 		                 .Select(x => (x.Item, Container: x.Container!))
 		                 .ToList();
-		switch (request.Service.ServiceType)
+		switch (service.ServiceType)
 		{
 			case HospitalServiceType.BloodDonation:
-				if (!TryFindDonationContainer(containers, request, out var donationItems))
+				if (!TryFindDonationContainer(containers, patient, out var donationItems))
 				{
 					return false;
 				}
@@ -5241,7 +5371,7 @@ public sealed class HospitalSupplyPreparationActionStep : EmploymentActionStepBa
 				items = selected;
 				return true;
 			case HospitalServiceType.BloodTransfusion:
-				if (!TryFindTransfusionContainers(containers, request, false, out var transfusionItems))
+				if (!TryFindTransfusionContainers(containers, hospital, service, patient, false, out var transfusionItems))
 				{
 					return false;
 				}
@@ -5251,7 +5381,7 @@ public sealed class HospitalSupplyPreparationActionStep : EmploymentActionStepBa
 				return true;
 			case HospitalServiceType.Stabilisation:
 			case HospitalServiceType.FullTreatment:
-				if (!TryFindTransfusionContainers(containers, request, true, out var combinedItems))
+				if (!TryFindTransfusionContainers(containers, hospital, service, patient, true, out var combinedItems))
 				{
 					return false;
 				}
@@ -5265,14 +5395,14 @@ public sealed class HospitalSupplyPreparationActionStep : EmploymentActionStepBa
 	}
 
 	private static bool TryFindBloodAccessItems(IReadOnlyCollection<IGameItem> available,
-		IHospitalServiceRequest request, string switchMode, List<IGameItem> selected, HashSet<long> used)
+		ICharacter? patient, string switchMode, List<IGameItem> selected, HashSet<long> used)
 	{
-		if (request.Patient?.Body.Implants.Any(x => x.Parent.GetItemType<ICannula>() is not null) != true)
+		if (patient?.Body.Implants.Any(x => x.Parent?.GetItemType<ICannula>() is not null) != true)
 		{
 			var cannulaItem = available.FirstOrDefault(x =>
 				!used.Contains(x.Id) &&
 				x.GetItemType<ICannula>() is { } cannula &&
-				(request.Patient is null || request.Patient.Body.Prototype.CountsAs(cannula.TargetBody)));
+				(patient is null || patient.Body.Prototype.CountsAs(cannula.TargetBody)));
 			if (cannulaItem is null)
 			{
 				return false;
@@ -5297,10 +5427,10 @@ public sealed class HospitalSupplyPreparationActionStep : EmploymentActionStepBa
 
 	private static bool TryFindDonationContainer(
 		IReadOnlyCollection<(IGameItem Item, ILiquidContainer Container)> containers,
-		IHospitalServiceRequest request, out IReadOnlyCollection<IGameItem> items)
+		ICharacter? patient, out IReadOnlyCollection<IGameItem> items)
 	{
 		items = [];
-		var donorBlood = request.Patient?.Body.BloodLiquid;
+		var donorBlood = patient?.Body.BloodLiquid;
 		var selected = containers.FirstOrDefault(x =>
 			x.Container.LiquidCapacity - x.Container.LiquidVolume > 0.0 &&
 			(donorBlood is null ||
@@ -5318,16 +5448,16 @@ public sealed class HospitalSupplyPreparationActionStep : EmploymentActionStepBa
 
 	private static bool TryFindTransfusionContainers(
 		IReadOnlyCollection<(IGameItem Item, ILiquidContainer Container)> containers,
-		IHospitalServiceRequest request, bool allowBloodVolumeSubstitute,
+		IHospital hospital, IHospitalService service, ICharacter? patient, bool allowBloodVolumeSubstitute,
 		out IReadOnlyCollection<IGameItem> items)
 	{
 		items = [];
-		if (request.Patient?.Body.Bloodtype is not { } bloodtype)
+		if (patient?.Body.Bloodtype is not { } bloodtype)
 		{
 			return false;
 		}
 
-		var amount = RequestedTransfusionLiquidAmount(request);
+		var amount = RequestedTransfusionLiquidAmount(hospital, service, patient);
 		if (amount <= 0.0)
 		{
 			return false;
@@ -5402,14 +5532,20 @@ public sealed class HospitalSupplyPreparationActionStep : EmploymentActionStepBa
 
 	private static double RequestedTransfusionLiquidAmount(IHospitalServiceRequest request)
 	{
-		if (request.Patient?.Body is not { TotalBloodVolumeLitres: > 0.0 } body)
+		return RequestedTransfusionLiquidAmount(request.Hospital, request.Service, request.Patient);
+	}
+
+	private static double RequestedTransfusionLiquidAmount(IHospital hospital, IHospitalService service,
+		ICharacter? patient)
+	{
+		if (patient?.Body is not { TotalBloodVolumeLitres: > 0.0 } body)
 		{
 			return 0.0;
 		}
 
-		var neededLitres = Math.Min(request.Service.BloodVolumeLitres > 0.0 ? request.Service.BloodVolumeLitres : 0.5,
+		var neededLitres = Math.Min(service.BloodVolumeLitres > 0.0 ? service.BloodVolumeLitres : 0.5,
 			body.TotalBloodVolumeLitres - body.CurrentBloodVolumeLitres);
-		return Math.Max(0.0, neededLitres) / request.Hospital.Gameworld.UnitManager.BaseFluidToLitres;
+		return Math.Max(0.0, neededLitres) / hospital.Gameworld.UnitManager.BaseFluidToLitres;
 	}
 
 	private static IEnumerable<IGameItem> DeepItemsOrSelf(IGameItem item)

--- a/MudSharpCore/Economy/Hospitals/HospitalMedicalServiceRunner.cs
+++ b/MudSharpCore/Economy/Hospitals/HospitalMedicalServiceRunner.cs
@@ -199,6 +199,7 @@ public static class HospitalMedicalServiceRunner
 		public HashSet<string> CompletedPhases { get; } = new(StringComparer.InvariantCultureIgnoreCase);
 		public Dictionary<HospitalServiceType, int> Charges { get; } = new();
 		public BloodWorkflowProgress? BloodWorkflow { get; set; }
+		public HashSet<long> BloodBagIds { get; } = new();
 
 		public IReadOnlyList<UsageCharge> UsageCharges =>
 			Charges.Select(x => new UsageCharge(x.Key, x.Value)).ToList();
@@ -228,6 +229,32 @@ public static class HospitalMedicalServiceRunner
 			}
 
 			Charges[serviceType] = Charges.GetValueOrDefault(serviceType) + count;
+		}
+
+		public void RememberBloodBags(BloodWorkflowProgress workflow)
+		{
+			if (workflow.ContainerId is { } containerId)
+			{
+				BloodBagIds.Add(containerId);
+			}
+
+			BloodBagIds.UnionWith(workflow.UsedContainerIds);
+		}
+
+		public IReadOnlyCollection<long> TrackedBloodBagIds()
+		{
+			var ids = BloodBagIds.ToHashSet();
+			if (BloodWorkflow is not null)
+			{
+				if (BloodWorkflow.ContainerId is { } containerId)
+				{
+					ids.Add(containerId);
+				}
+
+				ids.UnionWith(BloodWorkflow.UsedContainerIds);
+			}
+
+			return ids;
 		}
 
 		public string ToPayload(IHospital hospital, IHospitalServiceRequest request, bool completed)
@@ -260,6 +287,11 @@ public static class HospitalMedicalServiceRunner
 			if (BloodWorkflow is not null)
 			{
 				parts.Add($"blood={BloodWorkflow.ToPayload()}");
+			}
+
+			if (BloodBagIds.Any())
+			{
+				parts.Add($"bloodbags={BloodBagIds.OrderBy(x => x).Select(x => x.ToString("F0", CultureInfo.InvariantCulture)).ListToCommaSeparatedValues()}");
 			}
 
 			return string.Join(';', parts);
@@ -322,6 +354,17 @@ public static class HospitalMedicalServiceRunner
 				progress.BloodWorkflow = bloodWorkflow;
 			}
 
+			if (parts.TryGetValue("bloodbags", out var bloodBags))
+			{
+				foreach (var idText in bloodBags.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+				{
+					if (long.TryParse(idText, NumberStyles.Any, CultureInfo.InvariantCulture, out var id))
+					{
+						progress.BloodBagIds.Add(id);
+					}
+				}
+			}
+
 			return progress;
 		}
 	}
@@ -381,7 +424,7 @@ public static class HospitalMedicalServiceRunner
 			return true;
 		}
 
-		var args = ServiceProcedureArguments(employee, patient, service, procedureParameters, procedure, false)
+		var args = ServiceProcedureArguments(employee, patient, service, procedureParameters, procedure)
 			.ToArray();
 		return procedure.CanPerformProcedure(employee, patient, args);
 	}
@@ -491,7 +534,7 @@ public static class HospitalMedicalServiceRunner
 
 		if (!result.Success)
 		{
-			CleanupBloodWorkflowForTerminalRequest(context, employee, request);
+			CleanupBloodWorkflowForTerminalRequest(context, employee, request, result.Progress);
 			FailRequest(request, result.Message);
 			AnnounceRequestFailed(employee, request, result.Message);
 			HospitalPatientFlow.TransferAfterFailedTreatment(hospital, request, employee,
@@ -519,15 +562,26 @@ public static class HospitalMedicalServiceRunner
 	public static bool CleanupBloodWorkflowForTerminalRequest(IEmploymentTaskContext context, ICharacter employee,
 		IHospitalServiceRequest request)
 	{
-		var progress = HospitalTreatmentProgress.FromPayload(CurrentOperationalPayload(context), request);
-		if (progress.BloodWorkflow is null || request.Patient is not { } patient)
+		return CleanupBloodWorkflowForTerminalRequest(context, employee, request, null);
+	}
+
+	private static bool CleanupBloodWorkflowForTerminalRequest(IEmploymentTaskContext context, ICharacter employee,
+		IHospitalServiceRequest request, HospitalTreatmentProgress? progress)
+	{
+		progress ??= HospitalTreatmentProgress.FromPayload(CurrentOperationalPayload(context), request);
+		var bagIds = progress.TrackedBloodBagIds();
+		if (!bagIds.Any())
 		{
-			return ReturnBloodBagsToSupplyRoom(context, employee, request) > 0;
+			return false;
 		}
 
-		NeutralizeBloodWorkflowGear(context, employee, patient, request, progress.BloodWorkflow);
-		RemoveHospitalInsertedCannula(employee, patient, progress.BloodWorkflow);
-		ReturnBloodBagsToSupplyRoom(context, employee, request);
+		if (progress.BloodWorkflow is not null && request.Patient is { } patient)
+		{
+			NeutralizeBloodWorkflowGear(context, employee, patient, request, progress.BloodWorkflow);
+			RemoveHospitalInsertedCannula(employee, patient, progress.BloodWorkflow);
+		}
+
+		ReturnBloodBagsToSupplyRoom(context, employee, request, bagIds);
 		context.RecordRegister(EmploymentRegisterEntryType.AuditActionRecorded, employee,
 			$"Cleaned up IV blood workflow gear for hospital request #{request.Id.ToString("N0", CultureInfo.InvariantCulture)} after terminal interruption.",
 			CurrentCorrelationId(context));
@@ -535,7 +589,7 @@ public static class HospitalMedicalServiceRunner
 	}
 
 	public static bool CleanupBloodWorkflowForTerminalRequest(IHospital hospital, IHospitalServiceRequest request,
-		IEmploymentActiveTask? task, ICharacter employee)
+		IEmploymentActiveTask? task)
 	{
 		if (task is not EmploymentActiveTask concrete)
 		{
@@ -550,7 +604,8 @@ public static class HospitalMedicalServiceRunner
 
 		var context = new EmploymentTaskContext(hospital);
 		context.HydrateTaskState(task, index);
-		return CleanupBloodWorkflowForTerminalRequest(context, employee, request);
+		return concrete.AssignedEmployee is not null &&
+		       CleanupBloodWorkflowForTerminalRequest(context, concrete.AssignedEmployee, request);
 	}
 
 	private static EmploymentActionStepResult CompletedStep(IHospitalServiceRequest request, string message)
@@ -591,7 +646,7 @@ public static class HospitalMedicalServiceRunner
 			? result.Message
 			: $"{result.Message}\n{billingMessage}";
 		request.MarkStatus(HospitalServiceRequestStatus.Completed, completionMessage);
-		ReturnBloodBagsToSupplyRoom(context, employee, request);
+		ReturnBloodBagsToSupplyRoom(context, employee, request, result.Progress?.TrackedBloodBagIds() ?? []);
 		context.RecordRegister(EmploymentRegisterEntryType.AuditActionRecorded, employee,
 			$"Completed hospital service request #{request.Id.ToString("N0", CultureInfo.InvariantCulture)}: {completionMessage}",
 			CurrentCorrelationId(context));
@@ -1307,7 +1362,7 @@ public static class HospitalMedicalServiceRunner
 				               return true;
 			               }
 
-			               var args = ServiceProcedureArguments(employee, patient, service, procedureParameters, x, false)
+				               var args = ServiceProcedureArguments(employee, patient, service, procedureParameters, x)
 				               .ToArray();
 			               return x.CanPerformProcedure(employee, patient, args);
 		               });
@@ -1333,12 +1388,38 @@ public static class HospitalMedicalServiceRunner
 			}
 		}
 
-		var args = ServiceProcedureArguments(employee, patient, request, procedure, true).ToArray();
-		var suppliedImplant = ServiceSuppliedImplant(employee, service, args);
-		if (!TryBeginTrackedProcedure(context, employee, patient, hospital, request, procedure, args, suppliedImplant,
-			out var reason))
+
+		var arguments = ServiceProcedureArguments(employee, patient, request, procedure).ToList();
+		IGameItem? suppliedImplant = null;
+		if (UsesServiceSuppliedImplant(service))
 		{
-			return new ServiceExecutionResult(false, reason, string.Empty);
+			if (!TryCreateServiceSuppliedImplant(employee, service, out suppliedImplant, out var creationReason))
+			{
+				return new ServiceExecutionResult(false, creationReason, string.Empty);
+			}
+
+			if (suppliedImplant is null)
+			{
+				return new ServiceExecutionResult(false, "The configured implant could not be prepared.", string.Empty);
+			}
+
+			arguments.Insert(0, HeldItemSelector(employee, suppliedImplant));
+		}
+
+		var args = arguments.ToArray();
+		try
+		{
+			if (!TryBeginTrackedProcedure(context, employee, patient, hospital, request, procedure, args, suppliedImplant,
+				    out var reason))
+			{
+				DeleteUnstartedServiceSuppliedImplant(suppliedImplant);
+				return new ServiceExecutionResult(false, reason, string.Empty);
+			}
+		}
+		catch
+		{
+			DeleteUnstartedServiceSuppliedImplant(suppliedImplant);
+			throw;
 		}
 
 		return new ServiceExecutionResult(true,
@@ -1815,9 +1896,10 @@ public static class HospitalMedicalServiceRunner
 	}
 
 	internal static int ReturnBloodBagsToSupplyRoom(IEmploymentTaskContext context, ICharacter employee,
-		IHospitalServiceRequest request)
+		IHospitalServiceRequest request, IReadOnlyCollection<long> bagIds)
 	{
 		if (request.Service.ServiceType is not (HospitalServiceType.BloodDonation or HospitalServiceType.BloodTransfusion or HospitalServiceType.Stabilisation or HospitalServiceType.FullTreatment) ||
+		    !bagIds.Any() ||
 		    request.OperatingTheatreCellId is not { } theatreId ||
 		    request.Hospital.OperatingTheatres.FirstOrDefault(x => x.Id == theatreId) is not { } theatre ||
 		    request.Hospital.SupplyRooms.FirstOrDefault() is not { } supplyRoom ||
@@ -1827,6 +1909,7 @@ public static class HospitalMedicalServiceRunner
 		}
 
 		var bags = CandidateHospitalItems(context, employee, request)
+			.Where(x => bagIds.Contains(x.Id))
 			.Where(x => IsIvCapableLiquidContainerItem(x, "drain") &&
 			            IsIvCapableLiquidContainerItem(x, "drip"))
 			.Where(x => x.GetItemTypes<IConnectable>().All(y => !y.ConnectedItems.Any()))
@@ -2001,6 +2084,7 @@ public static class HospitalMedicalServiceRunner
 				if (!TryBeginTrackedProcedure(context, employee, patient, request.Hospital, request, procedure, args, null,
 					out message))
 				{
+					progress.RememberBloodBags(workflow);
 					progress.BloodWorkflow = null;
 					failures.Add(message);
 					continue;
@@ -2278,6 +2362,7 @@ public static class HospitalMedicalServiceRunner
 		                                          CharacterInstanceIdentityComparer.SamePhysicalInstance(x.Patient, patient));
 		if (effect is not null)
 		{
+			effect.HospitalRequestId = request.Id;
 			effect.OnProcedureResolved = (_, completed, outcome) => ResolveStagedProcedure(context, employee, hospital,
 				request, procedure, completed, outcome, suppliedImplant);
 		}
@@ -2438,16 +2523,39 @@ public static class HospitalMedicalServiceRunner
 		return true;
 	}
 
-	private static IGameItem? ServiceSuppliedImplant(ICharacter employee, IHospitalService service, object[] args)
+	private static bool UsesServiceSuppliedImplant(IHospitalService service)
 	{
-		if (service.ServiceType is not (HospitalServiceType.ImplantProcedure or HospitalServiceType.InstallImplant) ||
-		    service.ImplantItemPrototype is null ||
-		    args.FirstOrDefault() is not string selector)
+		return (service.ServiceType is HospitalServiceType.ImplantProcedure or HospitalServiceType.InstallImplant) &&
+		       service.ImplantItemPrototype is not null;
+	}
+
+	private static bool TryCreateServiceSuppliedImplant(ICharacter employee, IHospitalService service,
+		out IGameItem? implant, out string reason)
+	{
+		implant = null;
+		reason = string.Empty;
+		if (!UsesServiceSuppliedImplant(service))
 		{
-			return null;
+			return true;
 		}
 
-		return employee.TargetHeldItem(selector);
+		var created = service.ImplantItemPrototype!.CreateNew(employee);
+		employee.Gameworld.Add(created);
+		if (!employee.Body.CanGet(created, 0, ItemCanGetIgnore.IgnoreWeight))
+		{
+			created.Delete();
+			reason = $"{employee.HowSeen(employee, true)} cannot safely hold the service-supplied implant.";
+			return false;
+		}
+
+		employee.Body.Get(created, silent: true, ignoreFlags: ItemCanGetIgnore.IgnoreWeight);
+		implant = created;
+		return true;
+	}
+
+	private static void DeleteUnstartedServiceSuppliedImplant(IGameItem? implant)
+	{
+		implant?.Delete();
 	}
 
 	private static ImplantPipelineResolution TryBeginNextImplantPipelineStep(IEmploymentTaskContext context,
@@ -2771,6 +2879,7 @@ public static class HospitalMedicalServiceRunner
 		workflow.UsedContainerIds.Add(container.Parent.Id);
 		if (workflow.CompletedLitres <= BloodWorkflowToleranceLitres)
 		{
+			progress.RememberBloodBags(workflow);
 			progress.BloodWorkflow = null;
 			progress.ActivePhase = null;
 			return new ServiceExecutionResult(false, "No blood was collected before the donation workflow stopped.",
@@ -2781,6 +2890,7 @@ public static class HospitalMedicalServiceRunner
 		{
 			if (!TryBeginBloodDecannulation(context, employee, donor, request, progress, workflow, out var decannulationMessage))
 			{
+				progress.RememberBloodBags(workflow);
 				progress.BloodWorkflow = null;
 				progress.ActivePhase = null;
 				return new ServiceExecutionResult(false, decannulationMessage, string.Empty, Progress: progress);
@@ -2801,6 +2911,7 @@ public static class HospitalMedicalServiceRunner
 		{
 			if (!TryBeginBloodCannulation(context, employee, donor, request, progress, workflow, out var cannulationMessage))
 			{
+				progress.RememberBloodBags(workflow);
 				progress.BloodWorkflow = null;
 				progress.ActivePhase = null;
 				return new ServiceExecutionResult(false, cannulationMessage, string.Empty, Progress: progress);
@@ -2819,6 +2930,7 @@ public static class HospitalMedicalServiceRunner
 		if (container is null)
 		{
 			RemoveHospitalInsertedCannula(employee, donor, workflow);
+			progress.RememberBloodBags(workflow);
 			progress.BloodWorkflow = null;
 			progress.ActivePhase = null;
 			return new ServiceExecutionResult(false,
@@ -2830,6 +2942,7 @@ public static class HospitalMedicalServiceRunner
 			out var message))
 		{
 			RemoveHospitalInsertedCannula(employee, donor, workflow);
+			progress.RememberBloodBags(workflow);
 			progress.BloodWorkflow = null;
 			progress.ActivePhase = null;
 			return new ServiceExecutionResult(false, message, string.Empty, Progress: progress);
@@ -2861,6 +2974,7 @@ public static class HospitalMedicalServiceRunner
 		progress.ActivePhase = null;
 		progress.ActiveExpectedCount = 0;
 		progress.CompletedPhases.Add(BloodDonationPhase);
+		progress.RememberBloodBags(workflow);
 		progress.BloodWorkflow = null;
 		employee.OutputHandler.Send(new EmoteOutput(new Emote(
 			"@ finish|finishes drawing blood from $0 and secure|secures the IV collection gear.", employee, donor)));
@@ -3055,6 +3169,7 @@ public static class HospitalMedicalServiceRunner
 				if (!TryBeginBloodDecannulation(context, employee, recipient, request, progress, workflow,
 					out var decannulationMessage))
 				{
+					progress.RememberBloodBags(workflow);
 					progress.BloodWorkflow = null;
 					progress.ActivePhase = null;
 					return new ServiceExecutionResult(false, decannulationMessage, string.Empty, Progress: progress);
@@ -3080,6 +3195,7 @@ public static class HospitalMedicalServiceRunner
 		var nextContainer = NextTransfusionContainer(context, employee, request, recipient, workflow);
 		if (nextContainer is null)
 		{
+			progress.RememberBloodBags(workflow);
 			progress.BloodWorkflow = null;
 			progress.ActivePhase = null;
 			return new ServiceExecutionResult(false,
@@ -3090,6 +3206,7 @@ public static class HospitalMedicalServiceRunner
 		if (!TryPrepareBloodIvCircuit(context, employee, recipient, request, progress, workflow, nextContainer, "drip",
 			out var nextMessage))
 		{
+			progress.RememberBloodBags(workflow);
 			progress.BloodWorkflow = null;
 			progress.ActivePhase = null;
 			return new ServiceExecutionResult(false, nextMessage, string.Empty, Progress: progress);
@@ -3108,6 +3225,7 @@ public static class HospitalMedicalServiceRunner
 		{
 			if (!TryBeginBloodCannulation(context, employee, recipient, request, progress, workflow, out var cannulationMessage))
 			{
+				progress.RememberBloodBags(workflow);
 				progress.BloodWorkflow = null;
 				progress.ActivePhase = null;
 				return new ServiceExecutionResult(false, cannulationMessage, string.Empty, Progress: progress);
@@ -3124,6 +3242,7 @@ public static class HospitalMedicalServiceRunner
 		if (container is null)
 		{
 			RemoveHospitalInsertedCannula(employee, recipient, workflow);
+			progress.RememberBloodBags(workflow);
 			progress.BloodWorkflow = null;
 			progress.ActivePhase = null;
 			return new ServiceExecutionResult(false,
@@ -3136,6 +3255,7 @@ public static class HospitalMedicalServiceRunner
 		if (!TryPrepareBloodIvCircuit(context, employee, recipient, request, progress, workflow, container, "drip",
 			out var message))
 		{
+			progress.RememberBloodBags(workflow);
 			progress.BloodWorkflow = null;
 			progress.ActivePhase = null;
 			return new ServiceExecutionResult(false, message, string.Empty, Progress: progress);
@@ -3154,6 +3274,7 @@ public static class HospitalMedicalServiceRunner
 		progress.ActivePhase = null;
 		progress.ActiveExpectedCount = 0;
 		progress.CompletedPhases.Add(BloodTransfusionPhase);
+		progress.RememberBloodBags(workflow);
 		progress.BloodWorkflow = null;
 		var amountLitres = Math.Min(workflow.TargetLitres, workflow.CompletedLitres);
 		employee.OutputHandler.Send(new EmoteOutput(new Emote(
@@ -3263,34 +3384,14 @@ public static class HospitalMedicalServiceRunner
 	}
 
 	private static IEnumerable<object> ServiceProcedureArguments(ICharacter employee, ICharacter patient,
-		IHospitalServiceRequest request, ISurgicalProcedure procedure, bool createServiceSuppliedItem)
+		IHospitalServiceRequest request, ISurgicalProcedure procedure)
 	{
-		return ServiceProcedureArguments(employee, patient, request.Service, request.ProcedureParameters, procedure,
-			createServiceSuppliedItem);
+		return ServiceProcedureArguments(employee, patient, request.Service, request.ProcedureParameters, procedure);
 	}
 
 	private static IEnumerable<object> ServiceProcedureArguments(ICharacter employee, ICharacter patient,
-		IHospitalService service, string? procedureParameters, ISurgicalProcedure procedure, bool createServiceSuppliedItem)
+		IHospitalService service, string? procedureParameters, ISurgicalProcedure procedure)
 	{
-		if (service.ImplantItemPrototype is not null && createServiceSuppliedItem)
-		{
-			var implant = service.ImplantItemPrototype.CreateNew(employee);
-			employee.Gameworld.Add(implant);
-			if (employee.Body.CanGet(implant, 0, ItemCanGetIgnore.IgnoreWeight))
-			{
-				employee.Body.Get(implant, silent: true, ignoreFlags: ItemCanGetIgnore.IgnoreWeight);
-			}
-			else
-			{
-				if (employee.Location is not null)
-				{
-					implant.InsertAtSource(employee, true);
-				}
-			}
-
-			yield return HeldItemSelector(employee, implant);
-		}
-
 		var parameterText = string.IsNullOrWhiteSpace(procedureParameters)
 			? service.ProcedureParameters
 			: procedureParameters;

--- a/MudSharpCore/Economy/Hospitals/HospitalPatientFlow.cs
+++ b/MudSharpCore/Economy/Hospitals/HospitalPatientFlow.cs
@@ -373,17 +373,36 @@ public static class HospitalPatientFlow
 	public static bool IsTheatreAvailable(IHospital hospital, IHospitalServiceRequest request, ICell theatre,
 		out string reason)
 	{
+		return IsTheatreAvailable(hospital, theatre, candidate => !IsSameRequest(candidate, request),
+			occupant => IsRequestPatient(request, occupant), out reason);
+	}
+
+	/// <summary>
+	/// Checks whether a theatre can accept a new hospital request before that request has been created. This must
+	/// use the same reservation and occupant checks as the task runner, without mutating a request merely to test
+	/// availability.
+	/// </summary>
+	public static bool IsTheatreAvailableForNewRequest(IHospital hospital, ICharacter? patient, ICell theatre,
+		out string reason)
+	{
+		return IsTheatreAvailable(hospital, theatre, _ => true,
+			occupant => IsRequestPatient(patient, occupant), out reason);
+	}
+
+	private static bool IsTheatreAvailable(IHospital hospital, ICell theatre,
+		Func<IHospitalServiceRequest, bool> isConflictingRequest, Func<ICharacter, bool> isRequestPatient,
+		out string reason)
+	{
 		var conflictingRequest = (hospital.ActiveServiceRequests ?? Array.Empty<IHospitalServiceRequest>())
 		                                 .FirstOrDefault(x =>
-			                                 !IsSameRequest(x, request) &&
-			                                 x.OperatingTheatreCellId == theatre.Id);
+			                                 isConflictingRequest(x) && x.OperatingTheatreCellId == theatre.Id);
 		if (conflictingRequest is not null)
 		{
 			reason = $"Operating theatre {theatre.Name} is already reserved for active hospital request #{conflictingRequest.Id.ToString("N0")}.";
 			return false;
 		}
 
-		if ((theatre.Characters ?? Array.Empty<ICharacter>()).Any(x => !x.IsAdministrator() && !hospital.IsEmployee(x) && !IsRequestPatient(request, x)))
+		if ((theatre.Characters ?? Array.Empty<ICharacter>()).Any(x => !x.IsAdministrator() && !hospital.IsEmployee(x) && !isRequestPatient(x)))
 		{
 			reason = $"Operating theatre {theatre.Name} is occupied by someone unrelated to this request.";
 			return false;
@@ -416,6 +435,13 @@ public static class HospitalPatientFlow
 
 		return request.PatientId > 0 &&
 		       CharacterInstanceIdentityComparer.IdentityId(occupant) == request.PatientId;
+	}
+
+	private static bool IsRequestPatient(ICharacter? patient, ICharacter occupant)
+	{
+		return patient is not null &&
+		       (CharacterInstanceIdentityComparer.SamePhysicalInstance(occupant, patient) ||
+		        CharacterInstanceIdentityComparer.SameIdentity(occupant, patient));
 	}
 
 	private static void MoveCharacter(ICharacter character, ICell destination)

--- a/MudSharpCore/Economy/Hospitals/HospitalService.cs
+++ b/MudSharpCore/Economy/Hospitals/HospitalService.cs
@@ -24,6 +24,7 @@ public class HospitalService : SavableKeywordedItem, IHospitalService
 	private bool _allowDebt;
 	private bool _preferOperatingTheatre;
 	private HospitalServiceOfferingMode _offeringMode;
+	private HospitalServiceConsentPolicy _consentPolicy;
 	private int _sortOrder;
 	private long? _surgicalProcedureId;
 	private ISurgicalProcedure? _surgicalProcedure;
@@ -57,6 +58,7 @@ public class HospitalService : SavableKeywordedItem, IHospitalService
 		_allowDebt = true;
 		_preferOperatingTheatre = DefaultPreferOperatingTheatre(serviceType);
 		_offeringMode = HospitalServiceOfferingMode.StandaloneAndCombined;
+		_consentPolicy = DefaultConsentPolicy(serviceType);
 		_sortOrder = hospital.Services.Any() ? hospital.Services.Max(x => x.SortOrder) + 1 : 0;
 		_procedureParameters = string.Empty;
 		_bloodVolumeLitres = 0.5;
@@ -77,6 +79,7 @@ public class HospitalService : SavableKeywordedItem, IHospitalService
 				AllowDebt = true,
 				PreferOperatingTheatre = _preferOperatingTheatre,
 				OfferingMode = (int)_offeringMode,
+				ConsentPolicy = (int)_consentPolicy,
 				SortOrder = _sortOrder,
 				ProcedureParameters = string.Empty,
 				RequiredEquipmentJson = "[]",
@@ -106,6 +109,9 @@ public class HospitalService : SavableKeywordedItem, IHospitalService
 		_offeringMode = Enum.IsDefined(typeof(HospitalServiceOfferingMode), service.OfferingMode)
 			? (HospitalServiceOfferingMode)service.OfferingMode
 			: HospitalServiceOfferingMode.StandaloneAndCombined;
+		_consentPolicy = Enum.IsDefined(typeof(HospitalServiceConsentPolicy), service.ConsentPolicy)
+			? (HospitalServiceConsentPolicy)service.ConsentPolicy
+			: DefaultConsentPolicy(_serviceType);
 		_sortOrder = service.SortOrder;
 		_surgicalProcedureId = service.SurgicalProcedureId;
 		_implantItemPrototypeId = service.ImplantItemPrototypeId;
@@ -197,6 +203,16 @@ public class HospitalService : SavableKeywordedItem, IHospitalService
 		set
 		{
 			_offeringMode = value;
+			Changed = true;
+		}
+	}
+
+	public HospitalServiceConsentPolicy ConsentPolicy
+	{
+		get => _consentPolicy;
+		set
+		{
+			_consentPolicy = value;
 			Changed = true;
 		}
 	}
@@ -413,6 +429,7 @@ public class HospitalService : SavableKeywordedItem, IHospitalService
 		dbitem.AllowDebt = AllowDebt;
 		dbitem.PreferOperatingTheatre = PreferOperatingTheatre;
 		dbitem.OfferingMode = (int)OfferingMode;
+		dbitem.ConsentPolicy = (int)ConsentPolicy;
 		dbitem.SortOrder = SortOrder;
 		dbitem.SurgicalProcedureId = SurgicalProcedure?.Id;
 		dbitem.ImplantItemPrototypeId = ImplantItemPrototype?.Id;
@@ -442,6 +459,7 @@ public class HospitalService : SavableKeywordedItem, IHospitalService
 		sb.AppendLine($"Allow Debt: {(HospitalServiceBilling.IsDonorPaidServiceType(ServiceType) ? "not applicable".ColourValue() : AllowDebt.ToColouredString())}");
 		sb.AppendLine($"Prefer Theatre: {PreferOperatingTheatre.ToColouredString()}");
 		sb.AppendLine($"Offering Mode: {OfferingMode.DescribeEnum().ColourName()}");
+		sb.AppendLine($"Consent Policy: {ConsentPolicy.DescribeEnum().ColourName()}");
 		sb.AppendLine($"Requires Recovery: {RequiresRecovery.ToColouredString()}");
 		sb.AppendLine($"Blood Volume: {BloodVolumeLitres.ToString("N2", actor).ColourValue()}L");
 		sb.AppendLine($"Sort Order: {SortOrder.ToString("N0", actor).ColourValue()}");
@@ -492,6 +510,13 @@ public class HospitalService : SavableKeywordedItem, IHospitalService
 			HospitalServiceType.BoneSetting or HospitalServiceType.BloodDonation or HospitalServiceType.BloodTransfusion or
 			HospitalServiceType.Stabilisation or HospitalServiceType.FullTreatment ||
 			HospitalMedicalServiceRunner.ServiceTypeToSurgicalProcedureType(serviceType) is not null;
+	}
+
+	private static HospitalServiceConsentPolicy DefaultConsentPolicy(HospitalServiceType serviceType)
+	{
+		return serviceType == HospitalServiceType.Stabilisation
+			? HospitalServiceConsentPolicy.EmergencyPresumedConsent
+			: HospitalServiceConsentPolicy.InformedConsentRequired;
 	}
 
 	private static bool DefaultRequiresRecovery(HospitalServiceType serviceType)

--- a/MudSharpCore/Economy/Hospitals/HospitalServiceAvailability.cs
+++ b/MudSharpCore/Economy/Hospitals/HospitalServiceAvailability.cs
@@ -75,6 +75,16 @@ public static class HospitalServiceAvailability
 			return Unavailable(transfusionReason);
 		}
 
+		var requiresSupplyPreparation = HospitalSupplyPreparationActionStep.RequiresSupplyPreparation(hospital, service,
+			patient, out var treatmentLocations);
+		var suppliesAlreadyStaged = HospitalSupplyPreparationActionStep.TreatmentLocationSuppliesAreReady(hospital,
+			service, patient, treatmentLocations);
+		if ((requiresSupplyPreparation || !suppliesAlreadyStaged) &&
+		    !TryGetAvailableSupplyEmployee(hospital, service, patient, treatmentLocations, out var supplyReason))
+		{
+			return Unavailable(supplyReason);
+		}
+
 		return new HospitalServiceAvailabilityResult(true, string.Empty);
 	}
 
@@ -121,6 +131,46 @@ public static class HospitalServiceAvailability
 		return false;
 	}
 
+	private static bool TryGetAvailableSupplyEmployee(IHospital hospital, IHospitalService service,
+		ICharacter? patient, IReadOnlyCollection<ICell> treatmentLocations, out string reason)
+	{
+		var contracts = hospital.EmploymentContracts ?? Array.Empty<IEmploymentContract>();
+		var activeTasks = hospital.TaskBoard?.ActiveTasks ?? Array.Empty<IEmploymentActiveTask>();
+		var context = new EmploymentTaskContext(hospital, usePhysicalItemMovement: true);
+		foreach (var contract in contracts.Where(x =>
+			         x.Status == EmploymentStatus.Active &&
+			         x.Authority.Contains(EmploymentAuthority.PrepareMedicalSupplies)))
+		{
+			var candidate = contract.Employee;
+			if (!CharacterState.Able.HasFlag(candidate.State) || candidate.Location is null ||
+			    !CanPrepareHospitalSupplies(hospital, candidate))
+			{
+				continue;
+			}
+
+			var employeeId = CharacterInstanceIdentityComparer.IdentityId(candidate);
+			if (activeTasks.Any(x =>
+				    CharacterInstanceIdentityComparer.IdentityId(x.AssignedEmployee) == employeeId &&
+				    x.Status is EmploymentTaskStatus.Assigned or EmploymentTaskStatus.InProgress or
+					    EmploymentTaskStatus.Blocked))
+			{
+				continue;
+			}
+
+			if (!HospitalSupplyPreparationActionStep.CanPrepareRequiredSupplies(hospital, service, patient,
+				candidate, treatmentLocations, context, out _))
+			{
+				continue;
+			}
+
+			reason = string.Empty;
+			return true;
+		}
+
+		reason = "no hospital supply employee available to prepare required supplies";
+		return false;
+	}
+
 	private static bool CanFundDonationPayout(IHospital hospital, IHospitalService service, ICharacter? donor,
 		out string reason)
 	{
@@ -152,9 +202,24 @@ public static class HospitalServiceAvailability
 		return npc.AIs
 		          .OfType<EmploymentWorkerAI>()
 		          .Any(x =>
+		          x.TaskingEnabled &&
+		          (x.HostTypeFilter is null || x.HostTypeFilter.Value == hospital.EmploymentHostType) &&
+		          x.Capabilities.Contains(EmploymentAICapability.CanPerformMedicalServices));
+	}
+
+	private static bool CanPrepareHospitalSupplies(IHospital hospital, ICharacter employee)
+	{
+		if (employee is not INPC npc)
+		{
+			return false;
+		}
+
+		return npc.AIs
+		          .OfType<EmploymentWorkerAI>()
+		          .Any(x =>
 			          x.TaskingEnabled &&
 			          (x.HostTypeFilter is null || x.HostTypeFilter.Value == hospital.EmploymentHostType) &&
-			          x.Capabilities.Contains(EmploymentAICapability.CanPerformMedicalServices));
+			          x.Capabilities.Contains(EmploymentAICapability.CanPrepareHospitalSupplies));
 	}
 
 	private static bool TryFindRequiredEquipmentBundle(IHospital hospital, IHospitalService service, ICharacter? actor,

--- a/MudSharpCore/Effects/Concrete/SurgicalProcedureEffect.cs
+++ b/MudSharpCore/Effects/Concrete/SurgicalProcedureEffect.cs
@@ -36,6 +36,7 @@ public class SurgicalProcedureEffect : StagedCharacterActionWithTarget
     public ICharacter Surgeon { get; set; }
     public ICharacter Patient { get; set; }
     public object[] AdditionalArguments { get; set; }
+    public long? HospitalRequestId { get; set; }
     public Action<SurgicalProcedureEffect, bool, CheckOutcome>? OnProcedureResolved { get; set; }
     public override bool CanBeStoppedByPlayer => true;
 

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextHospitals.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextHospitals.cs
@@ -128,6 +128,7 @@ public partial class FuturemudDatabaseContext
 			entity.Property(e => e.AllowDebt).HasColumnType("bit(1)").HasDefaultValue(true);
 			entity.Property(e => e.PreferOperatingTheatre).HasColumnType("bit(1)").HasDefaultValue(false);
 			entity.Property(e => e.OfferingMode).HasColumnType("int(11)").HasDefaultValue(0);
+			entity.Property(e => e.ConsentPolicy).HasColumnType("int(11)").HasDefaultValue(0);
 			entity.Property(e => e.SortOrder).HasColumnType("int(11)");
 			entity.Property(e => e.SurgicalProcedureId).HasColumnType("bigint(20)");
 			entity.Property(e => e.ImplantItemPrototypeId).HasColumnType("bigint(20)");

--- a/MudsharpDatabaseLibrary/Migrations/20260816012516_HospitalServiceConsentPolicy.Designer.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260816012516_HospitalServiceConsentPolicy.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MudSharp.Database;
 
@@ -11,9 +12,11 @@ using MudSharp.Database;
 namespace MudSharp.Migrations
 {
     [DbContext(typeof(FuturemudDatabaseContext))]
-    partial class FutureMUDContextModelSnapshot : ModelSnapshot
+    [Migration("20260816012516_HospitalServiceConsentPolicy")]
+    partial class HospitalServiceConsentPolicy
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MudsharpDatabaseLibrary/Migrations/20260816012516_HospitalServiceConsentPolicy.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260816012516_HospitalServiceConsentPolicy.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MudSharp.Migrations
+{
+    /// <inheritdoc />
+    public partial class HospitalServiceConsentPolicy : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+			// HospitalServiceType.Stabilisation is persisted as 10.
+            migrationBuilder.AddColumn<int>(
+                name: "ConsentPolicy",
+                table: "HospitalServices",
+                type: "int(11)",
+                nullable: false,
+                defaultValue: 0);
+
+			migrationBuilder.Sql("UPDATE `HospitalServices` SET `ConsentPolicy` = 1 WHERE `ServiceType` = 10;");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ConsentPolicy",
+                table: "HospitalServices");
+        }
+    }
+}

--- a/MudsharpDatabaseLibrary/Models/Hospital.cs
+++ b/MudsharpDatabaseLibrary/Models/Hospital.cs
@@ -55,6 +55,7 @@ public class HospitalService
 	public bool AllowDebt { get; set; }
 	public bool PreferOperatingTheatre { get; set; }
 	public int OfferingMode { get; set; }
+	public int ConsentPolicy { get; set; }
 	public int SortOrder { get; set; }
 	public long? SurgicalProcedureId { get; set; }
 	public long? ImplantItemPrototypeId { get; set; }


### PR DESCRIPTION
## Summary

- Add hospital service consent policy support for implant and surgical procedures.
- Improve hospital patient flow, service availability, medical execution, and employment dispatch handling.
- Update hospital interfaces, database models, migration snapshots, blank database artifacts, and economy, health, and item-system documentation.
- Add regression coverage for unified employment dispatch behavior.

## Testing

- Added/updated unit test coverage for unified employment dispatch.
- Not run (not requested)