### PR TITLE
Add ordinary-item salvageable components

### DIFF
--- a/Design Documents/Items/Item_System_Component_Authoring.md
+++ b/Design Documents/Items/Item_System_Component_Authoring.md
@@ -71,6 +71,24 @@ Terrestrial engines use a separate, extensible `IVehicleEngine` contract. Vehicl
 
 New engine families should implement `IVehicleEngine` and use the shared `IVehicleEnginePrototype` exclusivity interface. Keep fuel chemistry, power storage, steam pressure, magic, or other implementation-specific state inside that component; the vehicle service should continue to aggregate only the common mechanical-power contract.
 
+### Ordinary-item salvage
+
+Use the revisioned `Salvageable` component to opt an ordinary item prototype into the player `salvage` command. This is separate from corpse and severed-bodypart salvage: it does not use races, anatomy, `IButcherable`, decay, skinning, or product subcategories.
+
+The component proto owns the check trait and difficulty, one optional required held-tool tag, ordered timed stage emotes, and explicit products. Builder commands are:
+
+- `trait <trait>` and `difficulty <difficulty>`
+- `tool <tag|none>`
+- `stage add <seconds> <emote>` and `stage remove <number>`
+- `commodity fixed <material> <success weight> <failure weight> [<tag>]`
+- `commodity fraction <material> <success percent> <failure percent> [<tag>]`
+- `item <prototype> <success quantity> <failure quantity> <success chance> <failure chance>`
+- `product remove <number>`
+
+Products are always explicit; source material and description never select them. Both success and failure consume the source after the final stage, with the authored branch controlling reduced failure recovery. The worst-case product mass for each branch must fit the source prototype's base mass (multiplied by stack quantity); item chance does not discount this validation.
+
+The current-instance guard refuses an item that contains liquid or another item, or has any attached or connected item. This ensures deleting the source cannot silently delete independent state. It deliberately does not test size, carryability, fixture status, or movement prevention: component attachment is the definition-level eligibility boundary. The staged action is not saved, so interruption or restart before completion leaves the source intact and creates no products.
+
 Computer-program and signal-automation work should follow the same rule:
 - shared contracts such as `IComputerHost`, `IComputerFileSystem`, `IComputerExecutable`, `ISignalSource`, and `ISignalSink` belong in `FutureMUDLibrary/Computers`
 - broader mutable file-owner contracts such as `IComputerFileOwner` belong in `FutureMUDLibrary/Computers` when item components need to expose files without also exposing executable storage

--- a/Design Documents/Items/Item_System_Component_Authoring.md
+++ b/Design Documents/Items/Item_System_Component_Authoring.md
@@ -79,13 +79,13 @@ The component proto owns the check trait and difficulty, one optional required h
 
 - `trait <trait>` and `difficulty <difficulty>`
 - `tool <tag|none>`
-- `stage add <seconds> <emote>` and `stage remove <number>`
+- `stage add <seconds> <emote>` and `stage remove <number>`; stage emotes use `$0` for the salvager, `$1` for the source and `$2` for the optional held tool
 - `commodity fixed <material> <success weight> <failure weight> [<tag>]`
 - `commodity fraction <material> <success percent> <failure percent> [<tag>]`
 - `item <prototype> <success quantity> <failure quantity> <success chance> <failure chance>`
 - `product remove <number>`
 
-Products are always explicit; source material and description never select them. Both success and failure consume the source after the final stage, with the authored branch controlling reduced failure recovery. The worst-case product mass for each branch must fit the source prototype's base mass (multiplied by stack quantity); item chance does not discount this validation.
+Products are always explicit; source material and description never select them. Both success and failure consume the source after the final stage, with the authored branch controlling reduced failure recovery. The worst-case product mass for each branch must fit the source prototype's base mass (multiplied by stack quantity); item chance does not discount this validation. Product amounts and chances must be finite; fractional outputs and chances are between 0% and 100%, and a salvage action may create at most 100 item products. Product construction is rollback-safe: a failure leaves the source and no partial recovered products.
 
 The current-instance guard refuses an item that contains liquid or another item, or has any attached or connected item. This ensures deleting the source cannot silently delete independent state. It deliberately does not test size, carryability, fixture status, or movement prevention: component attachment is the definition-level eligibility boundary. The staged action is not saved, so interruption or restart before completion leaves the source intact and creates no products.
 

--- a/Design Documents/Items/Item_System_Presentation_and_Integration.md
+++ b/Design Documents/Items/Item_System_Presentation_and_Integration.md
@@ -43,6 +43,8 @@ Components can decorate item descriptions by overriding:
 
 This is how components add behavioural presentation without forcing all description logic into `GameItem` itself.
 
+An ordinary item with the revisioned `Salvageable` component contributes the concise full-description addendum `It can be salvaged.` through this component decorator path. The indication is present only while that component is attached, is not copied into prototype prose, and does not alter short, long, contents, or evaluate descriptions.
+
 Examples include:
 - containers showing fullness, open state, and contents
 - commodity piles replacing the generated short/full description with quantity, commodity characteristics, material, and optional tag; when a functional tag already begins with the material name, the decorator presents it once (`gunpowder commodities`, not `gunpowder gunpowder commodities`)

--- a/FutureMUDLibrary/GameItems/Interfaces/ISalvageable.cs
+++ b/FutureMUDLibrary/GameItems/Interfaces/ISalvageable.cs
@@ -21,5 +21,9 @@ public interface ISalvageable : IGameItemComponent
 	IEnumerable<(string Emote, double Delay)> Stages { get; }
 	bool CanSalvage(out string reason);
 	double MaximumOutputWeight(bool success);
-	IEnumerable<IGameItem> CreateProducts(ICharacter actor, bool success);
+	/// <summary>
+	/// Creates every salvage product eagerly. Implementations must either return the complete set or clean up any
+	/// partially-created products before throwing.
+	/// </summary>
+	IReadOnlyList<IGameItem> CreateProducts(ICharacter actor, bool success);
 }

--- a/FutureMUDLibrary/GameItems/Interfaces/ISalvageable.cs
+++ b/FutureMUDLibrary/GameItems/Interfaces/ISalvageable.cs
@@ -1,0 +1,25 @@
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.Framework;
+using MudSharp.GameItems.Inventory;
+using MudSharp.RPG.Checks;
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace MudSharp.GameItems.Interfaces;
+
+/// <summary>
+/// Marks an ordinary item as explicitly eligible for the item-salvage workflow.
+/// </summary>
+public interface ISalvageable : IGameItemComponent
+{
+	ITraitDefinition Trait { get; }
+	Difficulty Difficulty { get; }
+	ITag? RequiredToolTag { get; }
+	IInventoryPlanTemplate ToolTemplate { get; }
+	IEnumerable<(string Emote, double Delay)> Stages { get; }
+	bool CanSalvage(out string reason);
+	double MaximumOutputWeight(bool success);
+	IEnumerable<IGameItem> CreateProducts(ICharacter actor, bool success);
+}

--- a/FutureMUDLibrary/GameItems/Prototypes/GameItemComponentPrototypeInterfaces.cs
+++ b/FutureMUDLibrary/GameItems/Prototypes/GameItemComponentPrototypeInterfaces.cs
@@ -564,6 +564,10 @@ public interface ISelectablePrototype : IExclusiveGameItemComponentPrototype<ISe
 {
 }
 
+public interface ISalvageablePrototype : IExclusiveGameItemComponentPrototype<ISalvageable>
+{
+}
+
 public interface ISeveredBodypartPrototype : IExclusiveGameItemComponentPrototype<ISeveredBodypart>, IContainerPrototype, IButcherablePrototype
 {
 }

--- a/MudSharpCore Unit Tests/SalvageableComponentTests.cs
+++ b/MudSharpCore Unit Tests/SalvageableComponentTests.cs
@@ -8,6 +8,7 @@ using MudSharp.Commands.Modules;
 using MudSharp.Effects;
 using MudSharp.Effects.Concrete;
 using MudSharp.Form.Material;
+using MudSharp.Form.Shape;
 using MudSharp.Framework;
 using MudSharp.Framework.Revision;
 using MudSharp.GameItems;
@@ -30,6 +31,51 @@ namespace MudSharp_Unit_Tests;
 [TestClass]
 public class SalvageableComponentTests
 {
+	[DataTestMethod]
+	[DataRow(false)]
+	[DataRow(true)]
+	public void FullDescriptionDecoration_LifecycleAndMovementVariants_AddOneStableDisclosure(bool preventsMovement)
+	{
+		var fixture = CreateFixture();
+		var proto = (SalvageableGameItemComponentProto)new GameItemComponentManager()
+			.GetProto(CreateDatabaseProto(), fixture.Gameworld.Object);
+		var parent = CreateParent(fixture.Gameworld.Object, 10.0);
+		parent.Setup(x => x.PreventsMovement()).Returns(preventsMovement);
+		var component = (SalvageableGameItemComponent)proto.CreateNew(
+			parent.Object, temporary: true);
+		var copy = (SalvageableGameItemComponent)component.Copy(
+			CreateParent(fixture.Gameworld.Object, 10.0).Object, temporary: true);
+		var loaded = (SalvageableGameItemComponent)proto.LoadComponent(
+			new DbGameItemComponent { Id = 99, Definition = "<Definition />" },
+			CreateParent(fixture.Gameworld.Object, 10.0).Object);
+		var voyeur = Mock.Of<IPerceiver>();
+		const string baseDescription = "This is an otherwise identical test item.";
+
+		Assert.IsTrue(component.DescriptionDecorator(DescriptionType.Full));
+		Assert.IsFalse(component.DescriptionDecorator(DescriptionType.Short));
+		Assert.IsFalse(component.DescriptionDecorator(DescriptionType.Long));
+		Assert.IsFalse(component.DescriptionDecorator(DescriptionType.Evaluate));
+
+		string Render(params IGameItemComponent[] components) => components
+			.Where(x => x.DescriptionDecorator(DescriptionType.Full))
+			.OrderBy(x => x.DecorationPriority)
+			.Aggregate(baseDescription, (current, decorator) => decorator.Decorate(voyeur, "test item", current,
+				DescriptionType.Full, colour: false, PerceiveIgnoreFlags.None));
+
+		Assert.AreEqual(baseDescription, Render());
+		foreach (var candidate in new[] { component, copy, loaded })
+		{
+			var firstRender = Render(candidate);
+			var repeatedRender = Render(candidate);
+
+			Assert.AreEqual($"{baseDescription}\n\nIt can be salvaged.", firstRender);
+			Assert.AreEqual(firstRender, repeatedRender);
+			Assert.AreEqual(1, firstRender.Split("It can be salvaged.").Length - 1);
+		}
+
+		parent.Verify(x => x.PreventsMovement(), Times.Never);
+	}
+
 	[TestMethod]
 	public void ComponentRegistrationXmlCopyAndLoad_PreserveCanonicalContract()
 	{

--- a/MudSharpCore Unit Tests/SalvageableComponentTests.cs
+++ b/MudSharpCore Unit Tests/SalvageableComponentTests.cs
@@ -160,6 +160,30 @@ public class SalvageableComponentTests
 		Assert.AreEqual(2, plan.Items.Single().Quantity);
 	}
 
+	[TestMethod]
+	public void ConfigurationIsComplete_RejectsNonFiniteAndOutOfRangeAuthoringPayloads()
+	{
+		var fixture = CreateFixture();
+		var cases = new[]
+		{
+			(From: "delay=\"1\"", To: "delay=\"NaN\"", Expected: "invalid delay"),
+			(From: "successChance=\"0.5\"", To: "successChance=\"1.1\"", Expected: "invalid item product"),
+			(From: "successQuantity=\"2\"", To: "successQuantity=\"101\"", Expected: "more than 100")
+		};
+
+		foreach (var testCase in cases)
+		{
+			var databaseProto = CreateDatabaseProto();
+			databaseProto.Definition = databaseProto.Definition.Replace(testCase.From, testCase.To,
+				StringComparison.Ordinal);
+			var proto = (SalvageableGameItemComponentProto)new GameItemComponentManager()
+				.GetProto(databaseProto, fixture.Gameworld.Object);
+
+			Assert.IsFalse(proto.ConfigurationIsComplete(out var reason));
+			StringAssert.Contains(reason, testCase.Expected);
+		}
+	}
+
 	[DataTestMethod]
 	[DataRow(false)]
 	[DataRow(true)]
@@ -229,6 +253,20 @@ public class SalvageableComponentTests
 
 		salvageable.Verify(x => x.CreateProducts(actor.Object, success), Times.Once);
 		source.Verify(x => x.Delete(), Times.Once);
+		source.Verify(x => x.RemoveEffect(It.IsAny<IEffect>(), false), Times.Once);
+	}
+
+	[TestMethod]
+	public void ItemSalvaging_ProductCreationFailure_PreservesSource()
+	{
+		var (action, actor, source, salvageable, actorEffects, targetEffects) = CreateActionFixture();
+		actorEffects.Add(action);
+		salvageable.Setup(x => x.CreateProducts(actor.Object, true))
+			.Throws(new InvalidOperationException("product creation failed"));
+
+		action.ExpireEffect();
+
+		source.Verify(x => x.Delete(), Times.Never);
 		source.Verify(x => x.RemoveEffect(It.IsAny<IEffect>(), false), Times.Once);
 	}
 
@@ -342,7 +380,8 @@ public class SalvageableComponentTests
 		salvageable.SetupGet(x => x.Difficulty).Returns(Difficulty.Normal);
 		salvageable.Setup(x => x.CanSalvage(out It.Ref<string>.IsAny))
 			.Returns((out string reason) => { reason = string.Empty; return true; });
-		salvageable.Setup(x => x.CreateProducts(actor.Object, It.IsAny<bool>())).Returns([]);
+		salvageable.Setup(x => x.CreateProducts(actor.Object, It.IsAny<bool>()))
+			.Returns(Array.Empty<IGameItem>());
 
 		var action = new ItemSalvaging(actor.Object, salvageable.Object, null);
 		return (action, actor, source, salvageable, actorEffects, targetEffects);

--- a/MudSharpCore Unit Tests/SalvageableComponentTests.cs
+++ b/MudSharpCore Unit Tests/SalvageableComponentTests.cs
@@ -86,6 +86,34 @@ public class SalvageableComponentTests
 		Assert.AreEqual(3.5, proto.MaximumOutputWeight(10.0, false), 1.0e-9);
 	}
 
+	[TestMethod]
+	public void CleanLoad_ItemPrototypeProvisionedLater_RetainsExactReferenceForFirstConsumer()
+	{
+		var fixture = CreateFixture(addItemProto: false);
+		var proto = (SalvageableGameItemComponentProto)new GameItemComponentManager()
+			.GetProto(CreateDatabaseProto(), fixture.Gameworld.Object);
+		var product = proto.ItemProducts.Single();
+
+		Assert.AreEqual(200L, product.ItemPrototypeId);
+		Assert.AreEqual(1, product.ItemPrototypeRevision);
+		Assert.IsNull(product.ItemPrototype);
+		Assert.IsFalse(proto.ConfigurationIsComplete(out var unresolvedReason));
+		StringAssert.Contains(unresolvedReason, "#200r1 is unavailable");
+
+		var component = (ISalvageable)proto.CreateNew(CreateParent(fixture.Gameworld.Object, 10.0).Object,
+			temporary: true);
+		Assert.IsFalse(component.CanSalvage(out var consumerReason));
+		StringAssert.Contains(consumerReason, "#200r1 is unavailable");
+
+		fixture.ItemProtos.Add(fixture.ItemProto.Object);
+
+		Assert.AreSame(fixture.ItemProto.Object, product.ItemPrototype);
+		Assert.IsTrue(component.CanSalvage(out var resolvedReason), resolvedReason);
+		var plan = proto.CreateProductPlan(10.0, true, () => 0.0);
+		Assert.AreSame(fixture.ItemProto.Object, plan.Items.Single().Product.ItemPrototype);
+		Assert.AreEqual(2, plan.Items.Single().Quantity);
+	}
+
 	[DataTestMethod]
 	[DataRow(false)]
 	[DataRow(true)]
@@ -294,7 +322,8 @@ public class SalvageableComponentTests
 		return parent;
 	}
 
-	private static (Mock<IFuturemud> Gameworld, Mock<ITraitDefinition> Trait) CreateFixture()
+	private static (Mock<IFuturemud> Gameworld, Mock<ITraitDefinition> Trait,
+		RevisableAll<IGameItemProto> ItemProtos, Mock<IGameItemProto> ItemProto) CreateFixture(bool addItemProto = true)
 	{
 		var trait = new Mock<ITraitDefinition>();
 		trait.SetupGet(x => x.Id).Returns(50);
@@ -315,14 +344,17 @@ public class SalvageableComponentTests
 		itemProto.SetupGet(x => x.Weight).Returns(2.0);
 		itemProto.SetupGet(x => x.Status).Returns(RevisionStatus.Current);
 		var itemProtos = new RevisableAll<IGameItemProto>();
-		itemProtos.Add(itemProto.Object);
+		if (addItemProto)
+		{
+			itemProtos.Add(itemProto.Object);
+		}
 
 		var gameworld = new Mock<IFuturemud>();
 		gameworld.SetupGet(x => x.Traits).Returns(traits);
 		gameworld.SetupGet(x => x.Materials).Returns(materials);
 		gameworld.SetupGet(x => x.Tags).Returns(new All<ITag>());
 		gameworld.SetupGet(x => x.ItemProtos).Returns(itemProtos);
-		return (gameworld, trait);
+		return (gameworld, trait, itemProtos, itemProto);
 	}
 
 	private static Mock<ISolid> CreateMaterial(long id, string name)

--- a/MudSharpCore Unit Tests/SalvageableComponentTests.cs
+++ b/MudSharpCore Unit Tests/SalvageableComponentTests.cs
@@ -1,0 +1,369 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.Commands.Modules;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Form.Material;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Components;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.GameItems.Prototypes;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Checks;
+using System.Reflection;
+using System.Collections.Generic;
+using System;
+using System.Linq;
+using System.Xml.Linq;
+using DbEditableItem = MudSharp.Models.EditableItem;
+using DbGameItemComponent = MudSharp.Models.GameItemComponent;
+using DbGameItemComponentProto = MudSharp.Models.GameItemComponentProto;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class SalvageableComponentTests
+{
+	[TestMethod]
+	public void ComponentRegistrationXmlCopyAndLoad_PreserveCanonicalContract()
+	{
+		var fixture = CreateFixture();
+		var manager = new GameItemComponentManager();
+
+		Assert.IsTrue(manager.PrimaryTypes.Any(x => x.EqualTo("salvageable")));
+		var proto = (SalvageableGameItemComponentProto)manager.GetProto(CreateDatabaseProto(), fixture.Gameworld.Object);
+
+		Assert.AreSame(fixture.Trait.Object, proto.Trait);
+		Assert.AreEqual(Difficulty.Normal, proto.Difficulty);
+		Assert.AreEqual(2, proto.Stages.Count);
+		Assert.AreEqual(2, proto.CommodityProducts.Count);
+		Assert.AreEqual(1, proto.ItemProducts.Count);
+		Assert.IsInstanceOfType(proto, typeof(ISalvageablePrototype));
+
+		var parent = CreateParent(fixture.Gameworld.Object, 10.0);
+		var component = proto.CreateNew(parent.Object, temporary: true);
+		var copy = component.Copy(CreateParent(fixture.Gameworld.Object, 10.0).Object, true);
+		var loaded = proto.LoadComponent(new DbGameItemComponent { Id = 99, Definition = "<Definition />" }, parent.Object);
+
+		Assert.IsInstanceOfType(component, typeof(ISalvageable));
+		Assert.IsInstanceOfType(copy, typeof(ISalvageable));
+		Assert.IsInstanceOfType(loaded, typeof(ISalvageable));
+
+		var saveMethod = typeof(SalvageableGameItemComponentProto)
+			.GetMethod("SaveToXml", BindingFlags.Instance | BindingFlags.NonPublic)!;
+		var saved = XElement.Parse((string)saveMethod.Invoke(proto, null)!);
+		CollectionAssert.AreEqual(
+			new[] { "Trait", "Difficulty", "ToolTag", "Stages", "CommodityProducts", "ItemProducts" },
+			saved.Elements().Select(x => x.Name.LocalName).ToArray());
+		CollectionAssert.AreEqual(new[] { "First stage", "Second stage" },
+			saved.Element("Stages")!.Elements().Select(x => x.Value).ToArray());
+		CollectionAssert.AreEqual(new long[] { 100, 101 },
+			saved.Element("CommodityProducts")!.Elements().Select(x => (long)x.Attribute("material")!).ToArray());
+	}
+
+	[TestMethod]
+	public void ProductPlan_SupportsFixedFractionItemAndDistinctSuccessFailureBranches()
+	{
+		var fixture = CreateFixture();
+		var proto = (SalvageableGameItemComponentProto)new GameItemComponentManager()
+			.GetProto(CreateDatabaseProto(), fixture.Gameworld.Object);
+
+		var success = proto.CreateProductPlan(10.0, true, () => 0.25);
+		var failure = proto.CreateProductPlan(10.0, false, () => 0.25);
+
+		CollectionAssert.AreEqual(new[] { 2.0, 1.0 }, success.Commodities.Select(x => x.Weight).ToArray());
+		Assert.AreEqual(1, success.Items.Count);
+		Assert.AreEqual(2, success.Items[0].Quantity);
+		CollectionAssert.AreEqual(new[] { 1.0, 0.5 }, failure.Commodities.Select(x => x.Weight).ToArray());
+		Assert.AreEqual(0, failure.Items.Count);
+		Assert.AreEqual(7.0, proto.MaximumOutputWeight(10.0, true), 1.0e-9);
+		Assert.AreEqual(3.5, proto.MaximumOutputWeight(10.0, false), 1.0e-9);
+	}
+
+	[DataTestMethod]
+	[DataRow(false)]
+	[DataRow(true)]
+	public void Eligibility_DoesNotDependOnCarryability(bool preventsMovement)
+	{
+		var fixture = CreateFixture();
+		var proto = (SalvageableGameItemComponentProto)new GameItemComponentManager()
+			.GetProto(CreateDatabaseProto(), fixture.Gameworld.Object);
+		var parent = CreateParent(fixture.Gameworld.Object, 10.0);
+		parent.Setup(x => x.PreventsMovement()).Returns(preventsMovement);
+		var component = (ISalvageable)proto.CreateNew(parent.Object, temporary: true);
+
+		Assert.IsTrue(component.CanSalvage(out var reason), reason);
+		parent.Verify(x => x.PreventsMovement(), Times.Never);
+		parent.Verify(x => x.CanGet(It.IsAny<ItemCanGetIgnore>()), Times.Never);
+	}
+
+	[TestMethod]
+	public void Eligibility_RejectsOverBudgetContentsAttachmentsAndLiquid()
+	{
+		var fixture = CreateFixture();
+		var proto = (SalvageableGameItemComponentProto)new GameItemComponentManager()
+			.GetProto(CreateDatabaseProto(), fixture.Gameworld.Object);
+
+		var overBudget = (ISalvageable)proto.CreateNew(CreateParent(fixture.Gameworld.Object, 6.0).Object, temporary: true);
+		Assert.IsFalse(overBudget.CanSalvage(out var budgetReason));
+		StringAssert.Contains(budgetReason, "mass budget");
+
+		var containedParent = CreateParent(fixture.Gameworld.Object, 10.0);
+		containedParent.SetupGet(x => x.DeepItems).Returns([containedParent.Object, Mock.Of<IGameItem>()]);
+		AssertRejected(proto, containedParent, "contains another item");
+
+		var attachedParent = CreateParent(fixture.Gameworld.Object, 10.0);
+		attachedParent.SetupGet(x => x.AttachedAndConnectedItems).Returns([Mock.Of<IGameItem>()]);
+		AssertRejected(proto, attachedParent, "contains another item");
+
+		var liquid = new Mock<ILiquidContainer>();
+		liquid.SetupGet(x => x.LiquidVolume).Returns(1.0);
+		var liquidParent = CreateParent(fixture.Gameworld.Object, 10.0);
+		liquidParent.Setup(x => x.GetItemTypes<ILiquidContainer>()).Returns([liquid.Object]);
+		AssertRejected(proto, liquidParent, "contains liquid");
+	}
+
+	[TestMethod]
+	public void ItemSalvaging_InterruptionAndRestartState_CreateNothingAndLeaveSource()
+	{
+		var (action, actor, source, salvageable, actorEffects, targetEffects) = CreateActionFixture();
+		actorEffects.Add(action);
+
+		Assert.IsFalse(action.SavingEffect, "An interrupted action must not persist as saved progress across restart.");
+		action.RemovalEffect();
+
+		salvageable.Verify(x => x.CreateProducts(It.IsAny<ICharacter>(), It.IsAny<bool>()), Times.Never);
+		source.Verify(x => x.Delete(), Times.Never);
+		source.Verify(x => x.RemoveEffect(It.IsAny<IEffect>(), false), Times.Once);
+	}
+
+	[DataTestMethod]
+	[DataRow(Outcome.Pass, true)]
+	[DataRow(Outcome.Fail, false)]
+	public void ItemSalvaging_CompletionConsumesSourceOnSuccessAndFailure(Outcome outcome, bool success)
+	{
+		var (action, actor, source, salvageable, actorEffects, targetEffects) = CreateActionFixture(outcome);
+		actorEffects.Add(action);
+
+		action.ExpireEffect();
+
+		salvageable.Verify(x => x.CreateProducts(actor.Object, success), Times.Once);
+		source.Verify(x => x.Delete(), Times.Once);
+		source.Verify(x => x.RemoveEffect(It.IsAny<IEffect>(), false), Times.Once);
+	}
+
+	[TestMethod]
+	public void ItemSalvaging_FailureCompletionIsVisiblyDistinct()
+	{
+		var success = ItemSalvaging.CompletionEmote(true, "some parts");
+		var failure = ItemSalvaging.CompletionEmote(false, "fewer parts");
+
+		Assert.IsFalse(success.Contains("rough work", StringComparison.Ordinal));
+		StringAssert.Contains(failure, "rough work leaves much of it unusable");
+		StringAssert.Contains(failure, "fewer parts");
+	}
+
+	[TestMethod]
+	public void SalvageCommand_ComponentDispatchIsSeparateAndLegacyFallbackRemains()
+	{
+		var output = new Mock<IOutputHandler>();
+		var actor = new Mock<ICharacter>();
+		actor.SetupGet(x => x.OutputHandler).Returns(output.Object);
+		var target = new Mock<IGameItem>();
+		actor.Setup(x => x.TargetLocalItem("target")).Returns(target.Object);
+
+		InvokeSalvage(actor.Object, "salvage target");
+		target.Verify(x => x.GetItemType<IButcherable>(), Times.Once,
+			"An item without Salvageable must continue through the unchanged corpse/bodypart branch.");
+
+		var salvageable = new Mock<ISalvageable>();
+		target.Setup(x => x.GetItemType<ISalvageable>()).Returns(salvageable.Object);
+		salvageable.Setup(x => x.CanSalvage(out It.Ref<string>.IsAny))
+			.Returns((out string reason) => { reason = "test refusal"; return false; });
+		target.Invocations.Clear();
+
+		InvokeSalvage(actor.Object, "salvage target");
+		salvageable.Verify(x => x.CanSalvage(out It.Ref<string>.IsAny), Times.Once);
+		target.Verify(x => x.GetItemType<IButcherable>(), Times.Never,
+			"An ordinary Salvageable item must not enter race/body butchery semantics.");
+
+		salvageable.Invocations.Clear();
+		InvokeSalvage(actor.Object, "salvage target engine");
+		salvageable.Verify(x => x.CanSalvage(out It.Ref<string>.IsAny), Times.Never,
+			"Ordinary item subcategories must be refused before starting work.");
+	}
+
+	[TestMethod]
+	public void SalvageCommand_ExistingWorkLockPreventsCompetingStart()
+	{
+		var actor = new Mock<ICharacter>();
+		actor.SetupGet(x => x.OutputHandler).Returns(Mock.Of<IOutputHandler>());
+		var target = new Mock<IGameItem>();
+		actor.Setup(x => x.TargetLocalItem("target")).Returns(target.Object);
+		var salvageable = new Mock<ISalvageable>();
+		target.Setup(x => x.GetItemType<ISalvageable>()).Returns(salvageable.Object);
+		var workLock = new ItemSalvaging.BeingSalvaged(target.Object, actor.Object);
+		target.Setup(x => x.EffectsOfType<ItemSalvaging.BeingSalvaged>(
+			It.IsAny<Predicate<ItemSalvaging.BeingSalvaged>>())).Returns([workLock]);
+
+		InvokeSalvage(actor.Object, "salvage target");
+
+		salvageable.Verify(x => x.CanSalvage(out It.Ref<string>.IsAny), Times.Never);
+	}
+
+	private static void InvokeSalvage(ICharacter actor, string input)
+	{
+		var method = typeof(CraftModule).GetMethod("Salvage", BindingFlags.Static | BindingFlags.NonPublic)!;
+		method.Invoke(null, [actor, input]);
+	}
+
+	private static void AssertRejected(SalvageableGameItemComponentProto proto, Mock<IGameItem> parent, string reasonText)
+	{
+		var component = (ISalvageable)proto.CreateNew(parent.Object, temporary: true);
+		Assert.IsFalse(component.CanSalvage(out var reason));
+		StringAssert.Contains(reason, reasonText);
+	}
+
+	private static (ItemSalvaging Action, Mock<ICharacter> Actor, Mock<IGameItem> Source,
+		Mock<ISalvageable> Salvageable, List<IEffect> ActorEffects, List<IEffect> TargetEffects)
+		CreateActionFixture(Outcome outcome = Outcome.Pass)
+	{
+		var gameworld = new Mock<IFuturemud>();
+		var check = new Mock<ICheck>();
+		check.Setup(x => x.Check(It.IsAny<ICharacter>(), It.IsAny<Difficulty>(), It.IsAny<ITraitDefinition>(),
+			It.IsAny<IPerceivable>(), It.IsAny<double>())).Returns(new CheckOutcome { Outcome = outcome });
+		gameworld.Setup(x => x.GetCheck(CheckType.ButcheryCheck)).Returns(check.Object);
+		var actorEffects = new List<IEffect>();
+		var targetEffects = new List<IEffect>();
+		var actor = new Mock<ICharacter>();
+		actor.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		actor.SetupGet(x => x.Body).Returns(Mock.Of<MudSharp.Body.IBody>());
+		actor.SetupGet(x => x.OutputHandler).Returns(Mock.Of<IOutputHandler>());
+		actor.SetupGet(x => x.Effects).Returns(() => actorEffects);
+		actor.Setup(x => x.RemoveEffect(It.IsAny<IEffect>(), It.IsAny<bool>()))
+			.Callback<IEffect, bool>((effect, _) => actorEffects.Remove(effect));
+
+		var source = new Mock<IGameItem>();
+		source.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		source.SetupGet(x => x.Effects).Returns(() => targetEffects);
+		source.Setup(x => x.AddEffect(It.IsAny<IEffect>()))
+			.Callback<IEffect>(effect => targetEffects.Add(effect));
+		source.Setup(x => x.RemoveEffect(It.IsAny<IEffect>(), It.IsAny<bool>()))
+			.Callback<IEffect, bool>((effect, _) => targetEffects.Remove(effect));
+
+		var salvageable = new Mock<ISalvageable>();
+		salvageable.SetupGet(x => x.Parent).Returns(source.Object);
+		salvageable.SetupGet(x => x.Stages).Returns([("@ work|works on $1.", 1.0)]);
+		salvageable.SetupGet(x => x.Trait).Returns(Mock.Of<ITraitDefinition>());
+		salvageable.SetupGet(x => x.Difficulty).Returns(Difficulty.Normal);
+		salvageable.Setup(x => x.CanSalvage(out It.Ref<string>.IsAny))
+			.Returns((out string reason) => { reason = string.Empty; return true; });
+		salvageable.Setup(x => x.CreateProducts(actor.Object, It.IsAny<bool>())).Returns([]);
+
+		var action = new ItemSalvaging(actor.Object, salvageable.Object, null);
+		return (action, actor, source, salvageable, actorEffects, targetEffects);
+	}
+
+	private static Mock<IGameItem> CreateParent(IFuturemud gameworld, double baseWeight)
+	{
+		var proto = new Mock<IGameItemProto>();
+		proto.SetupGet(x => x.Weight).Returns(baseWeight);
+		var parent = new Mock<IGameItem>();
+		parent.SetupGet(x => x.Gameworld).Returns(gameworld);
+		parent.SetupGet(x => x.Prototype).Returns(proto.Object);
+		parent.SetupGet(x => x.Quantity).Returns(1);
+		parent.SetupGet(x => x.DeepItems).Returns(() => [parent.Object]);
+		parent.SetupGet(x => x.AttachedAndConnectedItems).Returns([]);
+		parent.Setup(x => x.GetItemTypes<ILiquidContainer>()).Returns([]);
+		parent.Setup(x => x.GetItemTypes<ISheath>()).Returns([]);
+		parent.Setup(x => x.GetItemTypes<IRangedWeaponPlatform>()).Returns([]);
+		parent.Setup(x => x.GetItemTypes<IAutomationHousing>()).Returns([]);
+		parent.Setup(x => x.GetItemTypes<IArtilleryMount>()).Returns([]);
+		parent.Setup(x => x.GetItemTypes<IWeaponCarrierAttachment>()).Returns([]);
+		parent.Setup(x => x.GetItemTypes<IArtilleryChamber>()).Returns([]);
+		return parent;
+	}
+
+	private static (Mock<IFuturemud> Gameworld, Mock<ITraitDefinition> Trait) CreateFixture()
+	{
+		var trait = new Mock<ITraitDefinition>();
+		trait.SetupGet(x => x.Id).Returns(50);
+		trait.SetupGet(x => x.Name).Returns("Electronics");
+		var traits = new All<ITraitDefinition>();
+		traits.Add(trait.Object);
+
+		var materialA = CreateMaterial(100, "electronic parts");
+		var materialB = CreateMaterial(101, "plastic");
+		var materials = new All<ISolid>();
+		materials.Add(materialA.Object);
+		materials.Add(materialB.Object);
+
+		var itemProto = new Mock<IGameItemProto>();
+		itemProto.SetupGet(x => x.Id).Returns(200);
+		itemProto.SetupGet(x => x.RevisionNumber).Returns(1);
+		itemProto.SetupGet(x => x.Name).Returns("battery");
+		itemProto.SetupGet(x => x.Weight).Returns(2.0);
+		itemProto.SetupGet(x => x.Status).Returns(RevisionStatus.Current);
+		var itemProtos = new RevisableAll<IGameItemProto>();
+		itemProtos.Add(itemProto.Object);
+
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.Traits).Returns(traits);
+		gameworld.SetupGet(x => x.Materials).Returns(materials);
+		gameworld.SetupGet(x => x.Tags).Returns(new All<ITag>());
+		gameworld.SetupGet(x => x.ItemProtos).Returns(itemProtos);
+		return (gameworld, trait);
+	}
+
+	private static Mock<ISolid> CreateMaterial(long id, string name)
+	{
+		var material = new Mock<ISolid>();
+		material.SetupGet(x => x.Id).Returns(id);
+		material.SetupGet(x => x.Name).Returns(name);
+		return material;
+	}
+
+	private static DbGameItemComponentProto CreateDatabaseProto()
+	{
+		return new DbGameItemComponentProto
+		{
+			Id = 1,
+			Name = "Test Salvageable",
+			Description = "Test",
+			Type = "Salvageable",
+			RevisionNumber = 0,
+			Definition = """
+			             <Definition>
+			               <Trait>50</Trait>
+			               <Difficulty>5</Difficulty>
+			               <ToolTag>0</ToolTag>
+			               <Stages>
+			                 <Stage delay="1"><![CDATA[First stage]]></Stage>
+			                 <Stage delay="2"><![CDATA[Second stage]]></Stage>
+			               </Stages>
+			               <CommodityProducts>
+			                 <Product material="100" tag="0" fraction="false" success="2" failure="1" />
+			                 <Product material="101" tag="0" fraction="true" success="0.1" failure="0.05" />
+			               </CommodityProducts>
+			               <ItemProducts>
+			                 <Product id="200" revision="1" successQuantity="2" failureQuantity="1" successChance="0.5" failureChance="0.1" />
+			               </ItemProducts>
+			             </Definition>
+			             """,
+			EditableItem = new DbEditableItem
+			{
+				Id = 1,
+				BuilderAccountId = 1,
+				BuilderDate = DateTime.UtcNow,
+				RevisionNumber = 0,
+				RevisionStatus = (int)RevisionStatus.Current
+			}
+		};
+	}
+}

--- a/MudSharpCore Unit Tests/SalvageableComponentTests.cs
+++ b/MudSharpCore Unit Tests/SalvageableComponentTests.cs
@@ -253,7 +253,11 @@ public class SalvageableComponentTests
 		source.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
 		source.SetupGet(x => x.Effects).Returns(() => targetEffects);
 		source.Setup(x => x.AddEffect(It.IsAny<IEffect>()))
-			.Callback<IEffect>(effect => targetEffects.Add(effect));
+			.Callback<IEffect>(effect =>
+			{
+				Assert.IsNotNull(effect, "The base CharacterActionWithTarget constructor invokes virtual setup before the derived constructor body.");
+				targetEffects.Add(effect);
+			});
 		source.Setup(x => x.RemoveEffect(It.IsAny<IEffect>(), It.IsAny<bool>()))
 			.Callback<IEffect, bool>((effect, _) => targetEffects.Remove(effect));
 

--- a/MudSharpCore/Commands/Modules/CraftModule.cs
+++ b/MudSharpCore/Commands/Modules/CraftModule.cs
@@ -2157,18 +2157,18 @@ The syntax is:
     [NoHideCommand]
     [NoMovementCommand]
     [DelayBlock("general", "You must first stop {0} before you can do that.")]
-    [HelpInfo("salvage", @"The #3salvage#0 command begins dismantling a non-organic wreck or part into its configured components. Some targets have product subcategories, which you can name to process only that portion. The required tools and results depend on the target's salvage profile.
+    [HelpInfo("salvage", @"The #3salvage#0 command begins dismantling an explicitly salvageable ordinary item or a non-organic corpse/body part into its configured products. Ordinary items do not have subcategories. Corpse/bodypart profiles may have product subcategories. The required tools and results depend on the target's salvage configuration.
 
 The syntax is:
 
-	#3salvage <wreck|part> [<subcategory>]#0", AutoHelp.HelpArgOrNoArg)]
+	#3salvage <item> [<corpse/bodypart subcategory>]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Salvage(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
         if (ss.IsFinished || ss.Peek().EqualToAny("?", "help"))
         {
             actor.Send(
-                $"This command is used to take apart non-organic corpses and wrecks into their component parts.\nThe syntax is {"salvage <wreck|part> [<subcategory>]".ColourCommand()}.");
+                $"This command is used to take apart explicitly salvageable ordinary items or non-organic corpses/bodyparts.\nThe syntax is {"salvage <item> [<corpse/bodypart subcategory>]".ColourCommand()}.");
             return;
         }
 
@@ -2176,6 +2176,13 @@ The syntax is:
         if (target == null)
         {
             actor.Send("You don't see anything like that to salvage.");
+            return;
+        }
+
+        var targetAsSalvageable = target.GetItemType<ISalvageable>();
+        if (targetAsSalvageable is not null)
+        {
+            SalvageOrdinaryItem(actor, target, targetAsSalvageable, ss);
             return;
         }
 
@@ -2244,6 +2251,54 @@ The syntax is:
         actor.AddEffect(
             new Butchering(actor, targetAsButcherable, subcategory,
                 ButcheryToolFromPlanResults(results)), TimeSpan.FromSeconds(10));
+        actor.OutputHandler.Handle(new EmoteOutput(new Emote("@ begin|begins to salvage $0.", actor, target)));
+        plan.FinalisePlanNoRestore();
+    }
+
+    private static void SalvageOrdinaryItem(ICharacter actor, IGameItem target, ISalvageable salvageable,
+        StringStack command)
+    {
+        if (!command.IsFinished)
+        {
+            actor.Send("Ordinary-item salvage does not support subcategories.");
+            return;
+        }
+
+        if (target.EffectsOfType<ItemSalvaging.BeingSalvaged>().Any())
+        {
+            actor.Send($"Someone is already salvaging {target.HowSeen(actor)}.");
+            return;
+        }
+
+        if (!salvageable.CanSalvage(out var reason))
+        {
+            actor.Send($"{target.HowSeen(actor, true)} cannot be salvaged because {reason}.");
+            return;
+        }
+
+        var stages = salvageable.Stages.ToList();
+        if (stages.Any(x => x.Emote.Contains("$2", StringComparison.Ordinal)) &&
+            salvageable.RequiredToolTag is null)
+        {
+            actor.Send($"{target.HowSeen(actor, true)} cannot be salvaged because its stage emotes require a tool but no held tool is configured.");
+            return;
+        }
+
+        var plan = salvageable.ToolTemplate.CreatePlan(actor);
+        switch (plan.PlanIsFeasible())
+        {
+            case InventoryPlanFeasibility.NotFeasibleMissingItems:
+                actor.Send("You do not have the required salvage tool.");
+                return;
+            case InventoryPlanFeasibility.NotFeasibleNotEnoughHands:
+            case InventoryPlanFeasibility.NotFeasibleNotEnoughWielders:
+                actor.Send("You do not have enough free hands to ready the required salvage tool.");
+                return;
+        }
+
+        var results = plan.ExecuteWholePlan().ToList();
+        var tool = ButcheryToolFromPlanResults(results);
+        actor.AddEffect(new ItemSalvaging(actor, salvageable, tool), TimeSpan.FromSeconds(stages[0].Delay));
         actor.OutputHandler.Handle(new EmoteOutput(new Emote("@ begin|begins to salvage $0.", actor, target)));
         plan.FinalisePlanNoRestore();
     }

--- a/MudSharpCore/Effects/Concrete/ItemSalvaging.cs
+++ b/MudSharpCore/Effects/Concrete/ItemSalvaging.cs
@@ -30,7 +30,7 @@ public class ItemSalvaging : StagedCharacterActionWithTarget, IAffectProximity
 
 	private readonly ISalvageable _salvageable;
 	private readonly IGameItem? _tool;
-	private readonly BeingSalvaged _lock;
+	private BeingSalvaged? _lock;
 	private readonly Queue<string> _emotes;
 
 	public ItemSalvaging(ICharacter salvager, ISalvageable salvageable, IGameItem? tool)
@@ -38,7 +38,6 @@ public class ItemSalvaging : StagedCharacterActionWithTarget, IAffectProximity
 	{
 		_salvageable = salvageable;
 		_tool = tool;
-		_lock = new BeingSalvaged(Target, salvager);
 		var stages = salvageable.Stages.ToList();
 		_emotes = new Queue<string>(stages.Select(x => x.Emote));
 		TimesBetweenTicks = new Queue<TimeSpan>(stages.Skip(1).Select(x => TimeSpan.FromSeconds(x.Delay)));
@@ -51,7 +50,7 @@ public class ItemSalvaging : StagedCharacterActionWithTarget, IAffectProximity
 		void Final(IPerceivable perceivable)
 		{
 			SendStageEmote();
-			if (!Target.Effects.Contains(_lock))
+			if (_lock is null || !Target.Effects.Contains(_lock))
 			{
 				return;
 			}
@@ -104,6 +103,7 @@ public class ItemSalvaging : StagedCharacterActionWithTarget, IAffectProximity
 	protected override void SetupEventHandlers()
 	{
 		base.SetupEventHandlers();
+		_lock ??= new BeingSalvaged(Target, CharacterOwner);
 		if (_tool is not null)
 		{
 			_tool.OnDeleted -= ToolGone;
@@ -146,7 +146,10 @@ public class ItemSalvaging : StagedCharacterActionWithTarget, IAffectProximity
 			CharacterOwner.Body.OnInventoryChange -= CheckInventoryChange;
 		}
 
-		Target.RemoveEffect(_lock);
+		if (_lock is not null)
+		{
+			Target.RemoveEffect(_lock);
+		}
 	}
 
 	public (bool Affects, Proximity Proximity) GetProximityFor(IPerceivable thing)

--- a/MudSharpCore/Effects/Concrete/ItemSalvaging.cs
+++ b/MudSharpCore/Effects/Concrete/ItemSalvaging.cs
@@ -66,7 +66,19 @@ public class ItemSalvaging : StagedCharacterActionWithTarget, IAffectProximity
 			                            .Check(CharacterOwner, _salvageable.Difficulty, _salvageable.Trait, Target)
 			                            .IsPass();
 			ReleaseEventHandlers();
-			var products = _salvageable.CreateProducts(CharacterOwner, success).ToList();
+			IReadOnlyList<IGameItem> products;
+			try
+			{
+				products = _salvageable.CreateProducts(CharacterOwner, success);
+			}
+			catch
+			{
+				CharacterOwner.OutputHandler.Handle(new EmoteOutput(new Emote(
+					"@ stop|stops salvaging $1 because the products cannot be recovered safely.",
+					CharacterOwner, CharacterOwner, Target)));
+				return;
+			}
+
 			var result = products.Count == 0
 				? "no usable products"
 				: products.Select(x => x.HowSeen(CharacterOwner)).ListToString();

--- a/MudSharpCore/Effects/Concrete/ItemSalvaging.cs
+++ b/MudSharpCore/Effects/Concrete/ItemSalvaging.cs
@@ -1,0 +1,154 @@
+using MudSharp.Body;
+using MudSharp.Construction;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Checks;
+
+#nullable enable
+
+namespace MudSharp.Effects.Concrete;
+
+public class ItemSalvaging : StagedCharacterActionWithTarget, IAffectProximity
+{
+	internal sealed class BeingSalvaged : Effect, INoGetEffect, IAffectProximity
+	{
+		public ICharacter Salvager { get; }
+
+		public BeingSalvaged(IPerceivable owner, ICharacter salvager) : base(owner)
+		{
+			Salvager = salvager;
+		}
+
+		protected override string SpecificEffectType => "Being Salvaged";
+		public bool CombatRelated => false;
+		public override string Describe(IPerceiver voyeur) => "Being salvaged";
+
+		public (bool Affects, Proximity Proximity) GetProximityFor(IPerceivable thing)
+			=> thing == Salvager ? (true, Proximity.Immediate) : (false, Proximity.Unapproximable);
+	}
+
+	private readonly ISalvageable _salvageable;
+	private readonly IGameItem? _tool;
+	private readonly BeingSalvaged _lock;
+	private readonly Queue<string> _emotes;
+
+	public ItemSalvaging(ICharacter salvager, ISalvageable salvageable, IGameItem? tool)
+		: base(salvager, salvageable.Parent)
+	{
+		_salvageable = salvageable;
+		_tool = tool;
+		_lock = new BeingSalvaged(Target, salvager);
+		var stages = salvageable.Stages.ToList();
+		_emotes = new Queue<string>(stages.Select(x => x.Emote));
+		TimesBetweenTicks = new Queue<TimeSpan>(stages.Skip(1).Select(x => TimeSpan.FromSeconds(x.Delay)));
+
+		void Intermediate(IPerceivable perceivable)
+		{
+			SendStageEmote();
+		}
+
+		void Final(IPerceivable perceivable)
+		{
+			SendStageEmote();
+			if (!Target.Effects.Contains(_lock))
+			{
+				return;
+			}
+
+			if (!_salvageable.CanSalvage(out var reason))
+			{
+				CharacterOwner.OutputHandler.Handle(new EmoteOutput(new Emote(
+					$"@ stop|stops salvaging $1 because {reason}.", CharacterOwner, CharacterOwner, Target)));
+				return;
+			}
+
+			var success = CharacterOwner.Gameworld.GetCheck(CheckType.ButcheryCheck)
+			                            .Check(CharacterOwner, _salvageable.Difficulty, _salvageable.Trait, Target)
+			                            .IsPass();
+			ReleaseEventHandlers();
+			var products = _salvageable.CreateProducts(CharacterOwner, success).ToList();
+			var result = products.Count == 0
+				? "no usable products"
+				: products.Select(x => x.HowSeen(CharacterOwner)).ListToString();
+			CharacterOwner.OutputHandler.Handle(new EmoteOutput(new Emote(
+				CompletionEmote(success, result),
+				CharacterOwner, CharacterOwner, Target)));
+			_salvageable.Parent.Delete();
+		}
+
+		ActionQueue = new Queue<Action<IPerceivable>>(
+			Enumerable.Repeat<Action<IPerceivable>>(Intermediate, Math.Max(0, stages.Count - 1)).Plus(Final));
+		FireOnCount = stages.Count;
+		ActionDescription = "salvaging $1";
+		CancelEmoteString = "@ stop|stops salvaging $1";
+		WhyCannotMoveEmoteString = "@ cannot move because #0 are|is salvaging $1.";
+		LDescAddendum = "salvaging $1";
+		_blocks.AddRange(["general", "movement"]);
+		SetupEventHandlers();
+	}
+
+	internal static string CompletionEmote(bool success, string products)
+	{
+		return success
+			? $"@ finish|finishes salvaging $1 and recover|recovers {products}."
+			: $"@ finish|finishes salvaging $1, but rough work leaves much of it unusable. #0 recover|recovers {products}.";
+	}
+
+	private void SendStageEmote()
+	{
+		CharacterOwner.OutputHandler.Handle(new EmoteOutput(new Emote(
+			_emotes.Dequeue(), CharacterOwner, CharacterOwner, Target, _tool)));
+	}
+
+	protected override void SetupEventHandlers()
+	{
+		base.SetupEventHandlers();
+		if (_tool is not null)
+		{
+			_tool.OnDeleted -= ToolGone;
+			_tool.OnDeleted += ToolGone;
+			_tool.OnQuit -= ToolGone;
+			_tool.OnQuit += ToolGone;
+			CharacterOwner.Body.OnInventoryChange -= CheckInventoryChange;
+			CharacterOwner.Body.OnInventoryChange += CheckInventoryChange;
+		}
+
+		if (!Target.Effects.Contains(_lock))
+		{
+			Target.AddEffect(_lock);
+		}
+	}
+
+	private void CheckInventoryChange(InventoryState oldState, InventoryState newState, IGameItem item)
+	{
+		if (item == _tool && newState is not InventoryState.Wielded and not InventoryState.Held)
+		{
+			ToolGone(item);
+		}
+	}
+
+	private void ToolGone(IPerceivable owner)
+	{
+		CharacterOwner.OutputHandler.Handle(new EmoteOutput(new Emote(
+			"@ stop|stops salvaging $1 because #0 are|is no longer holding $2.",
+			CharacterOwner, CharacterOwner, Target, _tool)));
+		CharacterOwner.RemoveEffect(this, true);
+	}
+
+	protected override void ReleaseEventHandlers()
+	{
+		base.ReleaseEventHandlers();
+		if (_tool is not null)
+		{
+			_tool.OnDeleted -= ToolGone;
+			_tool.OnQuit -= ToolGone;
+			CharacterOwner.Body.OnInventoryChange -= CheckInventoryChange;
+		}
+
+		Target.RemoveEffect(_lock);
+	}
+
+	public (bool Affects, Proximity Proximity) GetProximityFor(IPerceivable thing)
+		=> thing == Target ? (true, Proximity.Immediate) : (false, Proximity.Unapproximable);
+}

--- a/MudSharpCore/GameItems/Components/SalvageableGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/SalvageableGameItemComponent.cs
@@ -48,6 +48,17 @@ public class SalvageableGameItemComponent : GameItemComponent, ISalvageable
 
 	protected override string SaveToXml() => "<Definition />";
 
+	public override bool DescriptionDecorator(DescriptionType type)
+	{
+		return type == DescriptionType.Full;
+	}
+
+	public override string Decorate(IPerceiver voyeur, string name, string description, DescriptionType type,
+		bool colour, PerceiveIgnoreFlags flags)
+	{
+		return type == DescriptionType.Full ? $"{description}\n\nIt can be salvaged." : description;
+	}
+
 	private double SourceBaseWeight => Parent.Prototype.Weight * Parent.Quantity;
 
 	public double MaximumOutputWeight(bool success) => _prototype.MaximumOutputWeight(SourceBaseWeight, success);

--- a/MudSharpCore/GameItems/Components/SalvageableGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/SalvageableGameItemComponent.cs
@@ -1,0 +1,194 @@
+using MudSharp.Body.Traits;
+using MudSharp.Events;
+using MudSharp.Form.Material;
+using MudSharp.Framework;
+using MudSharp.GameItems.Inventory;
+using MudSharp.GameItems.Prototypes;
+using MudSharp.RPG.Checks;
+
+#nullable enable
+
+namespace MudSharp.GameItems.Components;
+
+public class SalvageableGameItemComponent : GameItemComponent, ISalvageable
+{
+	private SalvageableGameItemComponentProto _prototype;
+	public override IGameItemComponentProto Prototype => _prototype;
+	public ITraitDefinition Trait => _prototype.Trait!;
+	public Difficulty Difficulty => _prototype.Difficulty;
+	public ITag? RequiredToolTag => _prototype.RequiredToolTag;
+	public IInventoryPlanTemplate ToolTemplate => _prototype.ToolTemplate;
+	public IEnumerable<(string Emote, double Delay)> Stages => _prototype.Stages;
+
+	public SalvageableGameItemComponent(SalvageableGameItemComponentProto proto, IGameItem parent, bool temporary = false)
+		: base(parent, proto, temporary)
+	{
+		_prototype = proto;
+	}
+
+	public SalvageableGameItemComponent(Models.GameItemComponent component,
+		SalvageableGameItemComponentProto proto, IGameItem parent) : base(component, parent)
+	{
+		_prototype = proto;
+	}
+
+	private SalvageableGameItemComponent(SalvageableGameItemComponent rhs, IGameItem newParent, bool temporary)
+		: base(rhs, newParent, temporary)
+	{
+		_prototype = rhs._prototype;
+	}
+
+	protected override void UpdateComponentNewPrototype(IGameItemComponentProto newProto)
+	{
+		_prototype = (SalvageableGameItemComponentProto)newProto;
+	}
+
+	public override IGameItemComponent Copy(IGameItem newParent, bool temporary = false)
+		=> new SalvageableGameItemComponent(this, newParent, temporary);
+
+	protected override string SaveToXml() => "<Definition />";
+
+	private double SourceBaseWeight => Parent.Prototype.Weight * Parent.Quantity;
+
+	public double MaximumOutputWeight(bool success) => _prototype.MaximumOutputWeight(SourceBaseWeight, success);
+
+	public bool CanSalvage(out string reason)
+	{
+		if (!_prototype.ConfigurationIsComplete(out reason))
+		{
+			return false;
+		}
+
+		if (Parent.Deleted)
+		{
+			reason = "it no longer exists";
+			return false;
+		}
+
+		if (IndependentNestedItems().Any())
+		{
+			reason = "it still contains another item";
+			return false;
+		}
+
+		if (Parent.GetItemTypes<ILiquidContainer>().Any(x => x.LiquidVolume > 1.0e-9))
+		{
+			reason = "it still contains liquid";
+			return false;
+		}
+
+		if (MaximumOutputWeight(true) > SourceBaseWeight + 1.0e-9 ||
+		    MaximumOutputWeight(false) > SourceBaseWeight + 1.0e-9)
+		{
+			reason = "its configured products exceed its source-base-mass budget";
+			return false;
+		}
+
+		reason = string.Empty;
+		return true;
+	}
+
+	private IEnumerable<IGameItem> IndependentNestedItems()
+	{
+		foreach (var item in Parent.DeepItems.Skip(1).Concat(Parent.AttachedAndConnectedItems))
+		{
+			yield return item;
+		}
+
+		foreach (var sheath in Parent.GetItemTypes<ISheath>())
+		{
+			if (sheath is IMultiSlotSheath multi)
+			{
+				foreach (var content in multi.WieldableContents)
+				{
+					yield return content.Parent;
+				}
+			}
+			else if (sheath.Content is not null)
+			{
+				yield return sheath.Content.Parent;
+			}
+		}
+
+		foreach (var item in Parent.GetItemTypes<IRangedWeaponPlatform>().SelectMany(x => x.AllContainedItems))
+		{
+			yield return item;
+		}
+
+		foreach (var item in Parent.GetItemTypes<IAutomationHousing>().SelectMany(x => x.ConcealedItems))
+		{
+			yield return item;
+		}
+
+		foreach (var mount in Parent.GetItemTypes<IArtilleryMount>())
+		{
+			if (mount.InstalledPiece is not null)
+			{
+				yield return mount.InstalledPiece;
+			}
+		}
+
+		foreach (var carrier in Parent.GetItemTypes<IWeaponCarrierAttachment>())
+		{
+			if (carrier.AttachedWeapon is not null)
+			{
+				yield return carrier.AttachedWeapon;
+			}
+		}
+
+		foreach (var chamber in Parent.GetItemTypes<IArtilleryChamber>())
+		{
+			if (chamber.LoadedAmmunition is not null)
+			{
+				yield return chamber.LoadedAmmunition.Parent;
+			}
+		}
+	}
+
+	public IEnumerable<IGameItem> CreateProducts(ICharacter actor, bool success)
+	{
+		var products = new List<IGameItem>();
+		var plan = _prototype.CreateProductPlan(SourceBaseWeight, success);
+		foreach (var (product, weight) in plan.Commodities)
+		{
+			if (CommodityGameItemComponentProto.ItemPrototype is null)
+			{
+				CommodityGameItemComponentProto.InitialiseItemType(Gameworld);
+			}
+
+			var item = CommodityGameItemComponentProto.CreateNewCommodity(product.Material, weight, product.Tag);
+			InitialiseProduct(actor, item);
+			products.Add(item);
+		}
+
+		foreach (var (product, quantity) in plan.Items)
+		{
+			if (product.ItemPrototype.IsItemType<StackableGameItemComponentProto>())
+			{
+				var item = product.ItemPrototype.CreateNew(actor);
+				item.GetItemType<IStackable>().Quantity = quantity;
+				InitialiseProduct(actor, item);
+				products.Add(item);
+				continue;
+			}
+
+			for (var i = 0; i < quantity; i++)
+			{
+				var item = product.ItemPrototype.CreateNew(actor);
+				InitialiseProduct(actor, item);
+				products.Add(item);
+			}
+		}
+
+		return products;
+	}
+
+	private void InitialiseProduct(ICharacter actor, IGameItem item)
+	{
+		item.SetOwner(actor);
+		Gameworld.Add(item);
+		ButcherySpatialPlacement.Place(item, actor, Parent.RoomLayer, true);
+		item.HandleEvent(EventType.ItemFinishedLoading, item);
+		item.Login();
+	}
+}

--- a/MudSharpCore/GameItems/Components/SalvageableGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/SalvageableGameItemComponent.cs
@@ -156,44 +156,63 @@ public class SalvageableGameItemComponent : GameItemComponent, ISalvageable
 		}
 	}
 
-	public IEnumerable<IGameItem> CreateProducts(ICharacter actor, bool success)
+	public IReadOnlyList<IGameItem> CreateProducts(ICharacter actor, bool success)
 	{
 		var products = new List<IGameItem>();
-		var plan = _prototype.CreateProductPlan(SourceBaseWeight, success);
-		foreach (var (product, weight) in plan.Commodities)
+		try
 		{
-			if (CommodityGameItemComponentProto.ItemPrototype is null)
+			var plan = _prototype.CreateProductPlan(SourceBaseWeight, success);
+			foreach (var (product, weight) in plan.Commodities)
 			{
-				CommodityGameItemComponentProto.InitialiseItemType(Gameworld);
-			}
+				if (CommodityGameItemComponentProto.ItemPrototype is null)
+				{
+					CommodityGameItemComponentProto.InitialiseItemType(Gameworld);
+				}
 
-			var item = CommodityGameItemComponentProto.CreateNewCommodity(product.Material, weight, product.Tag);
-			InitialiseProduct(actor, item);
-			products.Add(item);
-		}
-
-		foreach (var (product, quantity) in plan.Items)
-		{
-			var itemPrototype = product.ItemPrototype ?? throw new InvalidOperationException(
-				$"Salvage item product #{product.ItemPrototypeId}r{product.ItemPrototypeRevision} was unresolved after validation.");
-			if (itemPrototype.IsItemType<StackableGameItemComponentProto>())
-			{
-				var item = itemPrototype.CreateNew(actor);
-				item.GetItemType<IStackable>().Quantity = quantity;
-				InitialiseProduct(actor, item);
+				var item = CommodityGameItemComponentProto.CreateNewCommodity(product.Material, weight, product.Tag);
 				products.Add(item);
-				continue;
-			}
-
-			for (var i = 0; i < quantity; i++)
-			{
-				var item = itemPrototype.CreateNew(actor);
 				InitialiseProduct(actor, item);
-				products.Add(item);
 			}
-		}
 
-		return products;
+			foreach (var (product, quantity) in plan.Items)
+			{
+				var itemPrototype = product.ItemPrototype ?? throw new InvalidOperationException(
+					$"Salvage item product #{product.ItemPrototypeId}r{product.ItemPrototypeRevision} was unresolved after validation.");
+				if (itemPrototype.IsItemType<StackableGameItemComponentProto>())
+				{
+					var item = itemPrototype.CreateNew(actor);
+					item.GetItemType<IStackable>().Quantity = quantity;
+					products.Add(item);
+					InitialiseProduct(actor, item);
+					continue;
+				}
+
+				for (var i = 0; i < quantity; i++)
+				{
+					var item = itemPrototype.CreateNew(actor);
+					products.Add(item);
+					InitialiseProduct(actor, item);
+				}
+			}
+
+			return products;
+		}
+		catch
+			{
+			foreach (var product in products.AsEnumerable().Reverse().Where(x => !x.Deleted))
+			{
+				try
+				{
+					product.Delete();
+				}
+				catch
+				{
+					// Preserve the original creation failure while making a best-effort rollback of every staged product.
+				}
+			}
+
+			throw;
+		}
 	}
 
 	private void InitialiseProduct(ICharacter actor, IGameItem item)

--- a/MudSharpCore/GameItems/Components/SalvageableGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/SalvageableGameItemComponent.cs
@@ -163,9 +163,11 @@ public class SalvageableGameItemComponent : GameItemComponent, ISalvageable
 
 		foreach (var (product, quantity) in plan.Items)
 		{
-			if (product.ItemPrototype.IsItemType<StackableGameItemComponentProto>())
+			var itemPrototype = product.ItemPrototype ?? throw new InvalidOperationException(
+				$"Salvage item product #{product.ItemPrototypeId}r{product.ItemPrototypeRevision} was unresolved after validation.");
+			if (itemPrototype.IsItemType<StackableGameItemComponentProto>())
 			{
-				var item = product.ItemPrototype.CreateNew(actor);
+				var item = itemPrototype.CreateNew(actor);
 				item.GetItemType<IStackable>().Quantity = quantity;
 				InitialiseProduct(actor, item);
 				products.Add(item);
@@ -174,7 +176,7 @@ public class SalvageableGameItemComponent : GameItemComponent, ISalvageable
 
 			for (var i = 0; i < quantity; i++)
 			{
-				var item = product.ItemPrototype.CreateNew(actor);
+				var item = itemPrototype.CreateNew(actor);
 				InitialiseProduct(actor, item);
 				products.Add(item);
 			}

--- a/MudSharpCore/GameItems/Prototypes/SalvageableGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/SalvageableGameItemComponentProto.cs
@@ -67,6 +67,8 @@ public sealed record SalvageProductPlan(
 
 public class SalvageableGameItemComponentProto : GameItemComponentProto, ISalvageablePrototype
 {
+	public const int MaximumItemProductsPerSalvage = 100;
+
 	public override string TypeDescription => "Salvageable";
 	public ITraitDefinition? Trait { get; private set; }
 	public Difficulty Difficulty { get; private set; } = Difficulty.Normal;
@@ -202,9 +204,57 @@ public class SalvageableGameItemComponentProto : GameItemComponentProto, ISalvag
 			return false;
 		}
 
+		if (_stages.Any(x => !double.IsFinite(x.Delay) || x.Delay <= 0.0))
+		{
+			reason = "it has a salvage stage with an invalid delay";
+			return false;
+		}
+
+		var invalidEmote = _stages
+			.Select(x => new Emote(x.Emote, new DummyPerceiver(), new DummyPerceivable(), new DummyPerceivable(),
+				new DummyPerceivable()))
+			.FirstOrDefault(x => !x.Valid);
+		if (invalidEmote is not null)
+		{
+			reason = $"it has an invalid salvage stage emote: {invalidEmote.ErrorMessage}";
+			return false;
+		}
+
 		if (_commodityProducts.Count + _itemProducts.Count == 0)
 		{
 			reason = "it has no salvage products configured";
+			return false;
+		}
+
+		if (_commodityProducts.Any(x =>
+			!double.IsFinite(x.SuccessAmount) ||
+			!double.IsFinite(x.FailureAmount) ||
+			x.SuccessAmount < 0.0 ||
+			x.FailureAmount < 0.0 ||
+			x.IsFraction && (x.SuccessAmount > 1.0 || x.FailureAmount > 1.0)))
+		{
+			reason = "it has an invalid commodity product amount";
+			return false;
+		}
+
+		if (_itemProducts.Any(x =>
+			!double.IsFinite(x.SuccessChance) ||
+			!double.IsFinite(x.FailureChance) ||
+			x.SuccessChance < 0.0 ||
+			x.SuccessChance > 1.0 ||
+			x.FailureChance < 0.0 ||
+			x.FailureChance > 1.0 ||
+			x.SuccessQuantity < 0 ||
+			x.FailureQuantity < 0))
+		{
+			reason = "it has an invalid item product quantity or chance";
+			return false;
+		}
+
+		if (_itemProducts.Sum(x => (long)Math.Max(x.SuccessQuantity, x.FailureQuantity)) >
+			MaximumItemProductsPerSalvage)
+		{
+			reason = $"it has more than {MaximumItemProductsPerSalvage:N0} possible item products";
 			return false;
 		}
 
@@ -254,7 +304,7 @@ public class SalvageableGameItemComponentProto : GameItemComponentProto, ISalvag
 			trait <trait> - sets the skill or attribute used by the salvage check
 			difficulty <difficulty> - sets the salvage check difficulty
 			tool <tag|none> - sets or clears the required held-tool tag
-			stage add <seconds> <emote> - adds a visible salvage stage
+		stage add <seconds> <emote> - adds a visible salvage stage; use $0 for the salvager, $1 for the source and $2 for the held tool
 			stage remove <number> - removes a stage
 			commodity fixed <material> <success weight> <failure weight> [<tag>] - adds fixed commodity output
 			commodity fraction <material> <success percent> <failure percent> [<tag>] - adds source-base-mass fractional output
@@ -351,13 +401,23 @@ public class SalvageableGameItemComponentProto : GameItemComponentProto, ISalvag
 			return true;
 		}
 
-		if (!action.EqualToAny("add", "new") || !double.TryParse(command.PopSpeech(), out var delay) || delay <= 0.0 || command.IsFinished)
+		if (!action.EqualToAny("add", "new") || !double.TryParse(command.PopSpeech(), out var delay) ||
+			!double.IsFinite(delay) || delay <= 0.0 || command.IsFinished)
 		{
 			actor.OutputHandler.Send("Use stage add <seconds> <emote> or stage remove <number>.");
 			return false;
 		}
 
-		_stages.Add((command.SafeRemainingArgument, delay));
+		var emoteText = command.SafeRemainingArgument;
+		var emote = new Emote(emoteText, new DummyPerceiver(), new DummyPerceivable(), new DummyPerceivable(),
+			new DummyPerceivable());
+		if (!emote.Valid)
+		{
+			actor.OutputHandler.Send(emote.ErrorMessage);
+			return false;
+		}
+
+		_stages.Add((emoteText, delay));
 		Changed = true;
 		actor.OutputHandler.Send($"A {delay:N1}-second salvage stage has been added.");
 		return true;
@@ -396,9 +456,12 @@ public class SalvageableGameItemComponentProto : GameItemComponentProto, ISalvag
 			return false;
 		}
 
-		if (success < 0.0 || failure < 0.0)
+		if (!double.IsFinite(success) || !double.IsFinite(failure) || success < 0.0 || failure < 0.0 ||
+			mode == "fraction" && (success > 1.0 || failure > 1.0))
 		{
-			actor.OutputHandler.Send("Product amounts cannot be negative.");
+			actor.OutputHandler.Send(mode == "fraction"
+				? "Fractional product amounts must be finite percentages from 0% to 100%."
+				: "Product amounts must be finite and cannot be negative.");
 			return false;
 		}
 
@@ -433,9 +496,13 @@ public class SalvageableGameItemComponentProto : GameItemComponentProto, ISalvag
 		if (!int.TryParse(command.PopSpeech(), out var successQuantity) || successQuantity < 0 ||
 		    !int.TryParse(command.PopSpeech(), out var failureQuantity) || failureQuantity < 0 ||
 		    !command.PopSpeech().TryParsePercentage(out var successChance) ||
-		    !command.PopSpeech().TryParsePercentage(out var failureChance))
+		    !command.PopSpeech().TryParsePercentage(out var failureChance) ||
+		    !double.IsFinite(successChance) || !double.IsFinite(failureChance) ||
+		    successChance is < 0.0 or > 1.0 || failureChance is < 0.0 or > 1.0 ||
+		    _itemProducts.Sum(x => (long)Math.Max(x.SuccessQuantity, x.FailureQuantity)) +
+		    Math.Max(successQuantity, failureQuantity) > MaximumItemProductsPerSalvage)
 		{
-			actor.OutputHandler.Send("Specify non-negative success/failure quantities and valid success/failure chances.");
+			actor.OutputHandler.Send($"Specify non-negative success/failure quantities, chances from 0% to 100%, and no more than {MaximumItemProductsPerSalvage:N0} possible item products.");
 			return false;
 		}
 

--- a/MudSharpCore/GameItems/Prototypes/SalvageableGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/SalvageableGameItemComponentProto.cs
@@ -1,0 +1,477 @@
+using MudSharp.Accounts;
+using MudSharp.Body.Traits;
+using MudSharp.Form.Material;
+using MudSharp.Framework.Revision;
+using MudSharp.Framework.Units;
+using MudSharp.GameItems.Components;
+using MudSharp.GameItems.Inventory;
+using MudSharp.GameItems.Inventory.Plans;
+using MudSharp.RPG.Checks;
+using System.Globalization;
+
+#nullable enable
+
+namespace MudSharp.GameItems.Prototypes;
+
+public sealed record SalvageCommodityProduct(
+	ISolid Material,
+	ITag? Tag,
+	bool IsFraction,
+	double SuccessAmount,
+	double FailureAmount)
+{
+	public double Weight(double sourceBaseWeight, bool success)
+	{
+		var amount = success ? SuccessAmount : FailureAmount;
+		return IsFraction ? sourceBaseWeight * amount : amount;
+	}
+}
+
+public sealed record SalvageItemProduct(
+	IGameItemProto ItemPrototype,
+	int SuccessQuantity,
+	int FailureQuantity,
+	double SuccessChance,
+	double FailureChance)
+{
+	public int Quantity(bool success) => success ? SuccessQuantity : FailureQuantity;
+	public double Chance(bool success) => success ? SuccessChance : FailureChance;
+}
+
+public sealed record SalvageProductPlan(
+	IReadOnlyList<(SalvageCommodityProduct Product, double Weight)> Commodities,
+	IReadOnlyList<(SalvageItemProduct Product, int Quantity)> Items);
+
+public class SalvageableGameItemComponentProto : GameItemComponentProto, ISalvageablePrototype
+{
+	public override string TypeDescription => "Salvageable";
+	public ITraitDefinition? Trait { get; private set; }
+	public Difficulty Difficulty { get; private set; } = Difficulty.Normal;
+	public ITag? RequiredToolTag { get; private set; }
+	public IReadOnlyList<(string Emote, double Delay)> Stages => _stages;
+	public IReadOnlyList<SalvageCommodityProduct> CommodityProducts => _commodityProducts;
+	public IReadOnlyList<SalvageItemProduct> ItemProducts => _itemProducts;
+	public IInventoryPlanTemplate ToolTemplate { get; private set; } = null!;
+
+	private readonly List<(string Emote, double Delay)> _stages = [];
+	private readonly List<SalvageCommodityProduct> _commodityProducts = [];
+	private readonly List<SalvageItemProduct> _itemProducts = [];
+
+	protected SalvageableGameItemComponentProto(IFuturemud gameworld, IAccount originator)
+		: base(gameworld, originator, "Salvageable")
+	{
+		RecalculateInventoryPlan();
+	}
+
+	protected SalvageableGameItemComponentProto(Models.GameItemComponentProto proto, IFuturemud gameworld)
+		: base(proto, gameworld)
+	{
+		RecalculateInventoryPlan();
+	}
+
+	protected override void LoadFromXml(XElement root)
+	{
+		Trait = Gameworld.Traits.Get(long.Parse(root.Element("Trait")?.Value ?? "0"));
+		Difficulty = (Difficulty)int.Parse(root.Element("Difficulty")?.Value ?? ((int)Difficulty.Normal).ToString());
+		RequiredToolTag = Gameworld.Tags.Get(long.Parse(root.Element("ToolTag")?.Value ?? "0"));
+
+		foreach (var element in root.Element("Stages")?.Elements("Stage") ?? [])
+		{
+			_stages.Add((element.Value, double.Parse(element.Attribute("delay")!.Value, CultureInfo.InvariantCulture)));
+		}
+
+		foreach (var element in root.Element("CommodityProducts")?.Elements("Product") ?? [])
+		{
+			var material = Gameworld.Materials.Get(long.Parse(element.Attribute("material")!.Value)) as ISolid;
+			if (material is null)
+			{
+				continue;
+			}
+
+			_commodityProducts.Add(new SalvageCommodityProduct(
+				material,
+				Gameworld.Tags.Get(long.Parse(element.Attribute("tag")?.Value ?? "0")),
+				bool.Parse(element.Attribute("fraction")?.Value ?? "false"),
+				double.Parse(element.Attribute("success")!.Value, CultureInfo.InvariantCulture),
+				double.Parse(element.Attribute("failure")!.Value, CultureInfo.InvariantCulture)));
+		}
+
+		foreach (var element in root.Element("ItemProducts")?.Elements("Product") ?? [])
+		{
+			var itemProto = Gameworld.ItemProtos.Get(
+				long.Parse(element.Attribute("id")!.Value),
+				int.Parse(element.Attribute("revision")!.Value));
+			if (itemProto is null)
+			{
+				continue;
+			}
+
+			_itemProducts.Add(new SalvageItemProduct(
+				itemProto,
+				int.Parse(element.Attribute("successQuantity")!.Value),
+				int.Parse(element.Attribute("failureQuantity")!.Value),
+				double.Parse(element.Attribute("successChance")!.Value, CultureInfo.InvariantCulture),
+				double.Parse(element.Attribute("failureChance")!.Value, CultureInfo.InvariantCulture)));
+		}
+	}
+
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition",
+			new XElement("Trait", Trait?.Id ?? 0L),
+			new XElement("Difficulty", (int)Difficulty),
+			new XElement("ToolTag", RequiredToolTag?.Id ?? 0L),
+			new XElement("Stages",
+				_stages.Select(x => new XElement("Stage", new XAttribute("delay", x.Delay), new XCData(x.Emote)))),
+			new XElement("CommodityProducts",
+				_commodityProducts.Select(x => new XElement("Product",
+					new XAttribute("material", x.Material.Id),
+					new XAttribute("tag", x.Tag?.Id ?? 0L),
+					new XAttribute("fraction", x.IsFraction),
+					new XAttribute("success", x.SuccessAmount),
+					new XAttribute("failure", x.FailureAmount)))),
+			new XElement("ItemProducts",
+				_itemProducts.Select(x => new XElement("Product",
+					new XAttribute("id", x.ItemPrototype.Id),
+					new XAttribute("revision", x.ItemPrototype.RevisionNumber),
+					new XAttribute("successQuantity", x.SuccessQuantity),
+					new XAttribute("failureQuantity", x.FailureQuantity),
+					new XAttribute("successChance", x.SuccessChance),
+					new XAttribute("failureChance", x.FailureChance))))).ToString();
+	}
+
+	private void RecalculateInventoryPlan()
+	{
+		ToolTemplate = new InventoryPlanTemplate(Gameworld,
+		[
+			new InventoryPlanPhaseTemplate(1, RequiredToolTag is null
+				? []
+				: [new InventoryPlanActionHold(Gameworld, RequiredToolTag.Id, 0, _ => true, null, 1)])
+		]);
+	}
+
+	public double MaximumOutputWeight(double sourceBaseWeight, bool success)
+	{
+		return _commodityProducts.Sum(x => x.Weight(sourceBaseWeight, success)) +
+		       _itemProducts.Sum(x => x.ItemPrototype.Weight * x.Quantity(success));
+	}
+
+	public SalvageProductPlan CreateProductPlan(double sourceBaseWeight, bool success, Func<double>? random = null)
+	{
+		random ??= () => RandomUtilities.DoubleRandom(0.0, 1.0);
+		var commodities = _commodityProducts
+			.Select(x => (Product: x, Weight: x.Weight(sourceBaseWeight, success)))
+			.Where(x => x.Weight > 0.0)
+			.ToList();
+		var items = _itemProducts
+			.Select(x => (Product: x, Quantity: x.Quantity(success)))
+			.Where(x => x.Quantity > 0 && x.Product.Chance(success) > 0.0 &&
+			            random() < x.Product.Chance(success))
+			.ToList();
+		return new SalvageProductPlan(commodities, items);
+	}
+
+	public bool ConfigurationIsComplete(out string reason)
+	{
+		if (Trait is null)
+		{
+			reason = "it has no salvage trait configured";
+			return false;
+		}
+
+		if (_stages.Count == 0)
+		{
+			reason = "it has no salvage stages configured";
+			return false;
+		}
+
+		if (_commodityProducts.Count + _itemProducts.Count == 0)
+		{
+			reason = "it has no salvage products configured";
+			return false;
+		}
+
+		if (_commodityProducts.Any(x => x.FailureAmount > x.SuccessAmount) ||
+		    _itemProducts.Any(x => x.FailureQuantity > x.SuccessQuantity ||
+		                           x.FailureChance > x.SuccessChance))
+		{
+			reason = "its failure products are not reduced from its success products";
+			return false;
+		}
+
+		reason = string.Empty;
+		return true;
+	}
+
+	public override IGameItemComponent CreateNew(IGameItem parent, ICharacter? loader = null, bool temporary = false)
+		=> new SalvageableGameItemComponent(this, parent, temporary);
+
+	public override IGameItemComponent LoadComponent(Models.GameItemComponent component, IGameItem parent)
+		=> new SalvageableGameItemComponent(component, this, parent);
+
+	public override IEditableRevisableItem CreateNewRevision(ICharacter initiator)
+		=> CreateNewRevision(initiator, (proto, gameworld) => new SalvageableGameItemComponentProto(proto, gameworld));
+
+	public static void RegisterComponentInitialiser(GameItemComponentManager manager)
+	{
+		manager.AddBuilderLoader("salvageable", true,
+			(gameworld, account) => new SalvageableGameItemComponentProto(gameworld, account));
+		manager.AddDatabaseLoader("Salvageable",
+			(proto, gameworld) => new SalvageableGameItemComponentProto(proto, gameworld));
+		manager.AddTypeHelpInfo("Salvageable",
+			"Makes an ordinary item explicitly eligible for staged salvage into authored commodity and item products",
+			BuildingHelpText);
+	}
+
+	private const string BuildingHelpText = """
+		You can use the following options with this component:
+			name <name> - sets the name
+			desc <description> - sets the description
+			trait <trait> - sets the skill or attribute used by the salvage check
+			difficulty <difficulty> - sets the salvage check difficulty
+			tool <tag|none> - sets or clears the required held-tool tag
+			stage add <seconds> <emote> - adds a visible salvage stage
+			stage remove <number> - removes a stage
+			commodity fixed <material> <success weight> <failure weight> [<tag>] - adds fixed commodity output
+			commodity fraction <material> <success percent> <failure percent> [<tag>] - adds source-base-mass fractional output
+			item <prototype> <success quantity> <failure quantity> <success chance> <failure chance> - adds item output
+			product remove <number> - removes a product from the displayed combined list
+		""";
+
+	public override string ShowBuildingHelp => BuildingHelpText;
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		var verb = command.PopSpeech().ToLowerInvariant();
+		return verb switch
+		{
+			"trait" => BuildingCommandTrait(actor, command),
+			"difficulty" => BuildingCommandDifficulty(actor, command),
+			"tool" => BuildingCommandTool(actor, command),
+			"stage" => BuildingCommandStage(actor, command),
+			"commodity" => BuildingCommandCommodity(actor, command),
+			"item" => BuildingCommandItem(actor, command),
+			"product" => BuildingCommandProduct(actor, command),
+			_ => base.BuildingCommand(actor, new StringStack($"{verb} {command.RemainingArgument}"))
+		};
+	}
+
+	private bool BuildingCommandTrait(ICharacter actor, StringStack command)
+	{
+		var trait = Gameworld.Traits.GetByIdOrName(command.SafeRemainingArgument);
+		if (trait is null)
+		{
+			actor.OutputHandler.Send("There is no such trait.");
+			return false;
+		}
+
+		Trait = trait;
+		Changed = true;
+		actor.OutputHandler.Send($"This component now uses the {trait.Name.ColourName()} trait.");
+		return true;
+	}
+
+	private bool BuildingCommandDifficulty(ICharacter actor, StringStack command)
+	{
+		if (!command.SafeRemainingArgument.TryParseEnum(out Difficulty difficulty))
+		{
+			actor.OutputHandler.Send("That is not a valid difficulty.");
+			return false;
+		}
+
+		Difficulty = difficulty;
+		Changed = true;
+		actor.OutputHandler.Send($"The salvage check is now {difficulty.Describe().ColourValue()}.");
+		return true;
+	}
+
+	private bool BuildingCommandTool(ICharacter actor, StringStack command)
+	{
+		if (command.SafeRemainingArgument.EqualToAny("none", "clear", "remove"))
+		{
+			RequiredToolTag = null;
+			RecalculateInventoryPlan();
+			Changed = true;
+			actor.OutputHandler.Send("This component no longer requires a tool.");
+			return true;
+		}
+
+		var tags = Gameworld.Tags.FindMatchingTags(command.SafeRemainingArgument);
+		if (tags.Count != 1)
+		{
+			actor.OutputHandler.Send(tags.Count == 0 ? "There is no such tag." : "That text matches more than one tag.");
+			return false;
+		}
+
+		RequiredToolTag = tags.Single();
+		RecalculateInventoryPlan();
+		Changed = true;
+		actor.OutputHandler.Send($"Salvage now requires a held tool tagged {RequiredToolTag.FullName.ColourName()}.");
+		return true;
+	}
+
+	private bool BuildingCommandStage(ICharacter actor, StringStack command)
+	{
+		var action = command.PopSpeech().ToLowerInvariant();
+		if (action.EqualToAny("remove", "delete", "del"))
+		{
+			if (!int.TryParse(command.SafeRemainingArgument, out var index) || index < 1 || index > _stages.Count)
+			{
+				actor.OutputHandler.Send("Which valid stage number do you want to remove?");
+				return false;
+			}
+
+			_stages.RemoveAt(index - 1);
+			Changed = true;
+			actor.OutputHandler.Send($"Stage {index:N0} has been removed.");
+			return true;
+		}
+
+		if (!action.EqualToAny("add", "new") || !double.TryParse(command.PopSpeech(), out var delay) || delay <= 0.0 || command.IsFinished)
+		{
+			actor.OutputHandler.Send("Use stage add <seconds> <emote> or stage remove <number>.");
+			return false;
+		}
+
+		_stages.Add((command.SafeRemainingArgument, delay));
+		Changed = true;
+		actor.OutputHandler.Send($"A {delay:N1}-second salvage stage has been added.");
+		return true;
+	}
+
+	private bool BuildingCommandCommodity(ICharacter actor, StringStack command)
+	{
+		var mode = command.PopSpeech().ToLowerInvariant();
+		if (!mode.EqualToAny("fixed", "fraction"))
+		{
+			actor.OutputHandler.Send("Specify either fixed or fraction.");
+			return false;
+		}
+
+		var material = Gameworld.Materials.GetByIdOrName(command.PopSpeech()) as ISolid;
+		if (material is null)
+		{
+			actor.OutputHandler.Send("There is no such solid material.");
+			return false;
+		}
+
+		double success;
+		double failure;
+		if (mode == "fixed")
+		{
+			if (!Gameworld.UnitManager.TryGetBaseUnits(command.PopSpeech(), UnitType.Mass, actor, out success) ||
+			    !Gameworld.UnitManager.TryGetBaseUnits(command.PopSpeech(), UnitType.Mass, actor, out failure))
+			{
+				actor.OutputHandler.Send("Specify valid success and failure weights.");
+				return false;
+			}
+		}
+		else if (!command.PopSpeech().TryParsePercentage(out success) || !command.PopSpeech().TryParsePercentage(out failure))
+		{
+			actor.OutputHandler.Send("Specify valid success and failure percentages.");
+			return false;
+		}
+
+		if (success < 0.0 || failure < 0.0)
+		{
+			actor.OutputHandler.Send("Product amounts cannot be negative.");
+			return false;
+		}
+
+		ITag? tag = null;
+		if (!command.IsFinished)
+		{
+			var tags = Gameworld.Tags.FindMatchingTags(command.SafeRemainingArgument);
+			if (tags.Count != 1)
+			{
+				actor.OutputHandler.Send("The optional commodity tag must identify exactly one tag.");
+				return false;
+			}
+
+			tag = tags.Single();
+		}
+
+		_commodityProducts.Add(new SalvageCommodityProduct(material, tag, mode == "fraction", success, failure));
+		Changed = true;
+		actor.OutputHandler.Send($"A {material.Name.ColourName()} commodity product has been added.");
+		return true;
+	}
+
+	private bool BuildingCommandItem(ICharacter actor, StringStack command)
+	{
+		var itemProto = Gameworld.ItemProtos.GetByIdOrName(command.PopSpeech());
+		if (itemProto is null)
+		{
+			actor.OutputHandler.Send("There is no such item prototype.");
+			return false;
+		}
+
+		if (!int.TryParse(command.PopSpeech(), out var successQuantity) || successQuantity < 0 ||
+		    !int.TryParse(command.PopSpeech(), out var failureQuantity) || failureQuantity < 0 ||
+		    !command.PopSpeech().TryParsePercentage(out var successChance) ||
+		    !command.PopSpeech().TryParsePercentage(out var failureChance))
+		{
+			actor.OutputHandler.Send("Specify non-negative success/failure quantities and valid success/failure chances.");
+			return false;
+		}
+
+		_itemProducts.Add(new SalvageItemProduct(itemProto, successQuantity, failureQuantity, successChance, failureChance));
+		Changed = true;
+		actor.OutputHandler.Send($"Item prototype {itemProto.EditHeader().ColourName()} has been added as a product.");
+		return true;
+	}
+
+	private bool BuildingCommandProduct(ICharacter actor, StringStack command)
+	{
+		if (!command.PopSpeech().EqualToAny("remove", "delete", "del") ||
+		    !int.TryParse(command.SafeRemainingArgument, out var index) || index < 1 ||
+		    index > _commodityProducts.Count + _itemProducts.Count)
+		{
+			actor.OutputHandler.Send("Use product remove <valid product number>.");
+			return false;
+		}
+
+		if (index <= _commodityProducts.Count)
+		{
+			_commodityProducts.RemoveAt(index - 1);
+		}
+		else
+		{
+			_itemProducts.RemoveAt(index - _commodityProducts.Count - 1);
+		}
+
+		Changed = true;
+		actor.OutputHandler.Send($"Product {index:N0} has been removed.");
+		return true;
+	}
+
+	public override string ComponentDescriptionOLC(ICharacter actor)
+	{
+		var sb = new StringBuilder();
+		sb.AppendLine($"Salvageable Component #{Id:N0}r{RevisionNumber:N0} ({Name})");
+		sb.AppendLine($"Check: {Trait?.Name ?? "None"} / {Difficulty.Describe()}");
+		sb.AppendLine($"Tool Tag: {RequiredToolTag?.FullName ?? "None"}");
+		sb.AppendLine("Stages:");
+		foreach (var (stage, index) in _stages.Select((x, i) => (x, i + 1)))
+		{
+			sb.AppendLine($"  {index:N0}. {stage.Delay:N1}s - {stage.Emote}");
+		}
+		sb.AppendLine("Products:");
+		var productIndex = 1;
+		foreach (var product in _commodityProducts)
+		{
+			sb.AppendLine($"  {productIndex++:N0}. commodity {product.Material.Name}; success {DescribeAmount(product, true, actor)}, failure {DescribeAmount(product, false, actor)}");
+		}
+		foreach (var product in _itemProducts)
+		{
+			sb.AppendLine($"  {productIndex++:N0}. item {product.ItemPrototype.EditHeader()}; success {product.SuccessQuantity:N0} @ {product.SuccessChance:P2}, failure {product.FailureQuantity:N0} @ {product.FailureChance:P2}");
+		}
+		return sb.ToString();
+	}
+
+	private string DescribeAmount(SalvageCommodityProduct product, bool success, ICharacter actor)
+	{
+		var amount = success ? product.SuccessAmount : product.FailureAmount;
+		return product.IsFraction ? amount.ToString("P2", actor) : Gameworld.UnitManager.DescribeExact(amount, UnitType.Mass, actor);
+	}
+}

--- a/MudSharpCore/GameItems/Prototypes/SalvageableGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/SalvageableGameItemComponentProto.cs
@@ -27,13 +27,36 @@ public sealed record SalvageCommodityProduct(
 	}
 }
 
-public sealed record SalvageItemProduct(
-	IGameItemProto ItemPrototype,
-	int SuccessQuantity,
-	int FailureQuantity,
-	double SuccessChance,
-	double FailureChance)
+public sealed class SalvageItemProduct
 {
+	private readonly IFuturemud _gameworld;
+
+	public SalvageItemProduct(IFuturemud gameworld, long itemPrototypeId, int itemPrototypeRevision,
+		int successQuantity, int failureQuantity, double successChance, double failureChance)
+	{
+		_gameworld = gameworld;
+		ItemPrototypeId = itemPrototypeId;
+		ItemPrototypeRevision = itemPrototypeRevision;
+		SuccessQuantity = successQuantity;
+		FailureQuantity = failureQuantity;
+		SuccessChance = successChance;
+		FailureChance = failureChance;
+	}
+
+	public SalvageItemProduct(IFuturemud gameworld, IGameItemProto itemPrototype,
+		int successQuantity, int failureQuantity, double successChance, double failureChance)
+		: this(gameworld, itemPrototype.Id, itemPrototype.RevisionNumber, successQuantity, failureQuantity,
+			failureChance: failureChance, successChance: successChance)
+	{
+	}
+
+	public long ItemPrototypeId { get; }
+	public int ItemPrototypeRevision { get; }
+	public IGameItemProto? ItemPrototype => _gameworld.ItemProtos.Get(ItemPrototypeId, ItemPrototypeRevision);
+	public int SuccessQuantity { get; }
+	public int FailureQuantity { get; }
+	public double SuccessChance { get; }
+	public double FailureChance { get; }
 	public int Quantity(bool success) => success ? SuccessQuantity : FailureQuantity;
 	public double Chance(bool success) => success ? SuccessChance : FailureChance;
 }
@@ -98,16 +121,10 @@ public class SalvageableGameItemComponentProto : GameItemComponentProto, ISalvag
 
 		foreach (var element in root.Element("ItemProducts")?.Elements("Product") ?? [])
 		{
-			var itemProto = Gameworld.ItemProtos.Get(
-				long.Parse(element.Attribute("id")!.Value),
-				int.Parse(element.Attribute("revision")!.Value));
-			if (itemProto is null)
-			{
-				continue;
-			}
-
 			_itemProducts.Add(new SalvageItemProduct(
-				itemProto,
+				Gameworld,
+				long.Parse(element.Attribute("id")!.Value),
+				int.Parse(element.Attribute("revision")!.Value),
 				int.Parse(element.Attribute("successQuantity")!.Value),
 				int.Parse(element.Attribute("failureQuantity")!.Value),
 				double.Parse(element.Attribute("successChance")!.Value, CultureInfo.InvariantCulture),
@@ -132,8 +149,8 @@ public class SalvageableGameItemComponentProto : GameItemComponentProto, ISalvag
 					new XAttribute("failure", x.FailureAmount)))),
 			new XElement("ItemProducts",
 				_itemProducts.Select(x => new XElement("Product",
-					new XAttribute("id", x.ItemPrototype.Id),
-					new XAttribute("revision", x.ItemPrototype.RevisionNumber),
+					new XAttribute("id", x.ItemPrototypeId),
+					new XAttribute("revision", x.ItemPrototypeRevision),
 					new XAttribute("successQuantity", x.SuccessQuantity),
 					new XAttribute("failureQuantity", x.FailureQuantity),
 					new XAttribute("successChance", x.SuccessChance),
@@ -153,7 +170,7 @@ public class SalvageableGameItemComponentProto : GameItemComponentProto, ISalvag
 	public double MaximumOutputWeight(double sourceBaseWeight, bool success)
 	{
 		return _commodityProducts.Sum(x => x.Weight(sourceBaseWeight, success)) +
-		       _itemProducts.Sum(x => x.ItemPrototype.Weight * x.Quantity(success));
+		       _itemProducts.Sum(x => (x.ItemPrototype?.Weight ?? double.PositiveInfinity) * x.Quantity(success));
 	}
 
 	public SalvageProductPlan CreateProductPlan(double sourceBaseWeight, bool success, Func<double>? random = null)
@@ -188,6 +205,13 @@ public class SalvageableGameItemComponentProto : GameItemComponentProto, ISalvag
 		if (_commodityProducts.Count + _itemProducts.Count == 0)
 		{
 			reason = "it has no salvage products configured";
+			return false;
+		}
+
+		var unresolvedProduct = _itemProducts.FirstOrDefault(x => x.ItemPrototype is null);
+		if (unresolvedProduct is not null)
+		{
+			reason = $"its configured item product #{unresolvedProduct.ItemPrototypeId:N0}r{unresolvedProduct.ItemPrototypeRevision:N0} is unavailable";
 			return false;
 		}
 
@@ -415,7 +439,7 @@ public class SalvageableGameItemComponentProto : GameItemComponentProto, ISalvag
 			return false;
 		}
 
-		_itemProducts.Add(new SalvageItemProduct(itemProto, successQuantity, failureQuantity, successChance, failureChance));
+		_itemProducts.Add(new SalvageItemProduct(Gameworld, itemProto, successQuantity, failureQuantity, successChance, failureChance));
 		Changed = true;
 		actor.OutputHandler.Send($"Item prototype {itemProto.EditHeader().ColourName()} has been added as a product.");
 		return true;
@@ -464,7 +488,9 @@ public class SalvageableGameItemComponentProto : GameItemComponentProto, ISalvag
 		}
 		foreach (var product in _itemProducts)
 		{
-			sb.AppendLine($"  {productIndex++:N0}. item {product.ItemPrototype.EditHeader()}; success {product.SuccessQuantity:N0} @ {product.SuccessChance:P2}, failure {product.FailureQuantity:N0} @ {product.FailureChance:P2}");
+			var productDescription = product.ItemPrototype?.EditHeader() ??
+			                         $"unresolved item #{product.ItemPrototypeId:N0}r{product.ItemPrototypeRevision:N0}";
+			sb.AppendLine($"  {productIndex++:N0}. item {productDescription}; success {product.SuccessQuantity:N0} @ {product.SuccessChance:P2}, failure {product.FailureQuantity:N0} @ {product.FailureChance:P2}");
 		}
 		return sb.ToString();
 	}


### PR DESCRIPTION
## What changed

- adds a revisioned `Salvageable` item component for ordinary items without changing corpse or bodypart butchery
- supports ordered staged work, tool and skill checks, distinct success/failure commodity and exact item-prototype products, source locking, and guarded nested state
- preserves exact item-product references across clean-load ordering and fails visibly if a referenced prototype remains unresolved
- adds a stable, exactly-once full-description disclosure for salvageable items

## Why

Ordinary items previously had no explicit, component-owned salvage contract. Reusing corpse/bodypart butchery would mix unrelated ownership and persistence semantics. This keeps ordinary-item salvage opt-in, revisioned, and independent while reusing only the established source-relative output placement helper.

## Validation

- `SalvageableComponentTests`: 14/14 passed
- affected component exclusivity, butchery, and spatial-placement suite: 45/45 passed
- complete `MudSharpCore Unit Tests`: 2,355/2,355 passed on the final head
  - 2,333 tests ran together
  - 20 safe `ForagingRuntimeTests` ran separately
  - 2 foraging rows using the existing uninitialized-`Futuremud` fixture ran in their own host to avoid that fixture's finalizer crash
- `git diff --check`: passed
- stable patch IDs match the accepted four-commit series

## Contract and migration

Attachment ownership, create/save/load/copy/first-consumer lifecycle, staged interruption/completion/concurrency, commodity and exact-item variants, independent nested state, source topology, semantic ordering, canonical XML, and disclosure duplication are covered on the final head. No schema migration, numeric ID, seeded binding, or game-specific content is included.
