### PR TITLE
Preserve perceivable inputs for variable craft progs

### DIFF
--- a/Design Documents/Crafting/Crafting_System_Runtime_and_Extensibility.md
+++ b/Design Documents/Crafting/Crafting_System_Runtime_and_Extensibility.md
@@ -431,7 +431,7 @@ Subtype-specific prog use also exists in products such as:
 - `ProgVariableProduct`
 - `NPCProduct`
 
-`ProgVariableProduct` supplies its variable progs with consumed inputs in the craft's configured input order. Single inputs remain single entries, while perceivable groups are expanded to their members. A prog accepting a collection of perceivables receives every individual consumed perceivable; a prog accepting a collection of items receives only consumed game items. Input selection uses the prog's current `MatchesParameters` contract, so a later builder edit to a referenced prog's signature cannot cause craft completion to assume a singleton parameter list; the product's validity check reports a no-longer-matching signature for correction.
+`ProgVariableProduct` supplies its variable progs with consumed inputs in the craft's configured input order. Single inputs remain single entries, while perceivable groups are expanded to their members. A prog accepting a collection of perceivables receives every individual consumed perceivable; a prog accepting a collection of items receives only consumed game items. Input selection uses a bounded snapshot of the prog's declared parameters, rather than compatibility matching or a singleton assumption, so a later builder edit to the referenced signature cannot cause craft completion to throw or to filter perceivables incorrectly; the product's validity check reports a no-longer-matching signature for correction.
 
 ### Item system integration
 Crafting leans heavily on the item system.

--- a/MudSharpCore Unit Tests/Crafts/ProgVariableProductTests.cs
+++ b/MudSharpCore Unit Tests/Crafts/ProgVariableProductTests.cs
@@ -44,8 +44,7 @@ public class ProgVariableProductTests
 		perceivableProg.SetupGet(x => x.Id).Returns(900);
 		perceivableProg.SetupGet(x => x.Parameters).Returns([ProgVariableTypes.Collection | ProgVariableTypes.Perceivable]);
 		perceivableProg.Setup(x => x.MatchesParameters(It.IsAny<IEnumerable<ProgVariableTypes>>()))
-			.Returns((IEnumerable<ProgVariableTypes> parameters) => parameters.SequenceEqual(
-				[ProgVariableTypes.Collection | ProgVariableTypes.Perceivable]));
+			.Returns(true);
 		perceivableProg.Setup(x => x.ExecuteLong(0L, It.IsAny<object[]>()))
 			.Callback((long _, object[] arguments) =>
 				perceivablesSupplied = ((IEnumerable<IPerceivable>)arguments.Single()).ToArray())

--- a/MudSharpCore/Work/Crafts/Products/ProgVariableProduct.cs
+++ b/MudSharpCore/Work/Crafts/Products/ProgVariableProduct.cs
@@ -192,8 +192,11 @@ namespace MudSharp.Work.Crafts.Products
             List<(ICharacteristicDefinition Definition, ICharacteristicValue Value)> variables = new();
             foreach ((ICharacteristicDefinition definition, IFutureProg prog) in Characteristics)
             {
-                IEnumerable<IPerceivable> inputsForProg = !prog.AcceptsAnyParameters &&
-                                                          prog.MatchesParameters(ItemCollectionParameters)
+                ProgVariableTypes[] parameters = prog.AcceptsAnyParameters
+                    ? []
+                    : prog.Parameters.Take(2).ToArray();
+                IEnumerable<IPerceivable> inputsForProg = parameters.Length == 1 &&
+                                                          parameters[0] == ItemCollectionParameters[0]
                     ? consumedInputs.OfType<IGameItem>()
                     : consumedInputs;
                 ICharacteristicValue value = Gameworld.CharacteristicValues.Get(prog.ExecuteLong(0L, inputsForProg.ToList()));


### PR DESCRIPTION
## Summary

- Route ProgVariableProduct inputs from the exact declared parameter snapshot instead of compatibility matching.
- Preserve non-item perceivables for Collection|Perceivable progs while keeping mutable zero/multiple signatures safe.
- Add regression coverage and update the crafting runtime documentation.

## Testing

- dotnet test 'MudSharpCore Unit Tests\\MudSharpCore Unit Tests.csproj' -c Debug --no-build --no-restore -m:1 --filter 'FullyQualifiedName~ProgVariableProductTests'
- 2 passed
- git diff --check