### PR TITLE
Add revisioned atomic loot tables

### DIFF
--- a/DatabaseSeeder Unit Tests/BlankDatabaseSnapshotTests.cs
+++ b/DatabaseSeeder Unit Tests/BlankDatabaseSnapshotTests.cs
@@ -52,7 +52,8 @@ public class BlankDatabaseSnapshotTests
 		         {
 			         "__EFMigrationsHistory", "Vehicles", "VehicleOccupantSlotProtos",
 			         "VehicleMovementProfileProtos", "VehiclePropulsionProfileProtos",
-			         "CharacterCombatSettings", "TraitDefinitions", "RangedCovers"
+			         "CharacterCombatSettings", "TraitDefinitions", "RangedCovers", "LootTables",
+			         "EditableItems"
 		         })
 		{
 			Assert.IsFalse(deltas.Contains($"`{table}`", StringComparison.Ordinal),

--- a/DatabaseSeeder/BlankDatabaseSnapshot.manifest.json
+++ b/DatabaseSeeder/BlankDatabaseSnapshot.manifest.json
@@ -1,5 +1,5 @@
 {
   "ProductVersion": "3.1.0.0",
-  "LatestMigrationId": "20260816012516_HospitalServiceConsentPolicy",
-  "GeneratedUtc": "2026-08-16T01:25:16Z"
+  "LatestMigrationId": "20260816094719_AddLootTables",
+  "GeneratedUtc": "2026-08-17T03:22:27Z"
 }

--- a/DatabaseSeeder/BlankDatabaseSnapshot.sql
+++ b/DatabaseSeeder/BlankDatabaseSnapshot.sql
@@ -14896,3 +14896,56 @@ END //
 DELIMITER ;
 CALL MigrationsScript();
 DROP PROCEDURE MigrationsScript;
+
+-- EF-generated idempotent delta: 20260816094719_AddLootTables
+DROP PROCEDURE IF EXISTS MigrationsScript;
+DELIMITER //
+CREATE PROCEDURE MigrationsScript()
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM `__efmigrationshistory` WHERE `MigrationId` = '20260816094719_AddLootTables') THEN
+
+    CREATE TABLE `loottables` (
+        `Id` bigint(20) NOT NULL,
+        `RevisionNumber` int(11) NOT NULL,
+        `EditableItemId` bigint(20) NOT NULL,
+        `Name` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+        `Definition` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+        `AlgorithmVersion` int(11) NOT NULL,
+        CONSTRAINT `PRIMARY` PRIMARY KEY (`Id`, `RevisionNumber`),
+        CONSTRAINT `FK_LootTables_EditableItems` FOREIGN KEY (`EditableItemId`) REFERENCES `editableitems` (`Id`) ON DELETE CASCADE
+    ) CHARACTER SET=utf8mb4;
+
+    END IF;
+END //
+DELIMITER ;
+CALL MigrationsScript();
+DROP PROCEDURE MigrationsScript;
+
+DROP PROCEDURE IF EXISTS MigrationsScript;
+DELIMITER //
+CREATE PROCEDURE MigrationsScript()
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM `__efmigrationshistory` WHERE `MigrationId` = '20260816094719_AddLootTables') THEN
+
+    CREATE INDEX `FK_LootTables_EditableItems_idx` ON `loottables` (`EditableItemId`);
+
+    END IF;
+END //
+DELIMITER ;
+CALL MigrationsScript();
+DROP PROCEDURE MigrationsScript;
+
+DROP PROCEDURE IF EXISTS MigrationsScript;
+DELIMITER //
+CREATE PROCEDURE MigrationsScript()
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM `__efmigrationshistory` WHERE `MigrationId` = '20260816094719_AddLootTables') THEN
+
+    INSERT INTO `__efmigrationshistory` (`MigrationId`, `ProductVersion`)
+    VALUES ('20260816094719_AddLootTables', '9.0.11');
+
+    END IF;
+END //
+DELIMITER ;
+CALL MigrationsScript();
+DROP PROCEDURE MigrationsScript;

--- a/Design Documents/Features/LootTables.md
+++ b/Design Documents/Features/LootTables.md
@@ -35,7 +35,7 @@ Changing Group 3's destination from `target` to `vessel` would place the child t
 
 Each revision stores a canonical XML definition and SHA-256 hash. A definition contains named variants; each variant contains explicitly ordered roll groups; and each group selects one positively weighted choice per repetition. Groups target either the invocation target or a stable item key produced exactly once by an earlier group.
 
-Choices create an exact item-prototype revision, create a commodity from an exact solid and optional tag, invoke an exact nested loot-table revision and variant, or explicitly create nothing. Item choices may author quantity, quality, characteristic values and a result key. Commodity choices author a mass range. Nesting is acyclic and a realised plan is limited to 1,000 leaves.
+Choices create an exact item-prototype revision, create a commodity from an exact solid and optional tag, invoke an exact nested loot-table revision and variant, or explicitly create nothing. Item choices may author quantity, quality, characteristic values, initial open/lock state and a result key. Commodity choices author a mass range. Nesting is acyclic and a realised plan is limited to 1,000 leaves.
 
 Deterministic decisions use algorithm version 1 (`sha256-path-v1`). Semantic decision paths include exact table revision, variant, group key, repetition, choice key and field. Integer selection uses rejection sampling. Canonical saves preserve explicit group and choice ordering and sort only unordered semantic collections such as variants and characteristic assignments.
 
@@ -70,6 +70,8 @@ loottable edit
 | Result | The resolved item, commodity or exact nested-table reference and its authored ranges. |
 
 Commodity mass accepts explicit units such as `125g` and `1.5kg`. Bare numeric values remain accepted as engine base mass units for compatibility, but new definitions should use explicit units.
+
+Items start in their prototype's normal open and unlocked state. Add `closed` when a generated openable item must begin closed, or `locked` when a generated item with a built-in lock must begin closed and locked. These states are applied only after all planned contents have been inserted, so the full package remains atomic.
 
 `loottable validate` resolves every exact reference, confirms local destinations, rejects nesting cycles and enforces the expansion limit. `loottable preview` produces the complete realised plan and digest without creating anything. `loottable load` is the administrator test path and accepts `here`, `into <item>` or `to <character>`.
 

--- a/Design Documents/Features/LootTables.md
+++ b/Design Documents/Features/LootTables.md
@@ -1,0 +1,34 @@
+# Loot Tables
+
+Loot tables are revisioned, builder-authored definitions for atomically creating item and commodity graphs. They are generic engine content: a caller supplies an exact table revision, variant, destination and optional deterministic seed. Tables do not own depletion, one-shot state, Region bindings or gameplay conditions.
+
+## Definition
+
+Each revision stores a canonical XML definition and SHA-256 hash. A definition contains named variants; each variant contains explicitly ordered roll groups; and each group selects one positively weighted choice per repetition. Groups target either the invocation target or a stable item key produced exactly once by an earlier group.
+
+Choices create an exact item-prototype revision, create a commodity from an exact solid and optional tag, invoke an exact nested loot-table revision and variant, or explicitly create nothing. Item choices may author quantity, quality, characteristic values and a result key. Commodity choices author a mass range. Nesting is acyclic and a realised plan is limited to 1,000 leaves.
+
+Deterministic decisions use algorithm version 1 (`sha256-path-v1`). Semantic decision paths include exact table revision, variant, group key, repetition, choice key and field. Integer selection uses rejection sampling. Canonical saves preserve explicit group and choice ordering and sort only unordered semantic collections such as variants and characteristic assignments.
+
+## Builder surface
+
+Use `loottable` (alias `lt`) for normal editable-revision lifecycle commands: `list`, `show`, `new`, `clone`, `edit`, `close`, `revise`, `submit` and `review`. Definition editing uses `set variant`, `set group` and `set choice`. `loottable validate` resolves every exact reference and destination constraint. `loottable preview` produces the complete realised plan and digest without creating objects. `loottable load` is the administrator test path and accepts `here`, `into <item>` or `to <character>`.
+
+## FutureProg
+
+`loadloottable` returns Text and has seeded and unseeded overloads for Location, Item and Character destinations:
+
+```
+loadloottable(Number tableId, Number revision, Location target, Text variant) -> Text
+loadloottable(Number tableId, Number revision, Location target, Text variant, Number seed) -> Text
+loadloottable(Number tableId, Number revision, Item target, Text variant) -> Text
+loadloottable(Number tableId, Number revision, Item target, Text variant, Number seed) -> Text
+loadloottable(Number tableId, Number revision, Character target, Text variant) -> Text
+loadloottable(Number tableId, Number revision, Character target, Text variant, Number seed) -> Text
+```
+
+Success returns a canonical `OK` receipt with exact revision/hash, algorithm, variant, actual seed, root item IDs, created count and plan digest. Failure returns a stable `ERROR code=...` receipt. Creation is staged, all destinations are preflighted, merging is disabled, and any creation, placement, event or persistence failure deletes every staged object and leaves no residue.
+
+## Persistence
+
+Migration `AddLootTables` adds one `LootTables` table keyed by `(Id, RevisionNumber)` and linked to `EditableItems`. It stores name, algorithm version and canonical definition payload. No existing content is migrated automatically.

--- a/Design Documents/Features/LootTables.md
+++ b/Design Documents/Features/LootTables.md
@@ -1,6 +1,6 @@
 # Loot Tables
 
-Loot tables let a builder describe a package of generated items and commodities in a form that another human can inspect. The engine plans the whole package first and then creates it atomically: either every result reaches its intended destination, or every staged result is removed.
+Loot tables let a builder describe a package of generated items and commodities in a form that another human can inspect. The engine plans the whole package first and then creates it atomically: item existence and placement either complete as a package or are rolled back. Prototype on-load scripts are ordinary engine side effects and must be safe to run in this context.
 
 A caller supplies an exact table revision, variant, destination and optional deterministic seed. Tables do not own depletion, one-shot state, Region bindings or gameplay conditions.
 
@@ -35,7 +35,7 @@ Changing Group 3's destination from `target` to `vessel` would place the child t
 
 Each revision stores a canonical XML definition and SHA-256 hash. A definition contains named variants; each variant contains explicitly ordered roll groups; and each group selects one positively weighted choice per repetition. Groups target either the invocation target or a stable item key produced exactly once by an earlier group.
 
-Choices create an exact item-prototype revision, create a commodity from an exact solid and optional tag, invoke an exact nested loot-table revision and variant, or explicitly create nothing. Item choices may author quantity, quality, characteristic values, initial open/lock state and a result key. Commodity choices author a mass range. Nesting is acyclic and a realised plan is limited to 1,000 leaves.
+Choices create an exact item-prototype revision, create a commodity from an exact solid and optional tag, invoke an exact nested loot-table revision and variant, or explicitly create nothing. Item choices may author quantity, quality, characteristic values, initial open/lock state and a result key. Commodity choices author a mass range. Nesting is acyclic and every possible branch is bounded to 1,000 generated items, counting an item choice's full quantity.
 
 Deterministic decisions use algorithm version 1 (`sha256-path-v1`). Semantic decision paths include exact table revision, variant, group key, repetition, choice key and field. Integer selection uses rejection sampling. Canonical saves preserve explicit group and choice ordering and sort only unordered semantic collections such as variants and characteristic assignments.
 
@@ -88,7 +88,7 @@ loadloottable(Number tableId, Number revision, Character target, Text variant) -
 loadloottable(Number tableId, Number revision, Character target, Text variant, Number seed) -> Text
 ```
 
-Success returns a canonical `OK` receipt with exact revision/hash, algorithm, variant, actual seed, root item IDs, created count and plan digest. Failure returns a stable `ERROR code=...` receipt. Creation is staged, all destinations are preflighted, merging is disabled, and any creation, placement, event or persistence failure deletes every staged object and leaves no residue.
+Success returns a canonical `OK` receipt with exact revision/hash, algorithm, variant, actual seed, root item IDs, created count and plan digest. Failure returns a stable `ERROR code=...` receipt. Creation is staged, all destinations are preflighted, merging is disabled, and any creation, placement, event or persistence failure attempts to delete every staged object. Item existence and placement are rollback-safe; prototype on-load FutureProg side effects execute during creation and therefore must themselves be safe to run in this context, because arbitrary script side effects cannot be unwound by the loot system.
 
 ## Persistence
 

--- a/Design Documents/Features/LootTables.md
+++ b/Design Documents/Features/LootTables.md
@@ -1,6 +1,35 @@
 # Loot Tables
 
-Loot tables are revisioned, builder-authored definitions for atomically creating item and commodity graphs. They are generic engine content: a caller supplies an exact table revision, variant, destination and optional deterministic seed. Tables do not own depletion, one-shot state, Region bindings or gameplay conditions.
+Loot tables let a builder describe a package of generated items and commodities in a form that another human can inspect. The engine plans the whole package first and then creates it atomically: either every result reaches its intended destination, or every staged result is removed.
+
+A caller supplies an exact table revision, variant, destination and optional deterministic seed. Tables do not own depletion, one-shot state, Region bindings or gameplay conditions.
+
+## Mental model
+
+A LootTable is an ordered recipe:
+
+1. A **variant** is a named version of the recipe, such as `default`, `damaged` or `premium`.
+2. A variant runs its **groups** from top to bottom.
+3. Each group repeats within its authored range and selects one weighted **choice** each time.
+4. A choice creates an item, creates a commodity, invokes another exact LootTable revision, or deliberately creates nothing.
+5. An item choice may provide a **local key**. Later groups can direct their products inside that particular generated container.
+
+Table nesting and physical containment are different. Invoking a child LootTable means “run this other recipe here.” The invoking group's destination decides whether the child results go to the outer target or inside an earlier keyed container.
+
+For example:
+
+```text
+Group 1: vessel -> create an envelope at the outer target; provide key "vessel"
+Group 2: contents -> create 125g carbon steel inside "vessel"
+Group 3: nested -> invoke the child table at the outer target
+
+Outer target
+├── envelope from Group 1
+│   └── 125g carbon steel from Group 2
+└── child table's root item from Group 3
+```
+
+Changing Group 3's destination from `target` to `vessel` would place the child table's root inside the first envelope instead.
 
 ## Definition
 
@@ -10,9 +39,39 @@ Choices create an exact item-prototype revision, create a commodity from an exac
 
 Deterministic decisions use algorithm version 1 (`sha256-path-v1`). Semantic decision paths include exact table revision, variant, group key, repetition, choice key and field. Integer selection uses rejection sampling. Canonical saves preserve explicit group and choice ordering and sort only unordered semantic collections such as variants and characteristic assignments.
 
-## Builder surface
+## Builder workflow
 
-Use `loottable` (alias `lt`) for normal editable-revision lifecycle commands: `list`, `show`, `new`, `clone`, `edit`, `close`, `revise`, `submit` and `review`. Definition editing uses `set variant`, `set group` and `set choice`. `loottable validate` resolves every exact reference and destination constraint. `loottable preview` produces the complete realised plan and digest without creating objects. `loottable load` is the administrator test path and accepts `here`, `into <item>` or `to <character>`.
+Use `loottable` (alias `lt`) for normal editable-revision lifecycle commands: `list`, `show`, `new`, `clone`, `edit`, `close`, `revise`, `submit` and `review`.
+
+A small container example can be authored as follows:
+
+```text
+loottable new "Example Parcel"
+loottable set group add default vessel
+loottable set choice add default vessel envelope 1 item 53 revision 0 quantity 1 1 quality 5 5 as vessel
+loottable set group add default contents into vessel
+loottable set choice add default contents steel 1 commodity 24 tag 264 mass 125g 125g
+loottable set group add default child
+loottable set choice add default child nested 1 table 1 0 default
+loottable validate "Example Parcel"
+loottable preview "Example Parcel" default 202
+loottable edit
+```
+
+`loottable show` presents each variant as a table. Its columns mean:
+
+| Column | Meaning |
+|---|---|
+| Group | Execution order and the builder's stable group name. |
+| Repeat | How many selections this group makes. |
+| Destination | `Outer target` or an earlier local item key. |
+| Choice | The stable semantic key used by deterministic planning. |
+| Weight / Chance | Relative selection weight and its displayed probability within this group. |
+| Result | The resolved item, commodity or exact nested-table reference and its authored ranges. |
+
+Commodity mass accepts explicit units such as `125g` and `1.5kg`. Bare numeric values remain accepted as engine base mass units for compatibility, but new definitions should use explicit units.
+
+`loottable validate` resolves every exact reference, confirms local destinations, rejects nesting cycles and enforces the expansion limit. `loottable preview` produces the complete realised plan and digest without creating anything. `loottable load` is the administrator test path and accepts `here`, `into <item>` or `to <character>`.
 
 ## FutureProg
 

--- a/FutureMUDLibrary/Body/IInventory.cs
+++ b/FutureMUDLibrary/Body/IInventory.cs
@@ -401,6 +401,9 @@ namespace MudSharp.Body
         IGameItem? Get(IGameItem item, int quantity, IEmote? playerEmote, bool silent, ItemCanGetIgnore ignoreFlags,
             IEnumerable<IHandleEvents> witnessHandlers);
 
+		/// <summary>Places a complete item into held inventory without merging it into an existing stack.</summary>
+		IGameItem? GetWithoutMerge(IGameItem item, bool silent = true);
+
         void Get(IGameItem item, IGameItem containerItem, int quantity = 0, IEmote? playerEmote = null, bool silent = false, ItemCanGetIgnore ignoreFlags = ItemCanGetIgnore.None);
 
         IGameItem? Get(IGameItem item, IGameItem containerItem, int quantity, IEmote? playerEmote, bool silent,

--- a/FutureMUDLibrary/Framework/IFuturemud.cs
+++ b/FutureMUDLibrary/Framework/IFuturemud.cs
@@ -77,6 +77,7 @@ using MudSharp.Work.Butchering;
 using MudSharp.Work.Agriculture;
 using MudSharp.Work.Crafts;
 using MudSharp.Work.Foraging;
+using MudSharp.Work.Loot;
 using MudSharp.Work.Projects;
 using System;
 using System.Collections.Generic;
@@ -190,6 +191,7 @@ namespace MudSharp.Framework
         IUneditableRevisableAll<IForagable> Foragables { get; }
         IUneditableRevisableAll<IForagableProfile> ForagableProfiles { get; }
         IUneditableRevisableAll<ITrapTemplate> TrapTemplates { get; }
+        IUneditableRevisableAll<ILootTable> LootTables { get; }
         IUneditableAll<IFutureProg> FutureProgs { get; }
         IUneditableAll<IGas> Gases { get; }
         IUneditableAll<IGrid> Grids { get; }
@@ -523,6 +525,7 @@ namespace MudSharp.Framework
         void Add(IBodypart proto);
         void Add(IForagableProfile foragableProfile);
         void Add(ITrapTemplate trapTemplate);
+        void Add(ILootTable lootTable);
         void Add(IForagable foragable);
         void Add(IGameItemGroup group);
         void Add(ICorpseModel model);
@@ -675,6 +678,7 @@ namespace MudSharp.Framework
         void Destroy(IBodypart proto);
         void Destroy(IForagableProfile foragableProfile);
         void Destroy(ITrapTemplate trapTemplate);
+        void Destroy(ILootTable lootTable);
         void Destroy(IForagable foragable);
         void Destroy(ICorpseModel model);
         void Destroy(IGameItemGroup group);

--- a/FutureMUDLibrary/Framework/IFuturemudLoader.cs
+++ b/FutureMUDLibrary/Framework/IFuturemudLoader.cs
@@ -17,6 +17,7 @@ namespace MudSharp.Framework
         void LoadMaterials();
         void LoadForagables();
         void LoadTrapTemplates();
+        void LoadLootTables();
         void LoadCharacteristics();
         void LoadBodies();
         void LoadBodypartShapes();

--- a/FutureMUDLibrary/Work/Loot/ILootTable.cs
+++ b/FutureMUDLibrary/Work/Loot/ILootTable.cs
@@ -1,0 +1,12 @@
+#nullable enable
+
+using MudSharp.Framework.Revision;
+
+namespace MudSharp.Work.Loot;
+
+public interface ILootTable : IEditableRevisableItem
+{
+	int AlgorithmVersion { get; }
+	LootTableDefinition Definition { get; }
+	string DefinitionHash { get; }
+}

--- a/FutureMUDLibrary/Work/Loot/LootAtomicBatch.cs
+++ b/FutureMUDLibrary/Work/Loot/LootAtomicBatch.cs
@@ -25,7 +25,14 @@ public static class LootAtomicBatch
 		}
 		catch
 		{
-			rollback(created);
+			try
+			{
+				rollback(created);
+			}
+			catch
+			{
+				// The operation failure is more useful to callers than a secondary rollback error.
+			}
 			throw;
 		}
 	}

--- a/FutureMUDLibrary/Work/Loot/LootAtomicBatch.cs
+++ b/FutureMUDLibrary/Work/Loot/LootAtomicBatch.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+
+namespace MudSharp.Work.Loot;
+
+public static class LootAtomicBatch
+{
+	public static IReadOnlyList<TCreated> Execute<TPlan, TCreated>(
+		IEnumerable<TPlan> plan,
+		Func<TPlan, IEnumerable<TCreated>> create,
+		Action<IReadOnlyList<TCreated>> preflight,
+		Action<IReadOnlyList<TCreated>> commit,
+		Action<IReadOnlyList<TCreated>> rollback)
+	{
+		var created = new List<TCreated>();
+		try
+		{
+			foreach (var entry in plan)
+			{
+				foreach (var value in create(entry)) created.Add(value);
+			}
+			preflight(created);
+			commit(created);
+			return created;
+		}
+		catch
+		{
+			rollback(created);
+			throw;
+		}
+	}
+}

--- a/FutureMUDLibrary/Work/Loot/LootTableDefinition.cs
+++ b/FutureMUDLibrary/Work/Loot/LootTableDefinition.cs
@@ -62,6 +62,14 @@ public sealed class LootTableDefinition
 								new XAttribute("quantityMax", choice.QuantityMaximum),
 								new XAttribute("qualityMin", choice.QualityMinimum),
 								new XAttribute("qualityMax", choice.QualityMaximum));
+							if (choice.StartsClosed)
+							{
+								choiceElement.Add(new XAttribute("closed", true));
+							}
+							if (choice.StartsLocked)
+							{
+								choiceElement.Add(new XAttribute("locked", true));
+							}
 							if (!string.IsNullOrEmpty(choice.ResultKey))
 							{
 								choiceElement.Add(new XAttribute("resultKey", choice.ResultKey));
@@ -165,6 +173,8 @@ public sealed class LootTableDefinition
 							choice.QuantityMaximum = RequiredInt(choiceElement, "quantityMax");
 							choice.QualityMinimum = RequiredInt(choiceElement, "qualityMin");
 							choice.QualityMaximum = RequiredInt(choiceElement, "qualityMax");
+							choice.StartsClosed = OptionalBool(choiceElement, "closed");
+							choice.StartsLocked = OptionalBool(choiceElement, "locked");
 							choice.ResultKey = (string?)choiceElement.Attribute("resultKey");
 							foreach (var characteristic in choiceElement.Elements("Characteristic"))
 							{
@@ -211,6 +221,8 @@ public sealed class LootTableDefinition
 		long.TryParse((string?)element.Attribute(name), NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
 			? value
 			: null;
+	private static bool OptionalBool(XElement element, string name) =>
+		bool.TryParse((string?)element.Attribute(name), out var value) && value;
 	private static double RequiredDouble(XElement element, string name) =>
 		double.Parse(RequiredString(element, name), NumberStyles.Float, CultureInfo.InvariantCulture);
 }
@@ -242,6 +254,8 @@ public sealed class LootChoiceDefinition
 	public int QuantityMaximum { get; set; } = 1;
 	public int QualityMinimum { get; set; } = 5;
 	public int QualityMaximum { get; set; } = 5;
+	public bool StartsClosed { get; set; }
+	public bool StartsLocked { get; set; }
 	public string? ResultKey { get; set; }
 	public List<LootCharacteristicValue> Characteristics { get; } = [];
 

--- a/FutureMUDLibrary/Work/Loot/LootTableDefinition.cs
+++ b/FutureMUDLibrary/Work/Loot/LootTableDefinition.cs
@@ -1,0 +1,262 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Xml.Linq;
+
+namespace MudSharp.Work.Loot;
+
+public enum LootChoiceKind
+{
+	Nothing = 0,
+	Item = 1,
+	Commodity = 2,
+	LootTable = 3
+}
+
+public sealed class LootTableDefinition
+{
+	public const int CurrentAlgorithmVersion = 1;
+
+	public int AlgorithmVersion { get; set; } = CurrentAlgorithmVersion;
+	public List<LootVariantDefinition> Variants { get; } = [];
+
+	public LootTableDefinition Clone() => Load(ToCanonicalXml());
+
+	public string ToCanonicalXml()
+	{
+		var root = new XElement("LootTable", new XAttribute("algorithm", AlgorithmVersion));
+		foreach (var variant in Variants.OrderBy(x => x.Key, StringComparer.Ordinal))
+		{
+			var variantElement = new XElement("Variant", new XAttribute("key", variant.Key));
+			for (var groupIndex = 0; groupIndex < variant.Groups.Count; groupIndex++)
+			{
+				var group = variant.Groups[groupIndex];
+				var groupElement = new XElement("Group",
+					new XAttribute("order", groupIndex),
+					new XAttribute("key", group.Key),
+					new XAttribute("repeatMin", group.RepeatMinimum),
+					new XAttribute("repeatMax", group.RepeatMaximum),
+					new XAttribute("destination", group.DestinationKey));
+
+				for (var choiceIndex = 0; choiceIndex < group.Choices.Count; choiceIndex++)
+				{
+					var choice = group.Choices[choiceIndex];
+					var choiceElement = new XElement("Choice",
+						new XAttribute("order", choiceIndex),
+						new XAttribute("key", choice.Key),
+						new XAttribute("weight", choice.Weight),
+						new XAttribute("kind", choice.Kind.ToString()));
+
+					switch (choice.Kind)
+					{
+						case LootChoiceKind.Item:
+							choiceElement.Add(
+								new XAttribute("prototype", choice.ItemPrototypeId),
+								new XAttribute("revision", choice.ItemPrototypeRevision),
+								new XAttribute("quantityMin", choice.QuantityMinimum),
+								new XAttribute("quantityMax", choice.QuantityMaximum),
+								new XAttribute("qualityMin", choice.QualityMinimum),
+								new XAttribute("qualityMax", choice.QualityMaximum));
+							if (!string.IsNullOrEmpty(choice.ResultKey))
+							{
+								choiceElement.Add(new XAttribute("resultKey", choice.ResultKey));
+							}
+
+							foreach (var characteristic in choice.Characteristics
+							             .OrderBy(x => x.DefinitionId)
+							             .ThenBy(x => x.ValueId))
+							{
+								choiceElement.Add(new XElement("Characteristic",
+									new XAttribute("definition", characteristic.DefinitionId),
+									new XAttribute("value", characteristic.ValueId)));
+							}
+							break;
+						case LootChoiceKind.Commodity:
+							choiceElement.Add(
+								new XAttribute("material", choice.CommodityMaterialId),
+								new XAttribute("massMin", FormatDouble(choice.MassMinimum)),
+								new XAttribute("massMax", FormatDouble(choice.MassMaximum)));
+							if (choice.CommodityTagId is not null)
+							{
+								choiceElement.Add(new XAttribute("tag", choice.CommodityTagId.Value));
+							}
+							break;
+						case LootChoiceKind.LootTable:
+							choiceElement.Add(
+								new XAttribute("table", choice.NestedTableId),
+								new XAttribute("revision", choice.NestedTableRevision),
+								new XAttribute("variant", choice.NestedVariant));
+							break;
+					}
+
+					groupElement.Add(choiceElement);
+				}
+
+				variantElement.Add(groupElement);
+			}
+
+			root.Add(variantElement);
+		}
+
+		return root.ToString(SaveOptions.DisableFormatting);
+	}
+
+	public string ComputeHash()
+	{
+		return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(ToCanonicalXml())));
+	}
+
+	public static LootTableDefinition Load(string xml)
+	{
+		var root = XElement.Parse(xml, LoadOptions.None);
+		if (!root.Name.LocalName.Equals("LootTable", StringComparison.Ordinal))
+		{
+			throw new FormatException("LootTable definition root is invalid.");
+		}
+
+		var definition = new LootTableDefinition
+		{
+			AlgorithmVersion = RequiredInt(root, "algorithm")
+		};
+
+		foreach (var variantElement in root.Elements("Variant")
+		                                  .OrderBy(x => RequiredString(x, "key"), StringComparer.Ordinal))
+		{
+			var variant = new LootVariantDefinition { Key = RequiredString(variantElement, "key") };
+			foreach (var groupElement in variantElement.Elements("Group")
+			                                            .OrderBy(x => RequiredInt(x, "order"))
+			                                            .ThenBy(x => RequiredString(x, "key"), StringComparer.Ordinal))
+			{
+				var group = new LootRollGroupDefinition
+				{
+					Key = RequiredString(groupElement, "key"),
+					RepeatMinimum = RequiredInt(groupElement, "repeatMin"),
+					RepeatMaximum = RequiredInt(groupElement, "repeatMax"),
+					DestinationKey = RequiredString(groupElement, "destination")
+				};
+
+				foreach (var choiceElement in groupElement.Elements("Choice")
+				                                           .OrderBy(x => RequiredInt(x, "order"))
+				                                           .ThenBy(x => RequiredString(x, "key"), StringComparer.Ordinal))
+				{
+					if (!Enum.TryParse<LootChoiceKind>(RequiredString(choiceElement, "kind"), out var kind))
+					{
+						throw new FormatException("LootTable choice kind is invalid.");
+					}
+
+					var choice = new LootChoiceDefinition
+					{
+						Key = RequiredString(choiceElement, "key"),
+						Weight = RequiredLong(choiceElement, "weight"),
+						Kind = kind
+					};
+
+					switch (kind)
+					{
+						case LootChoiceKind.Item:
+							choice.ItemPrototypeId = RequiredLong(choiceElement, "prototype");
+							choice.ItemPrototypeRevision = RequiredInt(choiceElement, "revision");
+							choice.QuantityMinimum = RequiredInt(choiceElement, "quantityMin");
+							choice.QuantityMaximum = RequiredInt(choiceElement, "quantityMax");
+							choice.QualityMinimum = RequiredInt(choiceElement, "qualityMin");
+							choice.QualityMaximum = RequiredInt(choiceElement, "qualityMax");
+							choice.ResultKey = (string?)choiceElement.Attribute("resultKey");
+							foreach (var characteristic in choiceElement.Elements("Characteristic"))
+							{
+								choice.Characteristics.Add(new LootCharacteristicValue
+								{
+									DefinitionId = RequiredLong(characteristic, "definition"),
+									ValueId = RequiredLong(characteristic, "value")
+								});
+							}
+							break;
+						case LootChoiceKind.Commodity:
+							choice.CommodityMaterialId = RequiredLong(choiceElement, "material");
+							choice.CommodityTagId = OptionalLong(choiceElement, "tag");
+							choice.MassMinimum = RequiredDouble(choiceElement, "massMin");
+							choice.MassMaximum = RequiredDouble(choiceElement, "massMax");
+							break;
+						case LootChoiceKind.LootTable:
+							choice.NestedTableId = RequiredLong(choiceElement, "table");
+							choice.NestedTableRevision = RequiredInt(choiceElement, "revision");
+							choice.NestedVariant = RequiredString(choiceElement, "variant");
+							break;
+					}
+
+					group.Choices.Add(choice);
+				}
+
+				variant.Groups.Add(group);
+			}
+
+			definition.Variants.Add(variant);
+		}
+
+		return definition;
+	}
+
+	private static string FormatDouble(double value) => value.ToString("R", CultureInfo.InvariantCulture);
+	private static string RequiredString(XElement element, string name) =>
+		(string?)element.Attribute(name) ?? throw new FormatException($"Missing LootTable attribute {name}.");
+	private static int RequiredInt(XElement element, string name) =>
+		int.Parse(RequiredString(element, name), NumberStyles.Integer, CultureInfo.InvariantCulture);
+	private static long RequiredLong(XElement element, string name) =>
+		long.Parse(RequiredString(element, name), NumberStyles.Integer, CultureInfo.InvariantCulture);
+	private static long? OptionalLong(XElement element, string name) =>
+		long.TryParse((string?)element.Attribute(name), NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+			? value
+			: null;
+	private static double RequiredDouble(XElement element, string name) =>
+		double.Parse(RequiredString(element, name), NumberStyles.Float, CultureInfo.InvariantCulture);
+}
+
+public sealed class LootVariantDefinition
+{
+	public string Key { get; set; } = "default";
+	public List<LootRollGroupDefinition> Groups { get; } = [];
+}
+
+public sealed class LootRollGroupDefinition
+{
+	public string Key { get; set; } = string.Empty;
+	public int RepeatMinimum { get; set; } = 1;
+	public int RepeatMaximum { get; set; } = 1;
+	public string DestinationKey { get; set; } = "target";
+	public List<LootChoiceDefinition> Choices { get; } = [];
+}
+
+public sealed class LootChoiceDefinition
+{
+	public string Key { get; set; } = string.Empty;
+	public long Weight { get; set; } = 1;
+	public LootChoiceKind Kind { get; set; }
+
+	public long ItemPrototypeId { get; set; }
+	public int ItemPrototypeRevision { get; set; }
+	public int QuantityMinimum { get; set; } = 1;
+	public int QuantityMaximum { get; set; } = 1;
+	public int QualityMinimum { get; set; } = 5;
+	public int QualityMaximum { get; set; } = 5;
+	public string? ResultKey { get; set; }
+	public List<LootCharacteristicValue> Characteristics { get; } = [];
+
+	public long CommodityMaterialId { get; set; }
+	public long? CommodityTagId { get; set; }
+	public double MassMinimum { get; set; }
+	public double MassMaximum { get; set; }
+
+	public long NestedTableId { get; set; }
+	public int NestedTableRevision { get; set; }
+	public string NestedVariant { get; set; } = "default";
+}
+
+public sealed class LootCharacteristicValue
+{
+	public long DefinitionId { get; set; }
+	public long ValueId { get; set; }
+}

--- a/FutureMUDLibrary/Work/Loot/LootTablePlanner.cs
+++ b/FutureMUDLibrary/Work/Loot/LootTablePlanner.cs
@@ -47,7 +47,8 @@ public sealed class LootTablePlanResult
 
 public sealed class LootTablePlanner
 {
-	public const int MaximumPlannedLeaves = 1000;
+	public const int MaximumPlannedItems = 1000;
+	public const int MaximumPlannedLeaves = MaximumPlannedItems;
 
 	private readonly Func<long, int, LootTablePlanSource?> _resolver;
 
@@ -71,13 +72,10 @@ public sealed class LootTablePlanner
 		try
 		{
 			var leaves = new List<LootPlannedLeaf>();
-			var ancestry = new HashSet<(long Id, int Revision)>();
+			var ancestry = new HashSet<(long Id, int Revision, string Variant)>();
+			var plannedItemCount = 0;
 			var rootIdentity = $"a:{root.Definition.AlgorithmVersion}|root:{root.Id}r{root.Revision}|seed:{seed}";
-			Expand(root, variant, seed, rootIdentity, "target", ancestry, leaves);
-			if (leaves.Count > MaximumPlannedLeaves)
-			{
-				return Error("EXPANSION_LIMIT", $"The realised plan exceeds {MaximumPlannedLeaves} leaves.");
-			}
+			Expand(root, variant, seed, rootIdentity, "target", ancestry, leaves, ref plannedItemCount);
 
 			return new LootTablePlanResult
 			{
@@ -107,23 +105,25 @@ public sealed class LootTablePlanner
 		long seed,
 		string path,
 		string targetDestination,
-		HashSet<(long Id, int Revision)> ancestry,
-		List<LootPlannedLeaf> leaves)
+		HashSet<(long Id, int Revision, string Variant)> ancestry,
+		List<LootPlannedLeaf> leaves,
+		ref int plannedItemCount)
 	{
-		if (!ancestry.Add((source.Id, source.Revision)))
+		var variant = source.Definition.Variants.SingleOrDefault(x =>
+			x.Key.Equals(variantKey, StringComparison.OrdinalIgnoreCase));
+		if (variant is null)
+		{
+			throw new LootPlanningException("VARIANT_NOT_FOUND", $"Variant {variantKey} does not exist.");
+		}
+
+		var identity = (source.Id, source.Revision, variant.Key);
+		if (!ancestry.Add(identity))
 		{
 			throw new LootPlanningException("CYCLE", "A nested LootTable cycle was encountered.");
 		}
 
 		try
 		{
-			var variant = source.Definition.Variants.SingleOrDefault(x =>
-				x.Key.Equals(variantKey, StringComparison.OrdinalIgnoreCase));
-			if (variant is null)
-			{
-				throw new LootPlanningException("VARIANT_NOT_FOUND", $"Variant {variantKey} does not exist.");
-			}
-
 			var scope = $"{path}|table:{source.Id}r{source.Revision}|variant:{variant.Key}";
 			foreach (var group in variant.Groups)
 			{
@@ -151,20 +151,21 @@ public sealed class LootTablePlanner
 					var choicePath = $"{repetitionPath}|choice:{choice.Key}";
 					switch (choice.Kind)
 					{
-						case LootChoiceKind.Nothing:
-							break;
-						case LootChoiceKind.Item:
-							ValidateIntegerRange(choice.QuantityMinimum, choice.QuantityMaximum, "INVALID_QUANTITY");
-							ValidateIntegerRange(choice.QualityMinimum, choice.QualityMaximum, "INVALID_QUALITY");
-							leaves.Add(new LootPlannedLeaf(
-								LootChoiceKind.Item,
+					case LootChoiceKind.Nothing:
+						break;
+					case LootChoiceKind.Item:
+						ValidateItemQuantityRange(choice.QuantityMinimum, choice.QuantityMaximum);
+						ValidateIntegerRange(choice.QualityMinimum, choice.QualityMaximum, "INVALID_QUALITY");
+						var quantity = DrawIntInclusive(seed, choicePath + "|field:quantity", choice.QuantityMinimum,
+							choice.QuantityMaximum);
+						AddLeaf(leaves, new LootPlannedLeaf(
+							LootChoiceKind.Item,
 								choicePath,
 								destination,
 								string.IsNullOrEmpty(choice.ResultKey) ? null : $"{scope}|key:{choice.ResultKey}",
 								choice.ItemPrototypeId,
 								choice.ItemPrototypeRevision,
-								DrawIntInclusive(seed, choicePath + "|field:quantity", choice.QuantityMinimum,
-									choice.QuantityMaximum),
+							quantity,
 								DrawIntInclusive(seed, choicePath + "|field:quality", choice.QualityMinimum,
 									choice.QualityMaximum),
 								choice.StartsClosed,
@@ -174,10 +175,10 @@ public sealed class LootTablePlanner
 									DefinitionId = x.DefinitionId,
 									ValueId = x.ValueId
 								}).ToList(),
-								0,
-								null,
-								0.0));
-							break;
+							0,
+							null,
+							0.0), quantity, ref plannedItemCount);
+						break;
 						case LootChoiceKind.Commodity:
 							if (!double.IsFinite(choice.MassMinimum) || !double.IsFinite(choice.MassMaximum) ||
 							    choice.MassMinimum <= 0.0 || choice.MassMaximum < choice.MassMinimum)
@@ -185,7 +186,7 @@ public sealed class LootTablePlanner
 								throw new LootPlanningException("INVALID_MASS", "A commodity mass range is invalid.");
 							}
 
-							leaves.Add(new LootPlannedLeaf(
+						AddLeaf(leaves, new LootPlannedLeaf(
 								LootChoiceKind.Commodity,
 								choicePath,
 								destination,
@@ -198,9 +199,9 @@ public sealed class LootTablePlanner
 								false,
 								[],
 								choice.CommodityMaterialId,
-								choice.CommodityTagId,
-								DrawDoubleInclusive(seed, choicePath + "|field:mass", choice.MassMinimum,
-									choice.MassMaximum)));
+							choice.CommodityTagId,
+							DrawDoubleInclusive(seed, choicePath + "|field:mass", choice.MassMinimum,
+								choice.MassMaximum)), 1, ref plannedItemCount);
 							break;
 						case LootChoiceKind.LootTable:
 							var nested = _resolver(choice.NestedTableId, choice.NestedTableRevision);
@@ -210,22 +211,39 @@ public sealed class LootTablePlanner
 									$"Nested LootTable {choice.NestedTableId}r{choice.NestedTableRevision} does not exist.");
 							}
 
-							Expand(nested, choice.NestedVariant, seed, choicePath, destination, ancestry, leaves);
-							break;
-					}
-
-					if (leaves.Count > MaximumPlannedLeaves)
-					{
-						throw new LootPlanningException("EXPANSION_LIMIT",
-							$"The realised plan exceeds {MaximumPlannedLeaves} leaves.");
-					}
+						Expand(nested, choice.NestedVariant, seed, choicePath, destination, ancestry, leaves,
+							ref plannedItemCount);
+						break;
+				}
 				}
 			}
 		}
 		finally
 		{
-			ancestry.Remove((source.Id, source.Revision));
+			ancestry.Remove(identity);
 		}
+	}
+
+	private static void AddLeaf(List<LootPlannedLeaf> leaves, LootPlannedLeaf leaf, int itemCount,
+		ref int plannedItemCount)
+	{
+		try
+		{
+			plannedItemCount = checked(plannedItemCount + itemCount);
+		}
+		catch (OverflowException)
+		{
+			throw new LootPlanningException("EXPANSION_LIMIT",
+				$"The realised plan exceeds {MaximumPlannedItems} generated items.");
+		}
+
+		if (plannedItemCount > MaximumPlannedItems)
+		{
+			throw new LootPlanningException("EXPANSION_LIMIT",
+				$"The realised plan exceeds {MaximumPlannedItems} generated items.");
+		}
+
+		leaves.Add(leaf);
 	}
 
 	private static LootChoiceDefinition SelectChoice(long seed, string path, IReadOnlyList<LootChoiceDefinition> choices)
@@ -296,6 +314,14 @@ public sealed class LootTablePlanner
 		if (minimum < 0 || maximum < minimum)
 		{
 			throw new LootPlanningException(code, "An integer range is invalid.");
+		}
+	}
+
+	private static void ValidateItemQuantityRange(int minimum, int maximum)
+	{
+		if (minimum < 1 || maximum < minimum)
+		{
+			throw new LootPlanningException("INVALID_QUANTITY", "An item quantity range is invalid.");
 		}
 	}
 

--- a/FutureMUDLibrary/Work/Loot/LootTablePlanner.cs
+++ b/FutureMUDLibrary/Work/Loot/LootTablePlanner.cs
@@ -1,0 +1,325 @@
+#nullable enable
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace MudSharp.Work.Loot;
+
+public sealed record LootTablePlanSource(long Id, int Revision, string Hash, LootTableDefinition Definition);
+
+public sealed record LootPlannedLeaf(
+	LootChoiceKind Kind,
+	string Path,
+	string DestinationKey,
+	string? ResultKey,
+	long ItemPrototypeId,
+	int ItemPrototypeRevision,
+	int Quantity,
+	int Quality,
+	IReadOnlyList<LootCharacteristicValue> Characteristics,
+	long CommodityMaterialId,
+	long? CommodityTagId,
+	double Mass);
+
+public sealed class LootTablePlan
+{
+	public required LootTablePlanSource Root { get; init; }
+	public required string Variant { get; init; }
+	public required long Seed { get; init; }
+	public required IReadOnlyList<LootPlannedLeaf> Leaves { get; init; }
+	public required string Digest { get; init; }
+}
+
+public sealed class LootTablePlanResult
+{
+	public LootTablePlan? Plan { get; init; }
+	public string? ErrorCode { get; init; }
+	public string? ErrorMessage { get; init; }
+	public bool Success => Plan is not null;
+}
+
+public sealed class LootTablePlanner
+{
+	public const int MaximumPlannedLeaves = 1000;
+
+	private readonly Func<long, int, LootTablePlanSource?> _resolver;
+
+	public LootTablePlanner(Func<long, int, LootTablePlanSource?> resolver)
+	{
+		_resolver = resolver;
+	}
+
+	public LootTablePlanResult CreatePlan(LootTablePlanSource root, string variant, long seed)
+	{
+		if (seed < 0)
+		{
+			return Error("INVALID_SEED", "The seed must be non-negative.");
+		}
+
+		if (root.Definition.AlgorithmVersion != LootTableDefinition.CurrentAlgorithmVersion)
+		{
+			return Error("UNSUPPORTED_ALGORITHM", "The LootTable algorithm version is not supported.");
+		}
+
+		try
+		{
+			var leaves = new List<LootPlannedLeaf>();
+			var ancestry = new HashSet<(long Id, int Revision)>();
+			var rootIdentity = $"a:{root.Definition.AlgorithmVersion}|root:{root.Id}r{root.Revision}|seed:{seed}";
+			Expand(root, variant, seed, rootIdentity, "target", ancestry, leaves);
+			if (leaves.Count > MaximumPlannedLeaves)
+			{
+				return Error("EXPANSION_LIMIT", $"The realised plan exceeds {MaximumPlannedLeaves} leaves.");
+			}
+
+			return new LootTablePlanResult
+			{
+				Plan = new LootTablePlan
+				{
+					Root = root,
+					Variant = variant,
+					Seed = seed,
+					Leaves = leaves,
+					Digest = ComputePlanDigest(leaves)
+				}
+			};
+		}
+		catch (LootPlanningException ex)
+		{
+			return Error(ex.Code, ex.Message);
+		}
+		catch (OverflowException)
+		{
+			return Error("WEIGHT_OVERFLOW", "Choice weights exceed the supported range.");
+		}
+	}
+
+	private void Expand(
+		LootTablePlanSource source,
+		string variantKey,
+		long seed,
+		string path,
+		string targetDestination,
+		HashSet<(long Id, int Revision)> ancestry,
+		List<LootPlannedLeaf> leaves)
+	{
+		if (!ancestry.Add((source.Id, source.Revision)))
+		{
+			throw new LootPlanningException("CYCLE", "A nested LootTable cycle was encountered.");
+		}
+
+		try
+		{
+			var variant = source.Definition.Variants.SingleOrDefault(x =>
+				x.Key.Equals(variantKey, StringComparison.OrdinalIgnoreCase));
+			if (variant is null)
+			{
+				throw new LootPlanningException("VARIANT_NOT_FOUND", $"Variant {variantKey} does not exist.");
+			}
+
+			var scope = $"{path}|table:{source.Id}r{source.Revision}|variant:{variant.Key}";
+			foreach (var group in variant.Groups)
+			{
+				if (group.RepeatMinimum < 0 || group.RepeatMaximum < group.RepeatMinimum)
+				{
+					throw new LootPlanningException("INVALID_REPEAT", $"Group {group.Key} has an invalid repetition range.");
+				}
+
+				if (group.Choices.Count == 0 || group.Choices.Any(x => x.Weight <= 0))
+				{
+					throw new LootPlanningException("INVALID_CHOICES", $"Group {group.Key} has invalid choices.");
+				}
+
+				var groupPath = $"{scope}|group:{group.Key}";
+				var repetitions = DrawIntInclusive(seed, groupPath + "|field:repeat", group.RepeatMinimum,
+					group.RepeatMaximum);
+				var destination = group.DestinationKey.Equals("target", StringComparison.OrdinalIgnoreCase)
+					? targetDestination
+					: $"{scope}|key:{group.DestinationKey}";
+
+				for (var repetition = 0; repetition < repetitions; repetition++)
+				{
+					var repetitionPath = $"{groupPath}|repetition:{repetition}";
+					var choice = SelectChoice(seed, repetitionPath, group.Choices);
+					var choicePath = $"{repetitionPath}|choice:{choice.Key}";
+					switch (choice.Kind)
+					{
+						case LootChoiceKind.Nothing:
+							break;
+						case LootChoiceKind.Item:
+							ValidateIntegerRange(choice.QuantityMinimum, choice.QuantityMaximum, "INVALID_QUANTITY");
+							ValidateIntegerRange(choice.QualityMinimum, choice.QualityMaximum, "INVALID_QUALITY");
+							leaves.Add(new LootPlannedLeaf(
+								LootChoiceKind.Item,
+								choicePath,
+								destination,
+								string.IsNullOrEmpty(choice.ResultKey) ? null : $"{scope}|key:{choice.ResultKey}",
+								choice.ItemPrototypeId,
+								choice.ItemPrototypeRevision,
+								DrawIntInclusive(seed, choicePath + "|field:quantity", choice.QuantityMinimum,
+									choice.QuantityMaximum),
+								DrawIntInclusive(seed, choicePath + "|field:quality", choice.QualityMinimum,
+									choice.QualityMaximum),
+								choice.Characteristics.Select(x => new LootCharacteristicValue
+								{
+									DefinitionId = x.DefinitionId,
+									ValueId = x.ValueId
+								}).ToList(),
+								0,
+								null,
+								0.0));
+							break;
+						case LootChoiceKind.Commodity:
+							if (!double.IsFinite(choice.MassMinimum) || !double.IsFinite(choice.MassMaximum) ||
+							    choice.MassMinimum <= 0.0 || choice.MassMaximum < choice.MassMinimum)
+							{
+								throw new LootPlanningException("INVALID_MASS", "A commodity mass range is invalid.");
+							}
+
+							leaves.Add(new LootPlannedLeaf(
+								LootChoiceKind.Commodity,
+								choicePath,
+								destination,
+								null,
+								0,
+								0,
+								1,
+								0,
+								[],
+								choice.CommodityMaterialId,
+								choice.CommodityTagId,
+								DrawDoubleInclusive(seed, choicePath + "|field:mass", choice.MassMinimum,
+									choice.MassMaximum)));
+							break;
+						case LootChoiceKind.LootTable:
+							var nested = _resolver(choice.NestedTableId, choice.NestedTableRevision);
+							if (nested is null)
+							{
+								throw new LootPlanningException("TABLE_NOT_FOUND",
+									$"Nested LootTable {choice.NestedTableId}r{choice.NestedTableRevision} does not exist.");
+							}
+
+							Expand(nested, choice.NestedVariant, seed, choicePath, destination, ancestry, leaves);
+							break;
+					}
+
+					if (leaves.Count > MaximumPlannedLeaves)
+					{
+						throw new LootPlanningException("EXPANSION_LIMIT",
+							$"The realised plan exceeds {MaximumPlannedLeaves} leaves.");
+					}
+				}
+			}
+		}
+		finally
+		{
+			ancestry.Remove((source.Id, source.Revision));
+		}
+	}
+
+	private static LootChoiceDefinition SelectChoice(long seed, string path, IReadOnlyList<LootChoiceDefinition> choices)
+	{
+		var total = choices.Aggregate(0L, (current, choice) => checked(current + choice.Weight));
+		var choiceKeys = string.Join(',', choices.Select(x => x.Key));
+		var draw = (long)DrawBounded(seed, $"{path}|choices:{choiceKeys}|field:choice", (ulong)total);
+		long boundary = 0;
+		foreach (var choice in choices)
+		{
+			boundary = checked(boundary + choice.Weight);
+			if (draw < boundary)
+			{
+				return choice;
+			}
+		}
+
+		throw new InvalidOperationException("Weighted selection did not resolve a choice.");
+	}
+
+	public static ulong DrawBounded(long seed, string semanticPath, ulong upperExclusive)
+	{
+		if (seed < 0)
+		{
+			throw new ArgumentOutOfRangeException(nameof(seed));
+		}
+
+		if (upperExclusive == 0)
+		{
+			throw new ArgumentOutOfRangeException(nameof(upperExclusive));
+		}
+
+		var threshold = unchecked(0UL - upperExclusive) % upperExclusive;
+		for (var attempt = 0; ; attempt++)
+		{
+			var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(
+				$"loot-v1|seed:{seed}|path:{semanticPath}|attempt:{attempt}"));
+			var value = BinaryPrimitives.ReadUInt64BigEndian(bytes);
+			if (value >= threshold)
+			{
+				return value % upperExclusive;
+			}
+		}
+	}
+
+	private static int DrawIntInclusive(long seed, string path, int minimum, int maximum)
+	{
+		ValidateIntegerRange(minimum, maximum, "INVALID_RANGE");
+		var width = checked((ulong)((long)maximum - minimum) + 1UL);
+		return checked(minimum + (int)DrawBounded(seed, path, width));
+	}
+
+	private static double DrawDoubleInclusive(long seed, string path, double minimum, double maximum)
+	{
+		if (minimum == maximum)
+		{
+			return minimum;
+		}
+
+		var bytes = SHA256.HashData(Encoding.UTF8.GetBytes($"loot-v1|seed:{seed}|path:{path}"));
+		var value = BinaryPrimitives.ReadUInt64BigEndian(bytes);
+		var fraction = value / (double)ulong.MaxValue;
+		return minimum + (maximum - minimum) * fraction;
+	}
+
+	private static void ValidateIntegerRange(int minimum, int maximum, string code)
+	{
+		if (minimum < 0 || maximum < minimum)
+		{
+			throw new LootPlanningException(code, "An integer range is invalid.");
+		}
+	}
+
+	private static string ComputePlanDigest(IEnumerable<LootPlannedLeaf> leaves)
+	{
+		var canonical = string.Join('\n', leaves.Select(leaf => string.Join('|',
+			leaf.Kind,
+			leaf.Path,
+			leaf.DestinationKey,
+			leaf.ResultKey ?? string.Empty,
+			leaf.ItemPrototypeId.ToString(CultureInfo.InvariantCulture),
+			leaf.ItemPrototypeRevision.ToString(CultureInfo.InvariantCulture),
+			leaf.Quantity.ToString(CultureInfo.InvariantCulture),
+			leaf.Quality.ToString(CultureInfo.InvariantCulture),
+			string.Join(',', leaf.Characteristics.OrderBy(x => x.DefinitionId).ThenBy(x => x.ValueId)
+				.Select(x => $"{x.DefinitionId}:{x.ValueId}")),
+			leaf.CommodityMaterialId.ToString(CultureInfo.InvariantCulture),
+			leaf.CommodityTagId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+			leaf.Mass.ToString("R", CultureInfo.InvariantCulture))));
+		return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)));
+	}
+
+	private static LootTablePlanResult Error(string code, string message) => new()
+	{
+		ErrorCode = code,
+		ErrorMessage = message
+	};
+
+	private sealed class LootPlanningException(string code, string message) : Exception(message)
+	{
+		public string Code { get; } = code;
+	}
+}

--- a/FutureMUDLibrary/Work/Loot/LootTablePlanner.cs
+++ b/FutureMUDLibrary/Work/Loot/LootTablePlanner.cs
@@ -21,6 +21,8 @@ public sealed record LootPlannedLeaf(
 	int ItemPrototypeRevision,
 	int Quantity,
 	int Quality,
+	bool StartsClosed,
+	bool StartsLocked,
 	IReadOnlyList<LootCharacteristicValue> Characteristics,
 	long CommodityMaterialId,
 	long? CommodityTagId,
@@ -165,6 +167,8 @@ public sealed class LootTablePlanner
 									choice.QuantityMaximum),
 								DrawIntInclusive(seed, choicePath + "|field:quality", choice.QualityMinimum,
 									choice.QualityMaximum),
+								choice.StartsClosed,
+								choice.StartsLocked,
 								choice.Characteristics.Select(x => new LootCharacteristicValue
 								{
 									DefinitionId = x.DefinitionId,
@@ -190,6 +194,8 @@ public sealed class LootTablePlanner
 								0,
 								1,
 								0,
+								false,
+								false,
 								[],
 								choice.CommodityMaterialId,
 								choice.CommodityTagId,
@@ -304,6 +310,8 @@ public sealed class LootTablePlanner
 			leaf.ItemPrototypeRevision.ToString(CultureInfo.InvariantCulture),
 			leaf.Quantity.ToString(CultureInfo.InvariantCulture),
 			leaf.Quality.ToString(CultureInfo.InvariantCulture),
+			leaf.StartsClosed.ToString(CultureInfo.InvariantCulture),
+			leaf.StartsLocked.ToString(CultureInfo.InvariantCulture),
 			string.Join(',', leaf.Characteristics.OrderBy(x => x.DefinitionId).ThenBy(x => x.ValueId)
 				.Select(x => $"{x.DefinitionId}:{x.ValueId}")),
 			leaf.CommodityMaterialId.ToString(CultureInfo.InvariantCulture),

--- a/MudSharpCore Unit Tests/LootTableDefinitionTests.cs
+++ b/MudSharpCore Unit Tests/LootTableDefinitionTests.cs
@@ -1,0 +1,300 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Work.Loot;
+using MudSharp.FutureProg;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class LootTableDefinitionTests
+{
+	[TestMethod]
+	public void CanonicalXml_RoundTrip_PreservesExactOrderedDefinitionAndHash()
+	{
+		var definition = RepresentativeDefinition();
+
+		var xml = definition.ToCanonicalXml();
+		var loaded = LootTableDefinition.Load(xml);
+
+		Assert.AreEqual(xml, loaded.ToCanonicalXml());
+		Assert.AreEqual(definition.ComputeHash(), loaded.ComputeHash());
+		Assert.AreEqual("container", loaded.Variants.Single().Groups[0].Key);
+		Assert.AreEqual("contents", loaded.Variants.Single().Groups[1].Key);
+	}
+
+	[TestMethod]
+	public void CanonicalXml_CharacteristicEnumerationOrder_DoesNotChangeHash()
+	{
+		var first = RepresentativeDefinition();
+		var item = first.Variants.Single().Groups[0].Choices.Single();
+		item.Characteristics.Add(new LootCharacteristicValue { DefinitionId = 20, ValueId = 200 });
+		item.Characteristics.Add(new LootCharacteristicValue { DefinitionId = 10, ValueId = 100 });
+		var second = first.Clone();
+		second.Variants.Single().Groups[0].Choices.Single().Characteristics.Reverse();
+
+		Assert.AreEqual(first.ComputeHash(), second.ComputeHash());
+	}
+
+	[TestMethod]
+	public void Planner_SameIdentityVariantAndSeed_ReproducesPlanAndDigest()
+	{
+		var source = Source(1, 0, RepresentativeDefinition());
+		var planner = new LootTablePlanner((_, _) => null);
+
+		var first = planner.CreatePlan(source, "default", 123456789);
+		var second = planner.CreatePlan(source, "default", 123456789);
+
+		Assert.IsTrue(first.Success, first.ErrorMessage);
+		Assert.IsTrue(second.Success, second.ErrorMessage);
+		Assert.AreEqual(first.Plan!.Digest, second.Plan!.Digest);
+		CollectionAssert.AreEqual(first.Plan.Leaves.Select(x => x.Path).ToList(),
+			second.Plan.Leaves.Select(x => x.Path).ToList());
+		CollectionAssert.AreEqual(first.Plan.Leaves.Select(x => x.Quantity).ToList(),
+			second.Plan.Leaves.Select(x => x.Quantity).ToList());
+	}
+
+	[TestMethod]
+	public void Planner_NestedExactRevision_UsesParentDestinationAndStableDigest()
+	{
+		var childDefinition = new LootTableDefinition();
+		var childVariant = new LootVariantDefinition { Key = "child" };
+		var childGroup = new LootRollGroupDefinition { Key = "leaf", DestinationKey = "target" };
+		childGroup.Choices.Add(new LootChoiceDefinition
+		{
+			Key = "commodity",
+			Kind = LootChoiceKind.Commodity,
+			CommodityMaterialId = 50,
+			MassMinimum = 0.25,
+			MassMaximum = 0.25
+		});
+		childVariant.Groups.Add(childGroup);
+		childDefinition.Variants.Add(childVariant);
+		var child = Source(2, 3, childDefinition);
+
+		var rootDefinition = new LootTableDefinition();
+		var rootVariant = new LootVariantDefinition { Key = "default" };
+		var rootGroup = new LootRollGroupDefinition { Key = "nested", DestinationKey = "target" };
+		rootGroup.Choices.Add(new LootChoiceDefinition
+		{
+			Key = "child-table",
+			Kind = LootChoiceKind.LootTable,
+			NestedTableId = 2,
+			NestedTableRevision = 3,
+			NestedVariant = "child"
+		});
+		rootVariant.Groups.Add(rootGroup);
+		rootDefinition.Variants.Add(rootVariant);
+		var root = Source(1, 0, rootDefinition);
+
+		var result = new LootTablePlanner((id, revision) => id == 2 && revision == 3 ? child : null)
+			.CreatePlan(root, "default", 44);
+
+		Assert.IsTrue(result.Success, result.ErrorMessage);
+		Assert.AreEqual(1, result.Plan!.Leaves.Count);
+		Assert.AreEqual("target", result.Plan.Leaves[0].DestinationKey);
+		StringAssert.Contains(result.Plan.Leaves[0].Path, "table:2r3|variant:child");
+	}
+
+	[TestMethod]
+	public void Planner_DirectCycle_ReturnsStableError()
+	{
+		var definition = new LootTableDefinition();
+		var variant = new LootVariantDefinition { Key = "default" };
+		var group = new LootRollGroupDefinition { Key = "cycle" };
+		group.Choices.Add(new LootChoiceDefinition
+		{
+			Key = "self",
+			Kind = LootChoiceKind.LootTable,
+			NestedTableId = 1,
+			NestedTableRevision = 0,
+			NestedVariant = "default"
+		});
+		variant.Groups.Add(group);
+		definition.Variants.Add(variant);
+		var source = Source(1, 0, definition);
+
+		var result = new LootTablePlanner((id, revision) => id == 1 && revision == 0 ? source : null)
+			.CreatePlan(source, "default", 1);
+
+		Assert.IsFalse(result.Success);
+		Assert.AreEqual("CYCLE", result.ErrorCode);
+	}
+
+	[TestMethod]
+	public void DrawBounded_Boundaries_AlwaysFallWithinUnbiasedRange()
+	{
+		foreach (var bound in new ulong[] { 1, 2, 3, 7, 10, 65537, ulong.MaxValue })
+		{
+			for (var seed = 0; seed < 100; seed++)
+			{
+				Assert.IsTrue(LootTablePlanner.DrawBounded(seed, "boundary", bound) < bound);
+			}
+		}
+	}
+
+	[TestMethod]
+	public void Planner_InclusiveFixedRanges_ReturnAuthoredEndpoints()
+	{
+		var source = Source(1, 0, RepresentativeDefinition());
+		var result = new LootTablePlanner((_, _) => null).CreatePlan(source, "default", 9);
+
+		Assert.IsTrue(result.Success, result.ErrorMessage);
+		var container = result.Plan!.Leaves[0];
+		Assert.AreEqual(1, container.Quantity);
+		Assert.AreEqual(8, container.Quality);
+		var contents = result.Plan.Leaves[1];
+		Assert.IsTrue(contents.Quantity >= 2);
+		Assert.IsTrue(contents.Quantity <= 4);
+		Assert.IsTrue(contents.Quality >= 3);
+		Assert.IsTrue(contents.Quality <= 7);
+	}
+
+	[TestMethod]
+	public void AtomicBatch_PreflightFailure_RollsBackEveryCreatedObjectAndNeverCommits()
+	{
+		var rolledBack = new List<int>();
+		var commits = 0;
+		Assert.ThrowsException<InvalidOperationException>(() => LootAtomicBatch.Execute(
+			new[] { 1, 2, 3 },
+			x => new[] { x * 10, x * 10 + 1 },
+			_ => throw new InvalidOperationException("preflight"),
+			_ => commits++,
+			items => rolledBack.AddRange(items)));
+		Assert.AreEqual(0, commits);
+		CollectionAssert.AreEqual(new[] { 10, 11, 20, 21, 30, 31 }, rolledBack);
+	}
+
+	[TestMethod]
+	public void AtomicBatch_CreateFailure_RollsBackOnlyObjectsAlreadyCreated()
+	{
+		var rolledBack = new List<int>();
+		IEnumerable<int> Create(int value)
+		{
+			yield return value;
+			if (value == 2) throw new InvalidOperationException("creation");
+		}
+
+		Assert.ThrowsException<InvalidOperationException>(() => LootAtomicBatch.Execute(
+			new[] { 1, 2, 3 }, Create, _ => { }, _ => { }, items => rolledBack.AddRange(items)));
+		CollectionAssert.AreEqual(new[] { 1, 2 }, rolledBack);
+	}
+
+	[TestMethod]
+	public void Clone_CanonicalSaveLoadCopy_PreservesHashAndIndependentOrdering()
+	{
+		var original = RepresentativeDefinition();
+		var clone = original.Clone();
+		Assert.AreEqual(original.ComputeHash(), clone.ComputeHash());
+		clone.Variants[0].Groups.Reverse();
+		Assert.AreNotEqual(original.ComputeHash(), clone.ComputeHash());
+		Assert.AreEqual("container", original.Variants[0].Groups[0].Key);
+	}
+
+	[TestMethod]
+	public void Planner_IndirectCycle_ReturnsStableCycleError()
+	{
+		var a = NestedDefinition(2, 0);
+		var b = NestedDefinition(1, 0);
+		var sources = new Dictionary<(long, int), LootTablePlanSource>
+		{
+			[(1, 0)] = Source(1, 0, a),
+			[(2, 0)] = Source(2, 0, b)
+		};
+		var result = new LootTablePlanner((id, revision) => sources.GetValueOrDefault((id, revision)))
+			.CreatePlan(sources[(1, 0)], "default", 12);
+		Assert.IsFalse(result.Success);
+		Assert.AreEqual("CYCLE", result.ErrorCode);
+	}
+
+	[TestMethod]
+	public void FutureProgRegistration_AdvertisesExactlySixTypedLoadLootTableContracts()
+	{
+		var before = FutureProg.GetFunctionCompilerInformations().Where(x => x.FunctionName == "loadloottable").ToList();
+		var type = typeof(FutureProg).Assembly.GetType("MudSharp.FutureProg.Functions.GameItem.LoadLootTableFunction");
+		Assert.IsNotNull(type);
+		type.GetMethod("RegisterFunctionCompiler", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!.Invoke(null, null);
+		var added = FutureProg.GetFunctionCompilerInformations().Where(x => x.FunctionName == "loadloottable").Skip(before.Count).ToList();
+		try
+		{
+			Assert.AreEqual(6, added.Count);
+			foreach (var target in new[] { ProgVariableTypes.Location, ProgVariableTypes.Item, ProgVariableTypes.Character })
+			{
+				Assert.AreEqual(1, added.Count(x => x.Parameters.SequenceEqual(new[] { ProgVariableTypes.Number, ProgVariableTypes.Number, target, ProgVariableTypes.Text })));
+				Assert.AreEqual(1, added.Count(x => x.Parameters.SequenceEqual(new[] { ProgVariableTypes.Number, ProgVariableTypes.Number, target, ProgVariableTypes.Text, ProgVariableTypes.Number })));
+			}
+			Assert.IsTrue(added.All(x => x.ReturnType == ProgVariableTypes.Text));
+		}
+		finally
+		{
+			var field = typeof(FutureProg).GetField("BuiltInFunctionCompilers", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+			var registrations = (System.Collections.IList)field!.GetValue(null)!;
+			foreach (var registration in added) registrations.Remove(registration);
+		}
+	}
+
+	private static LootTableDefinition RepresentativeDefinition()
+	{
+		var definition = new LootTableDefinition();
+		var variant = new LootVariantDefinition { Key = "default" };
+		var container = new LootRollGroupDefinition { Key = "container", DestinationKey = "target" };
+		container.Choices.Add(new LootChoiceDefinition
+		{
+			Key = "box",
+			Kind = LootChoiceKind.Item,
+			ItemPrototypeId = 100,
+			ItemPrototypeRevision = 2,
+			QuantityMinimum = 1,
+			QuantityMaximum = 1,
+			QualityMinimum = 8,
+			QualityMaximum = 8,
+			ResultKey = "box"
+		});
+		var contents = new LootRollGroupDefinition
+		{
+			Key = "contents",
+			DestinationKey = "box",
+			RepeatMinimum = 1,
+			RepeatMaximum = 1
+		};
+		contents.Choices.Add(new LootChoiceDefinition
+		{
+			Key = "parts",
+			Kind = LootChoiceKind.Item,
+			ItemPrototypeId = 200,
+			ItemPrototypeRevision = 4,
+			QuantityMinimum = 2,
+			QuantityMaximum = 4,
+			QualityMinimum = 3,
+			QualityMaximum = 7
+		});
+		variant.Groups.Add(container);
+		variant.Groups.Add(contents);
+		definition.Variants.Add(variant);
+		return definition;
+	}
+
+	private static LootTableDefinition NestedDefinition(long targetId, int targetRevision)
+	{
+		var definition = new LootTableDefinition();
+		var variant = new LootVariantDefinition { Key = "default" };
+		var group = new LootRollGroupDefinition { Key = "nested" };
+		group.Choices.Add(new LootChoiceDefinition
+		{
+			Key = "next",
+			Kind = LootChoiceKind.LootTable,
+			NestedTableId = targetId,
+			NestedTableRevision = targetRevision,
+			NestedVariant = "default"
+		});
+		variant.Groups.Add(group);
+		definition.Variants.Add(variant);
+		return definition;
+	}
+
+	private static LootTablePlanSource Source(long id, int revision, LootTableDefinition definition) =>
+		new(id, revision, definition.ComputeHash(), definition);
+}

--- a/MudSharpCore Unit Tests/LootTableDefinitionTests.cs
+++ b/MudSharpCore Unit Tests/LootTableDefinitionTests.cs
@@ -3,6 +3,10 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MudSharp.Work.Loot;
 using MudSharp.FutureProg;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.Character;
+using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -234,6 +238,20 @@ public class LootTableDefinitionTests
 			var registrations = (System.Collections.IList)field!.GetValue(null)!;
 			foreach (var registration in added) registrations.Remove(registration);
 		}
+	}
+
+	[TestMethod]
+	public void ReviewProposal_ResolvesLootTableRegistryThroughRealLifecycleOwner()
+	{
+		var registry = new Mock<IUneditableRevisableAll<ILootTable>>();
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.Setup(x => x.LootTables).Returns(registry.Object);
+		var actor = new Mock<ICharacter>();
+		actor.Setup(x => x.Gameworld).Returns(gameworld.Object);
+		var proposal = new EditableItemReviewProposal<ILootTable>(actor.Object, []);
+		var method = typeof(EditableItemReviewProposal<ILootTable>).GetMethod("GetAppropriateAll", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+		Assert.IsNotNull(method);
+		Assert.AreSame(registry.Object, method.Invoke(proposal, null));
 	}
 
 	private static LootTableDefinition RepresentativeDefinition()

--- a/MudSharpCore Unit Tests/LootTableDefinitionTests.cs
+++ b/MudSharpCore Unit Tests/LootTableDefinitionTests.cs
@@ -8,6 +8,9 @@ using MudSharp.Framework.Revision;
 using MudSharp.Framework.Save;
 using MudSharp.Framework.Units;
 using MudSharp.Character;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.GameItems.Prototypes;
 using MudSharp.PerceptionEngine;
 using Moq;
 using System;
@@ -44,6 +47,28 @@ public class LootTableDefinitionTests
 		second.Variants.Single().Groups[0].Choices.Single().Characteristics.Reverse();
 
 		Assert.AreEqual(first.ComputeHash(), second.ComputeHash());
+	}
+
+	[TestMethod]
+	public void CanonicalXml_ItemInitialState_RoundTripsAndLegacyPayloadDefaultsOpenUnlocked()
+	{
+		var definition = RepresentativeDefinition();
+		var choice = definition.Variants.Single().Groups[0].Choices.Single();
+		choice.StartsClosed = true;
+		choice.StartsLocked = true;
+
+		var xml = definition.ToCanonicalXml();
+		var loaded = LootTableDefinition.Load(xml);
+
+		StringAssert.Contains(xml, "closed=\"true\"");
+		StringAssert.Contains(xml, "locked=\"true\"");
+		Assert.IsTrue(loaded.Variants.Single().Groups[0].Choices.Single().StartsClosed);
+		Assert.IsTrue(loaded.Variants.Single().Groups[0].Choices.Single().StartsLocked);
+
+		var legacy = LootTableDefinition.Load(xml.Replace(" closed=\"true\"", string.Empty)
+			.Replace(" locked=\"true\"", string.Empty));
+		Assert.IsFalse(legacy.Variants.Single().Groups[0].Choices.Single().StartsClosed);
+		Assert.IsFalse(legacy.Variants.Single().Groups[0].Choices.Single().StartsLocked);
 	}
 
 	[TestMethod]
@@ -158,6 +183,44 @@ public class LootTableDefinitionTests
 		Assert.IsTrue(contents.Quantity <= 4);
 		Assert.IsTrue(contents.Quality >= 3);
 		Assert.IsTrue(contents.Quality <= 7);
+	}
+
+	[TestMethod]
+	public void Planner_ItemInitialState_IsPartOfPlanAndDigest()
+	{
+		var definition = RepresentativeDefinition();
+		var open = new LootTablePlanner((_, _) => null).CreatePlan(Source(1, 0, definition), "default", 9);
+		definition.Variants.Single().Groups[0].Choices.Single().StartsClosed = true;
+		var closed = new LootTablePlanner((_, _) => null).CreatePlan(Source(1, 0, definition), "default", 9);
+
+		Assert.IsTrue(open.Success, open.ErrorMessage);
+		Assert.IsTrue(closed.Success, closed.ErrorMessage);
+		Assert.IsFalse(open.Plan!.Leaves[0].StartsClosed);
+		Assert.IsTrue(closed.Plan!.Leaves[0].StartsClosed);
+		Assert.AreNotEqual(open.Plan.Digest, closed.Plan.Digest);
+	}
+
+	[TestMethod]
+	public void Materialiser_InitialClosedLockedState_IsAppliedAfterCreationWithoutEcho()
+	{
+		var isOpen = true;
+		var isLocked = false;
+		var openable = new Mock<IOpenable>();
+		openable.SetupGet(x => x.IsOpen).Returns(() => isOpen);
+		openable.Setup(x => x.Close()).Callback(() => isOpen = false);
+		var lockComponent = new Mock<ILock>();
+		lockComponent.SetupGet(x => x.IsLocked).Returns(() => isLocked);
+		lockComponent.Setup(x => x.SetLocked(true, false)).Callback(() => isLocked = true).Returns(true);
+		var item = new Mock<IGameItem>();
+		item.Setup(x => x.GetItemType<IOpenable>()).Returns(openable.Object);
+		item.Setup(x => x.GetItemType<ILock>()).Returns(lockComponent.Object);
+
+		LootTableMaterialiser.ApplyInitialState(item.Object, true, true);
+
+		Assert.IsFalse(isOpen);
+		Assert.IsTrue(isLocked);
+		openable.Verify(x => x.Close(), Times.Once);
+		lockComponent.Verify(x => x.SetLocked(true, false), Times.Once);
 	}
 
 	[TestMethod]
@@ -279,6 +342,7 @@ public class LootTableDefinitionTests
 		};
 		var gameworld = new Mock<IFuturemud>();
 		gameworld.Setup(x => x.SaveManager).Returns(new Mock<ISaveManager>().Object);
+		gameworld.Setup(x => x.ItemProtos).Returns(new Mock<IUneditableRevisableAll<IGameItemProto>>().Object);
 		var table = new MudSharp.Work.Loot.LootTable(row, gameworld.Object);
 		var output = new Mock<IOutputHandler>();
 		var actor = new Mock<ICharacter>();
@@ -381,6 +445,46 @@ public class LootTableDefinitionTests
 		var choice = table.Definition.Variants.Single().Groups.Single().Choices.Single();
 		Assert.AreEqual(125.0, choice.MassMinimum);
 		Assert.AreEqual(250.0, choice.MassMaximum);
+	}
+
+	[TestMethod]
+	public void BuildingCommand_ItemLocked_AlsoAuthorsClosedState()
+	{
+		var definition = new LootTableDefinition();
+		var variant = new LootVariantDefinition { Key = "default" };
+		variant.Groups.Add(new LootRollGroupDefinition { Key = "vessel" });
+		definition.Variants.Add(variant);
+		var row = new MudSharp.Models.LootTable
+		{
+			Id = 9,
+			RevisionNumber = 0,
+			Name = "State Test",
+			AlgorithmVersion = LootTableDefinition.CurrentAlgorithmVersion,
+			Definition = definition.ToCanonicalXml(),
+			EditableItem = new MudSharp.Models.EditableItem
+			{
+				RevisionNumber = 0,
+				RevisionStatus = (int)RevisionStatus.UnderDesign,
+				BuilderAccountId = 1,
+				BuilderDate = DateTime.UtcNow
+			}
+		};
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.Setup(x => x.SaveManager).Returns(new Mock<ISaveManager>().Object);
+		gameworld.Setup(x => x.ItemProtos).Returns(new Mock<IUneditableRevisableAll<IGameItemProto>>().Object);
+		var output = new Mock<IOutputHandler>();
+		var actor = new Mock<ICharacter>();
+		actor.Setup(x => x.OutputHandler).Returns(output.Object);
+		var table = new MudSharp.Work.Loot.LootTable(row, gameworld.Object);
+
+		var result = table.BuildingCommand(actor.Object,
+			new StringStack("choice add default vessel cage 1 item 1010 revision 1 locked as vessel"));
+
+		Assert.IsTrue(result);
+		var choice = table.Definition.Variants.Single().Groups.Single().Choices.Single();
+		Assert.IsTrue(choice.StartsClosed);
+		Assert.IsTrue(choice.StartsLocked);
+		Assert.AreEqual("vessel", choice.ResultKey);
 	}
 
 	private static LootTableDefinition RepresentativeDefinition()

--- a/MudSharpCore Unit Tests/LootTableDefinitionTests.cs
+++ b/MudSharpCore Unit Tests/LootTableDefinitionTests.cs
@@ -293,6 +293,50 @@ public class LootTableDefinitionTests
 		Assert.AreEqual(LootChoiceKind.Nothing, added.Kind);
 	}
 
+	[TestMethod]
+	public void Show_RendersHumanReadableVariantChoiceTable()
+	{
+		var definition = new LootTableDefinition();
+		var variant = new LootVariantDefinition { Key = "default" };
+		var group = new LootRollGroupDefinition { Key = "selection", DestinationKey = "target" };
+		group.Choices.Add(new LootChoiceDefinition { Key = "empty", Kind = LootChoiceKind.Nothing, Weight = 3 });
+		variant.Groups.Add(group);
+		definition.Variants.Add(variant);
+		var row = new MudSharp.Models.LootTable
+		{
+			Id = 7,
+			RevisionNumber = 2,
+			Name = "Readable Test",
+			AlgorithmVersion = LootTableDefinition.CurrentAlgorithmVersion,
+			Definition = definition.ToCanonicalXml(),
+			EditableItem = new MudSharp.Models.EditableItem
+			{
+				RevisionNumber = 2,
+				RevisionStatus = (int)RevisionStatus.Current,
+				BuilderAccountId = 1,
+				BuilderDate = DateTime.UtcNow
+			}
+		};
+		var gameworld = new Mock<IFuturemud>();
+		var account = new Mock<MudSharp.Accounts.IAccount>();
+		account.Setup(x => x.LineFormatLength).Returns(160);
+		account.Setup(x => x.UseUnicode).Returns(true);
+		var actor = new Mock<ICharacter>();
+		actor.Setup(x => x.Account).Returns(account.Object);
+		var table = new MudSharp.Work.Loot.LootTable(row, gameworld.Object);
+
+		var shown = table.Show(actor.Object).StripANSIColour();
+
+		StringAssert.Contains(shown, "Loot Table #7r2: Readable Test");
+		StringAssert.Contains(shown, "Variant: default");
+		foreach (var heading in new[] { "Group", "Repeat", "Destination", "Choice", "Weight / Chance", "Result" })
+			StringAssert.Contains(shown, heading);
+		StringAssert.Contains(shown, "1. selection");
+		StringAssert.Contains(shown, "Outer target");
+		StringAssert.Contains(shown, "3 (100.00%)");
+		StringAssert.Contains(shown, "Nothing");
+	}
+
 	private static LootTableDefinition RepresentativeDefinition()
 	{
 		var definition = new LootTableDefinition();

--- a/MudSharpCore Unit Tests/LootTableDefinitionTests.cs
+++ b/MudSharpCore Unit Tests/LootTableDefinitionTests.cs
@@ -5,7 +5,9 @@ using MudSharp.Work.Loot;
 using MudSharp.FutureProg;
 using MudSharp.Framework;
 using MudSharp.Framework.Revision;
+using MudSharp.Framework.Save;
 using MudSharp.Character;
+using MudSharp.PerceptionEngine;
 using Moq;
 using System;
 using System.Collections.Generic;
@@ -252,6 +254,43 @@ public class LootTableDefinitionTests
 		var method = typeof(EditableItemReviewProposal<ILootTable>).GetMethod("GetAppropriateAll", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 		Assert.IsNotNull(method);
 		Assert.AreSame(registry.Object, method.Invoke(proposal, null));
+	}
+
+	[TestMethod]
+	public void BuildingCommand_ChoiceAdd_TargetsNamedNonFirstGroupWithoutConsumingArguments()
+	{
+		var definition = RepresentativeDefinition();
+		definition.Variants.Single().Groups[1].Choices.Clear();
+		var row = new MudSharp.Models.LootTable
+		{
+			Id = 1,
+			RevisionNumber = 0,
+			Name = "Builder Test",
+			AlgorithmVersion = LootTableDefinition.CurrentAlgorithmVersion,
+			Definition = definition.ToCanonicalXml(),
+			EditableItem = new MudSharp.Models.EditableItem
+			{
+				RevisionNumber = 0,
+				RevisionStatus = (int)RevisionStatus.UnderDesign,
+				BuilderAccountId = 1,
+				BuilderDate = DateTime.UtcNow
+			}
+		};
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.Setup(x => x.SaveManager).Returns(new Mock<ISaveManager>().Object);
+		var table = new MudSharp.Work.Loot.LootTable(row, gameworld.Object);
+		var output = new Mock<IOutputHandler>();
+		var actor = new Mock<ICharacter>();
+		actor.Setup(x => x.OutputHandler).Returns(output.Object);
+
+		var result = table.BuildingCommand(actor.Object,
+			new StringStack("choice add default contents salvage 1 nothing"));
+
+		Assert.IsTrue(result);
+		Assert.AreEqual(1, table.Definition.Variants.Single().Groups[0].Choices.Count);
+		var added = table.Definition.Variants.Single().Groups[1].Choices.Single();
+		Assert.AreEqual("salvage", added.Key);
+		Assert.AreEqual(LootChoiceKind.Nothing, added.Kind);
 	}
 
 	private static LootTableDefinition RepresentativeDefinition()

--- a/MudSharpCore Unit Tests/LootTableDefinitionTests.cs
+++ b/MudSharpCore Unit Tests/LootTableDefinitionTests.cs
@@ -8,6 +8,7 @@ using MudSharp.Framework.Revision;
 using MudSharp.Framework.Save;
 using MudSharp.Framework.Units;
 using MudSharp.Character;
+using MudSharp.Form.Characteristics;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Interfaces;
 using MudSharp.GameItems.Prototypes;
@@ -16,6 +17,7 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace MudSharp_Unit_Tests;
 
@@ -157,6 +159,83 @@ public class LootTableDefinitionTests
 	}
 
 	[TestMethod]
+	public void Planner_ItemQuantity_ContributesToExpansionLimit()
+	{
+		var definition = new LootTableDefinition();
+		var variant = new LootVariantDefinition { Key = "default" };
+		var group = new LootRollGroupDefinition { Key = "large-result" };
+		group.Choices.Add(new LootChoiceDefinition
+		{
+			Key = "many-items",
+			Kind = LootChoiceKind.Item,
+			ItemPrototypeId = 1,
+			QuantityMinimum = LootTablePlanner.MaximumPlannedItems + 1,
+			QuantityMaximum = LootTablePlanner.MaximumPlannedItems + 1
+		});
+		variant.Groups.Add(group);
+		definition.Variants.Add(variant);
+
+		var result = new LootTablePlanner((_, _) => null).CreatePlan(Source(1, 0, definition), "default", 0);
+
+		Assert.IsFalse(result.Success);
+		Assert.AreEqual("EXPANSION_LIMIT", result.ErrorCode);
+	}
+
+	[TestMethod]
+	public void Validator_ExaminesUnselectedNestedChoicePathsForCycles()
+	{
+		var definition = new LootTableDefinition();
+		var variant = new LootVariantDefinition { Key = "default" };
+		var group = new LootRollGroupDefinition { Key = "selection" };
+		group.Choices.Add(new LootChoiceDefinition { Key = "empty", Kind = LootChoiceKind.Nothing });
+		group.Choices.Add(new LootChoiceDefinition
+		{
+			Key = "recursive", Kind = LootChoiceKind.LootTable, NestedTableId = 1,
+			NestedTableRevision = 0, NestedVariant = "default"
+		});
+		variant.Groups.Add(group);
+		definition.Variants.Add(variant);
+		var table = LootTableMock(1, 0, definition);
+		var tables = new Mock<IUneditableRevisableAll<ILootTable>>();
+		tables.Setup(x => x.Get(1, 0)).Returns(table.Object);
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.LootTables).Returns(tables.Object);
+
+		var errors = LootTableValidator.Validate(table.Object, gameworld.Object);
+
+		Assert.IsTrue(errors.Any(x => x.Contains("cycle", StringComparison.OrdinalIgnoreCase)));
+	}
+
+	[TestMethod]
+	public void Validator_RejectsWorstCaseQuantityAboveExpansionLimit()
+	{
+		var definition = new LootTableDefinition();
+		var variant = new LootVariantDefinition { Key = "default" };
+		var group = new LootRollGroupDefinition { Key = "selection" };
+		group.Choices.Add(new LootChoiceDefinition
+		{
+			Key = "many-items", Kind = LootChoiceKind.Item, ItemPrototypeId = 101, ItemPrototypeRevision = 0,
+			QuantityMinimum = LootTablePlanner.MaximumPlannedItems + 1,
+			QuantityMaximum = LootTablePlanner.MaximumPlannedItems + 1
+		});
+		variant.Groups.Add(group);
+		definition.Variants.Add(variant);
+		var table = LootTableMock(1, 0, definition);
+		var prototype = new Mock<IGameItemProto>();
+		prototype.SetupGet(x => x.Status).Returns(RevisionStatus.Current);
+		prototype.SetupGet(x => x.Components).Returns(Array.Empty<IGameItemComponentProto>());
+		var prototypes = new Mock<IUneditableRevisableAll<IGameItemProto>>();
+		prototypes.Setup(x => x.Get(101, 0)).Returns(prototype.Object);
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.ItemProtos).Returns(prototypes.Object);
+		gameworld.SetupGet(x => x.LootTables).Returns(new Mock<IUneditableRevisableAll<ILootTable>>().Object);
+
+		var errors = LootTableValidator.Validate(table.Object, gameworld.Object);
+
+		Assert.IsTrue(errors.Any(x => x.Contains("maximum expansion", StringComparison.OrdinalIgnoreCase)));
+	}
+
+	[TestMethod]
 	public void DrawBounded_Boundaries_AlwaysFallWithinUnbiasedRange()
 	{
 		foreach (var bound in new ulong[] { 1, 2, 3, 7, 10, 65537, ulong.MaxValue })
@@ -251,6 +330,16 @@ public class LootTableDefinitionTests
 		Assert.ThrowsException<InvalidOperationException>(() => LootAtomicBatch.Execute(
 			new[] { 1, 2, 3 }, Create, _ => { }, _ => { }, items => rolledBack.AddRange(items)));
 		CollectionAssert.AreEqual(new[] { 1, 2 }, rolledBack);
+	}
+
+	[TestMethod]
+	public void AtomicBatch_RollbackFailure_PreservesOriginalOperationFailure()
+	{
+		var error = Assert.ThrowsException<InvalidOperationException>(() => LootAtomicBatch.Execute(
+			new[] { 1 }, _ => new[] { 1 }, _ => throw new InvalidOperationException("creation"), _ => { },
+			_ => throw new InvalidOperationException("rollback")));
+
+		Assert.AreEqual("creation", error.Message);
 	}
 
 	[TestMethod]
@@ -487,6 +576,96 @@ public class LootTableDefinitionTests
 		Assert.AreEqual("vessel", choice.ResultKey);
 	}
 
+	[TestMethod]
+	public void BuildingCommand_ChoiceVariables_InvalidInputPreservesExistingAssignments()
+	{
+		var definition = RepresentativeDefinition();
+		var row = new MudSharp.Models.LootTable
+		{
+			Id = 10,
+			RevisionNumber = 0,
+			Name = "Variables Test",
+			AlgorithmVersion = LootTableDefinition.CurrentAlgorithmVersion,
+			Definition = definition.ToCanonicalXml(),
+			EditableItem = new MudSharp.Models.EditableItem
+			{
+				RevisionNumber = 0,
+				RevisionStatus = (int)RevisionStatus.UnderDesign,
+				BuilderAccountId = 1,
+				BuilderDate = DateTime.UtcNow
+			}
+		};
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.SaveManager).Returns(new Mock<ISaveManager>().Object);
+		gameworld.SetupGet(x => x.ItemProtos).Returns(new Mock<IUneditableRevisableAll<IGameItemProto>>().Object);
+		var actor = new Mock<ICharacter>();
+		actor.SetupGet(x => x.OutputHandler).Returns(new Mock<IOutputHandler>().Object);
+		var table = new MudSharp.Work.Loot.LootTable(row, gameworld.Object);
+		var choice = table.Definition.Variants.Single().Groups.Single(x => x.Key == "container").Choices.Single();
+		choice.Characteristics.Add(new LootCharacteristicValue { DefinitionId = 10, ValueId = 100 });
+
+		var result = table.BuildingCommand(actor.Object,
+			new StringStack("choice variables default container box 20=not-a-number"));
+
+		Assert.IsFalse(result);
+		Assert.AreEqual(1, choice.Characteristics.Count);
+		Assert.AreEqual(10L, choice.Characteristics.Single().DefinitionId);
+		Assert.AreEqual(100L, choice.Characteristics.Single().ValueId);
+	}
+
+	[TestMethod]
+	public void BuilderLookup_NamedRevision_SelectsRequestedRevision()
+	{
+		var current = LootTableMock(41, 0, new LootTableDefinition());
+		var requested = LootTableMock(41, 3, new LootTableDefinition());
+		var tables = new Mock<IUneditableRevisableAll<ILootTable>>();
+		tables.Setup(x => x.GetByName("parcel", true)).Returns(current.Object);
+		tables.Setup(x => x.Get(41, 3)).Returns(requested.Object);
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.LootTables).Returns(tables.Object);
+		var actor = new Mock<ICharacter>();
+		actor.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		actor.SetupGet(x => x.OutputHandler).Returns(new Mock<IOutputHandler>().Object);
+		var method = typeof(Futuremud).Assembly
+			.GetType("MudSharp.Commands.Modules.ItemBuilderModule")!
+			.GetMethod("TryGetLootTable", BindingFlags.NonPublic | BindingFlags.Static)!;
+		object?[] arguments = [actor.Object, new StringStack("parcel 3"), null];
+
+		var success = (bool)method.Invoke(null, arguments)!;
+
+		Assert.IsTrue(success);
+		Assert.AreSame(requested.Object, arguments[2]);
+	}
+
+	[TestMethod]
+	public void Materialiser_NonStackableQuantity_CreatesEveryAuthoredItem()
+	{
+		var item = new Mock<IGameItem>();
+		var prototype = new Mock<IGameItemProto>();
+		prototype.Setup(x => x.IsItemType<IStackablePrototype>()).Returns(false);
+		prototype.SetupGet(x => x.Components).Returns(Array.Empty<IGameItemComponentProto>());
+		prototype.Setup(x => x.CreateNew<List<(ICharacteristicDefinition Definition, ICharacteristicValue Value)>>(
+				It.IsAny<ICharacter>(), It.IsAny<IGameItemSkin>(), 1,
+				It.IsAny<List<(ICharacteristicDefinition Definition, ICharacteristicValue Value)>>()))
+			.Returns([item.Object]);
+		var prototypes = new Mock<IUneditableRevisableAll<IGameItemProto>>();
+		prototypes.Setup(x => x.Get(501, 2)).Returns(prototype.Object);
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.ItemProtos).Returns(prototypes.Object);
+		var materialiser = new LootTableMaterialiser(gameworld.Object);
+		var leaf = new LootPlannedLeaf(LootChoiceKind.Item, "test", "target", null, 501, 2, 12, 5,
+			false, false, [], 0, null, 0.0);
+		var method = typeof(LootTableMaterialiser).GetMethod("CreateLeaf",
+			BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+		var created = ((IEnumerable<IGameItem>)method.Invoke(materialiser, [leaf])!).ToList();
+
+		Assert.AreEqual(12, created.Count);
+		prototype.Verify(x => x.CreateNew<List<(ICharacteristicDefinition Definition, ICharacteristicValue Value)>>(
+			It.IsAny<ICharacter>(), It.IsAny<IGameItemSkin>(), 1,
+			It.IsAny<List<(ICharacteristicDefinition Definition, ICharacteristicValue Value)>>()), Times.Exactly(12));
+	}
+
 	private static LootTableDefinition RepresentativeDefinition()
 	{
 		var definition = new LootTableDefinition();
@@ -548,4 +727,15 @@ public class LootTableDefinitionTests
 
 	private static LootTablePlanSource Source(long id, int revision, LootTableDefinition definition) =>
 		new(id, revision, definition.ComputeHash(), definition);
+
+	private static Mock<ILootTable> LootTableMock(long id, int revision, LootTableDefinition definition)
+	{
+		var table = new Mock<ILootTable>();
+		table.SetupGet(x => x.Id).Returns(id);
+		table.SetupGet(x => x.RevisionNumber).Returns(revision);
+		table.SetupGet(x => x.Definition).Returns(definition);
+		table.SetupGet(x => x.DefinitionHash).Returns(definition.ComputeHash());
+		table.SetupGet(x => x.Status).Returns(RevisionStatus.Current);
+		return table;
+	}
 }

--- a/MudSharpCore Unit Tests/LootTableDefinitionTests.cs
+++ b/MudSharpCore Unit Tests/LootTableDefinitionTests.cs
@@ -6,6 +6,7 @@ using MudSharp.FutureProg;
 using MudSharp.Framework;
 using MudSharp.Framework.Revision;
 using MudSharp.Framework.Save;
+using MudSharp.Framework.Units;
 using MudSharp.Character;
 using MudSharp.PerceptionEngine;
 using Moq;
@@ -335,6 +336,51 @@ public class LootTableDefinitionTests
 		StringAssert.Contains(shown, "Outer target");
 		StringAssert.Contains(shown, "3 (100.00%)");
 		StringAssert.Contains(shown, "Nothing");
+	}
+
+	[TestMethod]
+	public void BuildingCommand_CommodityMass_AcceptsExplicitHumanUnits()
+	{
+		var definition = new LootTableDefinition();
+		var variant = new LootVariantDefinition { Key = "default" };
+		variant.Groups.Add(new LootRollGroupDefinition { Key = "contents" });
+		definition.Variants.Add(variant);
+		var row = new MudSharp.Models.LootTable
+		{
+			Id = 8,
+			RevisionNumber = 0,
+			Name = "Unit Test",
+			AlgorithmVersion = LootTableDefinition.CurrentAlgorithmVersion,
+			Definition = definition.ToCanonicalXml(),
+			EditableItem = new MudSharp.Models.EditableItem
+			{
+				RevisionNumber = 0,
+				RevisionStatus = (int)RevisionStatus.UnderDesign,
+				BuilderAccountId = 1,
+				BuilderDate = DateTime.UtcNow
+			}
+		};
+		var minimum = 125.0;
+		var maximum = 250.0;
+		var units = new Mock<IUnitManager>();
+		var actor = new Mock<ICharacter>();
+		units.Setup(x => x.TryGetBaseUnits("125g", UnitType.Mass, actor.Object, out minimum)).Returns(true);
+		units.Setup(x => x.TryGetBaseUnits("250g", UnitType.Mass, actor.Object, out maximum)).Returns(true);
+		var saveManager = new Mock<ISaveManager>();
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.Setup(x => x.UnitManager).Returns(units.Object);
+		gameworld.Setup(x => x.SaveManager).Returns(saveManager.Object);
+		var output = new Mock<IOutputHandler>();
+		actor.Setup(x => x.OutputHandler).Returns(output.Object);
+		var table = new MudSharp.Work.Loot.LootTable(row, gameworld.Object);
+
+		var result = table.BuildingCommand(actor.Object,
+			new StringStack("choice add default contents steel 1 commodity 24 mass 125g 250g"));
+
+		Assert.IsTrue(result);
+		var choice = table.Definition.Variants.Single().Groups.Single().Choices.Single();
+		Assert.AreEqual(125.0, choice.MassMinimum);
+		Assert.AreEqual(250.0, choice.MassMaximum);
 	}
 
 	private static LootTableDefinition RepresentativeDefinition()

--- a/MudSharpCore/Body/Implementations/BodyInventory.cs
+++ b/MudSharpCore/Body/Implementations/BodyInventory.cs
@@ -1598,11 +1598,22 @@ public partial class Body
     public void Get(IGameItem item, int quantity = 0, IEmote? playerEmote = null, bool silent = false,
         ItemCanGetIgnore ignoreFlags = ItemCanGetIgnore.None)
     {
-        Get(item, quantity, playerEmote, silent, ignoreFlags, null);
+		GetInternal(item, quantity, playerEmote, silent, ignoreFlags, null, true);
     }
 
     public IGameItem? Get(IGameItem item, int quantity, IEmote? playerEmote, bool silent,
-        ItemCanGetIgnore ignoreFlags, IEnumerable<IHandleEvents> witnessHandlers)
+		ItemCanGetIgnore ignoreFlags, IEnumerable<IHandleEvents> witnessHandlers)
+	{
+		return GetInternal(item, quantity, playerEmote, silent, ignoreFlags, witnessHandlers, true);
+	}
+
+	public IGameItem? GetWithoutMerge(IGameItem item, bool silent = true)
+	{
+		return GetInternal(item, 0, null, silent, ItemCanGetIgnore.None, null, false);
+	}
+
+	private IGameItem? GetInternal(IGameItem item, int quantity, IEmote? playerEmote, bool silent,
+		ItemCanGetIgnore ignoreFlags, IEnumerable<IHandleEvents> witnessHandlers, bool allowMerge)
     {
         if (!CanGet(item, quantity, ignoreFlags))
         {
@@ -1623,7 +1634,7 @@ public partial class Body
 
             if (!_heldItems.Any(x => x.Item1 == gottenItem))
             {
-                if (HeldOrWieldedItems.Any(x => x.CanMerge(gottenItem)))
+                if (allowMerge && HeldOrWieldedItems.Any(x => x.CanMerge(gottenItem)))
                 {
                     HeldOrWieldedItems.First(x => x.CanMerge(gottenItem)).Merge(gottenItem);
                 }
@@ -1656,7 +1667,7 @@ public partial class Body
         {
             IGameItem newItem = item.Get(this, quantity);
             gottenItem = newItem;
-            if (HeldOrWieldedItems.Any(x => x.CanMerge(gottenItem)))
+            if (allowMerge && HeldOrWieldedItems.Any(x => x.CanMerge(gottenItem)))
             {
                 HeldOrWieldedItems.First(x => x.CanMerge(gottenItem)).Merge(gottenItem);
             }

--- a/MudSharpCore/Commands/Helpers/EditableRevisableItemHelper.cs
+++ b/MudSharpCore/Commands/Helpers/EditableRevisableItemHelper.cs
@@ -9,6 +9,7 @@ using MudSharp.NPC.AI;
 using MudSharp.NPC.Templates;
 using MudSharp.Work.Crafts;
 using MudSharp.Work.Foraging;
+using MudSharp.Work.Loot;
 using MudSharp.Work.Projects;
 using MudSharp.Traps;
 
@@ -1067,7 +1068,68 @@ internal class EditableRevisableItemHelper
         };
 
         #endregion
-    }
+
+		#region Loot Tables
+
+		LootTableHelper = new EditableRevisableItemHelper
+		{
+			ItemName = "Loot Table",
+			ItemNamePlural = "Loot Tables",
+			DeleteEditableItemAction = item =>
+			{
+				using (new FMDB())
+				{
+					var row = FMDB.Context.LootTables.Find(item.Id, item.RevisionNumber);
+					if (row is not null)
+					{
+						FMDB.Context.LootTables.Remove(row);
+						FMDB.Context.EditableItems.Remove(row.EditableItem);
+						FMDB.Context.SaveChanges();
+					}
+				}
+				item.Gameworld.Destroy((ILootTable)item);
+			},
+			SetEditableItemAction = (character, item) =>
+			{
+				character.RemoveAllEffects(x => x.IsEffectType<BuilderEditingEffect<ILootTable>>());
+				if (item is not null) character.AddEffect(new BuilderEditingEffect<ILootTable>(character) { EditingItem = (ILootTable)item });
+			},
+			GetEditableItemFunc = character => character.EffectsOfType<BuilderEditingEffect<ILootTable>>().FirstOrDefault()?.EditingItem,
+			EditableNewAction = (actor, input) =>
+			{
+				var name = input.SafeRemainingArgument;
+				if (string.IsNullOrWhiteSpace(name)) { actor.Send("What name should the new loot table have?"); return; }
+				var item = new LootTable(actor.Account, name);
+				actor.Gameworld.Add(item);
+				actor.RemoveAllEffects(x => x.IsEffectType<BuilderEditingEffect<ILootTable>>());
+				actor.AddEffect(new BuilderEditingEffect<ILootTable>(actor) { EditingItem = item });
+				actor.Send($"You create loot table #{item.Id.ToStringN0(actor)}r0, which you are now editing.");
+			},
+			AddItemToGameWorldAction = item => item.Gameworld.Add((ILootTable)item),
+			GetAllEditableItems = character => character.Gameworld.LootTables,
+			GetAllEditableItemsByIdFunc = (character, id) => character.Gameworld.LootTables.GetAll(id),
+			GetEditableItemByIdFunc = (character, id) => character.Gameworld.LootTables.Get(id),
+			GetEditableItemByIdRevNumFunc = (character, id, revision) => character.Gameworld.LootTables.Get(id, revision),
+			GetReviewTableContentsFunc = (actor, items) => items.OfType<ILootTable>().Select(item => new[]
+			{
+				item.Id.ToStringN0(actor), item.RevisionNumber.ToStringN0(actor), item.Name,
+				item.Definition.Variants.Count.ToStringN0(actor), item.DefinitionHash[..12], item.BuilderComment ?? ""
+			}),
+			GetReviewTableHeaderFunc = _ => new[] { "ID", "Rev", "Name", "Variants", "Hash", "Comment" },
+			GetListTableContentsFunc = (actor, items) => items.OfType<ILootTable>().Select(item => new[]
+			{
+				item.Id.ToStringN0(actor), item.RevisionNumber.ToStringN0(actor), item.Name,
+				item.Definition.Variants.Count.ToStringN0(actor), item.Status.Describe()
+			}),
+			GetListTableHeaderFunc = _ => new[] { "ID", "Rev", "Name", "Variants", "Status" },
+			GetReviewProposalEffectFunc = (items, character) => new Accept(character,
+				new EditableItemReviewProposal<ILootTable>(character, items.Cast<ILootTable>().ToList())),
+			CastToType = typeof(ILootTable),
+			CustomSearch = (items, keyword, gameworld) => items
+		};
+
+		#endregion
+	}
 
     public static EditableRevisableItemHelper GameItemHelper { get; }
     public static EditableRevisableItemHelper GameItemComponentHelper { get; private set; }
@@ -1079,6 +1141,7 @@ internal class EditableRevisableItemHelper
     public static EditableRevisableItemHelper ProjectHelper { get; }
     public static EditableRevisableItemHelper TattooHelper { get; }
     public static EditableRevisableItemHelper ItemSkinHelper { get; }
+	public static EditableRevisableItemHelper LootTableHelper { get; }
 
     public string ItemName { get; private set; }
     public string ItemNamePlural { get; private set; }

--- a/MudSharpCore/Commands/Modules/ItemBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/ItemBuilderModule.cs
@@ -1624,7 +1624,7 @@ Outer target
 
 #6Weighted choices:#0
 #3loottable set choice add <variant> <group> <key> <weight> nothing#0
-#3loottable set choice add <variant> <group> <key> <weight> item <prototype> [revision <rev>] [quantity <min> <max>] [quality <min> <max>] [as <local-key>]#0
+#3loottable set choice add <variant> <group> <key> <weight> item <prototype> [revision <rev>] [quantity <min> <max>] [quality <min> <max>] [closed|locked] [as <local-key>]#0
 #3loottable set choice add <variant> <group> <key> <weight> commodity <material> [tag <tag>] [mass <min> <max>]#0
 #3loottable set choice add <variant> <group> <key> <weight> table <id> <revision> <variant>#0
 #3loottable set choice weight <variant> <group> <key> <weight>#0
@@ -1632,6 +1632,8 @@ Outer target
 #3loottable set choice remove <variant> <group> <key>#0
 
 Commodity mass accepts explicit units such as #3125g#0 or #31.5kg#0. Bare numbers remain supported as engine base mass units for compatibility.
+
+Item choices start open and unlocked unless marked #3closed#0 or #3locked#0. #3locked#0 also closes the item and requires a prototype with a built-in lock.
 
 #6Validate and test:#0
 #3loottable validate <id|name> [revision]#0 - checks references, destinations, cycles and limits
@@ -1680,7 +1682,7 @@ Commodity mass accepts explicit units such as #3125g#0 or #31.5kg#0. Bare number
 				var plan = preview.Plan!;
 				var sb = new StringBuilder();
 				sb.AppendLine($"Preview #{table.Id}r{table.RevisionNumber} {variant} seed {seed} digest {plan.Digest}");
-				foreach (var leaf in plan.Leaves) sb.AppendLine($"- {leaf.Kind} into {leaf.DestinationKey}: {(leaf.Kind == LootChoiceKind.Item ? $"#{leaf.ItemPrototypeId}r{leaf.ItemPrototypeRevision} x{leaf.Quantity} quality {leaf.Quality}" : $"material #{leaf.CommodityMaterialId} mass {leaf.Mass:R}")}");
+				foreach (var leaf in plan.Leaves) sb.AppendLine($"- {leaf.Kind} into {leaf.DestinationKey}: {(leaf.Kind == LootChoiceKind.Item ? $"#{leaf.ItemPrototypeId}r{leaf.ItemPrototypeRevision} x{leaf.Quantity} quality {leaf.Quality}{(leaf.StartsLocked ? " closed+locked" : leaf.StartsClosed ? " closed" : "")}" : $"material #{leaf.CommodityMaterialId} mass {leaf.Mass:R}")}");
 				actor.Send(sb.ToString()); return;
 			}
 			if (command.IsFinished) { actor.Send("Specify HERE, INTO <item>, or TO <character>."); return; }

--- a/MudSharpCore/Commands/Modules/ItemBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/ItemBuilderModule.cs
@@ -8,6 +8,7 @@ using MudSharp.Framework.Scheduling;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Groups;
 using MudSharp.Models;
+using MudSharp.Work.Loot;
 
 namespace MudSharp.Commands.Modules
 {
@@ -1586,5 +1587,106 @@ The syntax to use this command is as follows:
         }
 
         #endregion
+
+		#region Loot Tables
+
+		private const string LootTableHelp = @"Loot tables are revisioned deterministic item/commodity graphs.
+
+#3loottable list [filters]#0
+#3loottable show <id|name> [revision]#0
+#3loottable edit new <name>|<id|name>|close|submit|delete|obsolete#0
+#3loottable revise <id|name>#0
+#3loottable review ...#0
+#3loottable set variant|group|choice ...#0
+#3loottable validate <id|name> [revision]#0
+#3loottable preview <id|name> [revision] <variant> [seed]#0
+#3loottable load <id|name> [revision] <variant> [seed] here|into <item>|to <character>#0
+
+Group and choice editing syntax is shown by #3loottable set#0.";
+
+		[PlayerCommand("LootTable", "loottable", "lt")]
+		[CommandPermission(PermissionLevel.Admin)]
+		[HelpInfo("loottable", LootTableHelp, AutoHelp.HelpArgOrNoArg)]
+		protected static void LootTableCommand(ICharacter actor, string input)
+		{
+			var command = new StringStack(input.RemoveFirstWord());
+			var action = command.PeekSpeech().ToLowerInvariant();
+			if (action == "new") command = new StringStack($"edit new {command.SafeRemainingArgument.RemoveFirstWord()}");
+			else if (action == "revise") command = new StringStack($"edit {command.SafeRemainingArgument.RemoveFirstWord()}");
+			else if (action is "close" or "submit") command = new StringStack($"edit {command.SafeRemainingArgument}");
+			action = command.PeekSpeech().ToLowerInvariant();
+			if (action is not ("validate" or "preview" or "load" or "clone"))
+			{
+				GenericRevisableBuildingCommand(actor, command, EditableRevisableItemHelper.LootTableHelper);
+				return;
+			}
+			command.PopSpeech();
+			if (action == "clone") { LootTableClone(actor, command); return; }
+			if (!TryGetLootTable(actor, command, out var table)) return;
+			if (action == "validate")
+			{
+				var errors = LootTableValidator.Validate(table, actor.Gameworld);
+				actor.Send(errors.Count == 0 ? $"Loot table #{table.Id}r{table.RevisionNumber} validates successfully.".Colour(Telnet.Green) : $"ERROR validation failed:\n{errors.Select(x => $"- {x}").ListToString(separator: "\n")}".ColourError());
+				return;
+			}
+			if (command.IsFinished) { actor.Send("Which variant do you want to use?"); return; }
+			var variant = command.PopSpeech();
+			var seed = !command.IsFinished && long.TryParse(command.PeekSpeech(), out var suppliedSeed) ? (command.PopSpeech(), suppliedSeed).Item2 : Random.Shared.NextInt64(long.MaxValue);
+			var materialiser = new LootTableMaterialiser(actor.Gameworld);
+			if (action == "preview")
+			{
+				var preview = materialiser.Preview(table, variant, seed);
+				if (!preview.Success) { actor.Send($"ERROR code={preview.ErrorCode} message={preview.ErrorMessage}".ColourError()); return; }
+				var plan = preview.Plan!;
+				var sb = new StringBuilder();
+				sb.AppendLine($"Preview #{table.Id}r{table.RevisionNumber} {variant} seed {seed} digest {plan.Digest}");
+				foreach (var leaf in plan.Leaves) sb.AppendLine($"- {leaf.Kind} into {leaf.DestinationKey}: {(leaf.Kind == LootChoiceKind.Item ? $"#{leaf.ItemPrototypeId}r{leaf.ItemPrototypeRevision} x{leaf.Quantity} quality {leaf.Quality}" : $"material #{leaf.CommodityMaterialId} mass {leaf.Mass:R}")}");
+				actor.Send(sb.ToString()); return;
+			}
+			if (command.IsFinished) { actor.Send("Specify HERE, INTO <item>, or TO <character>."); return; }
+			LootMaterialisationResult result;
+			switch (command.PopSpeech().ToLowerInvariant())
+			{
+				case "here": result = materialiser.Materialise(table, variant, seed, actor.Location); break;
+				case "into":
+					var item = actor.TargetItem(command.SafeRemainingArgument);
+					if (item is null) { actor.Send("You do not see that item."); return; }
+					result = materialiser.Materialise(table, variant, seed, item); break;
+				case "to":
+					var target = actor.TargetActor(command.SafeRemainingArgument);
+					if (target is null) { actor.Send("You do not see that character."); return; }
+					result = materialiser.Materialise(table, variant, seed, target); break;
+				default: actor.Send("Specify HERE, INTO <item>, or TO <character>."); return;
+			}
+			actor.Send(result.Success ? result.Receipt.Colour(Telnet.Green) : result.Receipt.ColourError());
+		}
+
+		private static bool TryGetLootTable(ICharacter actor, StringStack command, out ILootTable table)
+		{
+			table = null;
+			if (command.IsFinished) { actor.Send("Which loot table?"); return false; }
+			var token = command.PopSpeech();
+			if (long.TryParse(token, out var id))
+			{
+				table = !command.IsFinished && int.TryParse(command.PeekSpeech(), out var revision)
+					? actor.Gameworld.LootTables.Get(id, (command.PopSpeech(), revision).Item2)
+					: actor.Gameworld.LootTables.Get(id);
+			}
+			else table = actor.Gameworld.LootTables.GetByName(token, ignoreCase: true);
+			if (table is not null) return true;
+			actor.Send("There is no such loot table revision."); return false;
+		}
+
+		private static void LootTableClone(ICharacter actor, StringStack command)
+		{
+			if (!TryGetLootTable(actor, command, out var source) || command.IsFinished) { actor.Send("Specify a source and new name."); return; }
+			var clone = ((MudSharp.Work.Loot.LootTable)source).Clone(actor.Account, command.SafeRemainingArgument);
+			clone.Save(); actor.Gameworld.Add(clone);
+			actor.RemoveAllEffects(x => x.IsEffectType<BuilderEditingEffect<ILootTable>>());
+			actor.AddEffect(new BuilderEditingEffect<ILootTable>(actor) { EditingItem = clone });
+			actor.Send($"You clone #{source.Id}r{source.RevisionNumber} as #{clone.Id}r0 and begin editing it.");
+		}
+
+		#endregion
     }
 }

--- a/MudSharpCore/Commands/Modules/ItemBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/ItemBuilderModule.cs
@@ -1590,19 +1590,59 @@ The syntax to use this command is as follows:
 
 		#region Loot Tables
 
-		private const string LootTableHelp = @"Loot tables are revisioned deterministic item/commodity graphs.
+		private const string LootTableHelp = @"Loot tables create an ordered graph of items and commodities in one atomic operation.
 
-#3loottable list [filters]#0
+A table contains named #6variants#0. Each variant runs its #6groups#0 from top to bottom. A group repeats a number of times and selects one weighted #6choice#0 each time. A choice can create an exact item revision, create a commodity, run an exact nested LootTable revision, or create nothing.
+
+An item choice can #6provide a local key#0. Later groups may use that key as their destination, which puts their results inside that particular generated container. Running a nested table does not itself imply containment: the nested group's destination controls where the child table's outer-target results go.
+
+#6Example realised structure:#0
+Outer target
+|- envelope provided as key 'vessel'
+|  '- 125 grams of carbon steel directed inside 'vessel'
+'- envelope produced by a nested child table directed to the outer target
+
+#6Create and inspect:#0
+#3loottable new <name>#0
+#3loottable edit <id|name> [revision]#0
+#3loottable edit#0
+#3loottable close#0
 #3loottable show <id|name> [revision]#0
-#3loottable edit new <name>|<id|name>|close|submit|delete|obsolete#0
-#3loottable revise <id|name>#0
-#3loottable review ...#0
-#3loottable set variant|group|choice ...#0
-#3loottable validate <id|name> [revision]#0
-#3loottable preview <id|name> [revision] <variant> [seed]#0
-#3loottable load <id|name> [revision] <variant> [seed] here|into <item>|to <character>#0
+#3loottable list [filters]#0
 
-Group and choice editing syntax is shown by #3loottable set#0.";
+#6Variants:#0
+#3loottable set variant add <key>#0
+#3loottable set variant remove <key>#0
+#3loottable set variant rename <old> <new>#0
+
+#6Ordered groups:#0
+#3loottable set group add <variant> <key> [repeat <min> <max>] [into <target|earlier-key>]#0
+#3loottable set group repeat <variant> <key> <min> <max>#0
+#3loottable set group destination <variant> <key> <target|earlier-key>#0
+#3loottable set group swap <variant> <key> <position>#0
+#3loottable set group remove <variant> <key>#0
+
+#6Weighted choices:#0
+#3loottable set choice add <variant> <group> <key> <weight> nothing#0
+#3loottable set choice add <variant> <group> <key> <weight> item <prototype> [revision <rev>] [quantity <min> <max>] [quality <min> <max>] [as <local-key>]#0
+#3loottable set choice add <variant> <group> <key> <weight> commodity <material> [tag <tag>] [mass <min> <max>]#0
+#3loottable set choice add <variant> <group> <key> <weight> table <id> <revision> <variant>#0
+#3loottable set choice weight <variant> <group> <key> <weight>#0
+#3loottable set choice variables <variant> <group> <key> <definition=value ...|clear>#0
+#3loottable set choice remove <variant> <group> <key>#0
+
+Commodity mass accepts explicit units such as #3125g#0 or #31.5kg#0. Bare numbers remain supported as engine base mass units for compatibility.
+
+#6Validate and test:#0
+#3loottable validate <id|name> [revision]#0 - checks references, destinations, cycles and limits
+#3loottable preview <id|name> [revision] <variant> [seed]#0 - shows the deterministic plan without creating anything
+#3loottable load <id|name> [revision] <variant> [seed] here|into <item>|to <character>#0 - atomically creates the plan
+
+#6Revision lifecycle:#0
+#3loottable clone <id|name> [revision] <new name>#0
+#3loottable revise <id|name>#0
+#3loottable submit <comment>#0
+#3loottable review <id|name> [revision]#0";
 
 		[PlayerCommand("LootTable", "loottable", "lt")]
 		[CommandPermission(PermissionLevel.Admin)]

--- a/MudSharpCore/Commands/Modules/ItemBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/ItemBuilderModule.cs
@@ -1714,7 +1714,19 @@ Item choices start open and unlocked unless marked #3closed#0 or #3locked#0. #3l
 					? actor.Gameworld.LootTables.Get(id, (command.PopSpeech(), revision).Item2)
 					: actor.Gameworld.LootTables.Get(id);
 			}
-			else table = actor.Gameworld.LootTables.GetByName(token, ignoreCase: true);
+			else
+			{
+				var named = actor.Gameworld.LootTables.GetByName(token, ignoreCase: true);
+				if (named is not null && !command.IsFinished && int.TryParse(command.PeekSpeech(), out var revision))
+				{
+					command.PopSpeech();
+					table = actor.Gameworld.LootTables.Get(named.Id, revision);
+				}
+				else
+				{
+					table = named;
+				}
+			}
 			if (table is not null) return true;
 			actor.Send("There is no such loot table revision."); return false;
 		}

--- a/MudSharpCore/Framework/Futuremud.cs
+++ b/MudSharpCore/Framework/Futuremud.cs
@@ -71,6 +71,7 @@ using MudSharp.Vehicles;
 using MudSharp.Work.Butchering;
 using MudSharp.Work.Crafts;
 using MudSharp.Work.Foraging;
+using MudSharp.Work.Loot;
 using MudSharp.Work.Projects;
 using System.Diagnostics;
 using System.Numerics;
@@ -1252,6 +1253,11 @@ public sealed partial class Futuremud : IFuturemud, IDisposable, IRuntimePerform
         _trapTemplates.Add(trapTemplate);
     }
 
+    public void Add(ILootTable lootTable)
+    {
+        _lootTables.Add(lootTable);
+    }
+
     public void Add(IForagable foragable)
     {
         _foragables.Add(foragable);
@@ -2293,6 +2299,11 @@ public sealed partial class Futuremud : IFuturemud, IDisposable, IRuntimePerform
     public void Destroy(ITrapTemplate trapTemplate)
     {
         _trapTemplates.Remove(trapTemplate);
+    }
+
+    public void Destroy(ILootTable lootTable)
+    {
+        _lootTables.Remove(lootTable);
     }
 
     public void Destroy(IForagable foragable)

--- a/MudSharpCore/Framework/FuturemudLoaders.cs
+++ b/MudSharpCore/Framework/FuturemudLoaders.cs
@@ -74,6 +74,7 @@ using MudSharp.TimeAndDate.Time;
 using MudSharp.Vehicles;
 using MudSharp.Work.Butchering;
 using MudSharp.Work.Projects;
+using MudSharp.Work.Loot;
 using System.Diagnostics;
 using System.IO;
 using System.Numerics;
@@ -353,6 +354,7 @@ public sealed partial class Futuremud : IFuturemudLoader, IFuturemud, IDisposabl
             // End Game Item Related Loads
 
             game.LoadForagables(); // Depends on LoadGameItemProtos
+			game.LoadLootTables(); // Depends on item prototypes, materials, tags and characteristics
 
             game.LoadNameCultures();
             game.LoadEthnicities(); // depends on LoadCharacteristics and LoadNameCultures
@@ -2321,6 +2323,20 @@ For information on the syntax to use in emotes (such as those included in bracke
 #endif
         var count = templates.Count;
         ConsoleUtilities.WriteLine("Loaded #2{0:N0}#0 {1}.", count, count == 1 ? "Trap Template" : "Trap Templates");
+    }
+
+    void IFuturemudLoader.LoadLootTables()
+    {
+        ConsoleUtilities.WriteLine("\nLoading #5Loot Tables#0...");
+        using (new FMDB())
+        {
+            var rows = FMDB.Context.LootTables.Include(x => x.EditableItem).AsNoTracking().ToList();
+            foreach (var row in rows)
+            {
+                _lootTables.Add(new MudSharp.Work.Loot.LootTable(row, this));
+            }
+            ConsoleUtilities.WriteLine("Loaded #2{0:N0}#0 {1}.", rows.Count, rows.Count == 1 ? "Loot Table" : "Loot Tables");
+        }
     }
 
     void IFuturemudLoader.LoadCorpseModels()

--- a/MudSharpCore/Framework/FuturemudVariables.cs
+++ b/MudSharpCore/Framework/FuturemudVariables.cs
@@ -68,6 +68,7 @@ using MudSharp.Vehicles;
 using MudSharp.Work.Butchering;
 using MudSharp.Work.Crafts;
 using MudSharp.Work.Foraging;
+using MudSharp.Work.Loot;
 using MudSharp.Work.Projects;
 
 #nullable enable
@@ -168,6 +169,7 @@ public sealed partial class Futuremud : IDisposable
     private readonly RevisableAll<IForagable> _foragables = new();
     private readonly RevisableAll<IForagableProfile> _foragableProfiles = new();
     private readonly RevisableAll<ITrapTemplate> _trapTemplates = new();
+    private readonly RevisableAll<ILootTable> _lootTables = new();
     private readonly All<IFutureProg> _futureProgs = new();
     private readonly All<IGrid> _grids = new();
     private readonly All<IHealthStrategy> _healthStrategies = new();
@@ -434,6 +436,7 @@ public sealed partial class Futuremud : IDisposable
 
     public IUneditableRevisableAll<IForagableProfile> ForagableProfiles => _foragableProfiles;
     public IUneditableRevisableAll<ITrapTemplate> TrapTemplates => _trapTemplates;
+    public IUneditableRevisableAll<ILootTable> LootTables => _lootTables;
 
     public IUneditableAll<IFutureProg> FutureProgs => _futureProgs;
 

--- a/MudSharpCore/Framework/Revision/EditableItemReviewProposal.cs
+++ b/MudSharpCore/Framework/Revision/EditableItemReviewProposal.cs
@@ -5,6 +5,7 @@ using MudSharp.NPC.Templates;
 using MudSharp.Traps;
 using MudSharp.Work.Crafts;
 using MudSharp.Work.Foraging;
+using MudSharp.Work.Loot;
 using MudSharp.Work.Projects;
 
 namespace MudSharp.Framework.Revision;
@@ -75,6 +76,11 @@ public class EditableItemReviewProposal<T> : Proposal, IProposal where T : IEdit
 		if (typeof(T) == typeof(ITrapTemplate))
 		{
 			return _proponent.Gameworld.TrapTemplates;
+		}
+
+		if (typeof(T) == typeof(ILootTable))
+		{
+			return _proponent.Gameworld.LootTables;
 		}
 
         throw new NotSupportedException("Not supported type in EDitableItemREviewProposal");

--- a/MudSharpCore/FutureProg/Functions/GameItem/LoadLootTableFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/GameItem/LoadLootTableFunction.cs
@@ -1,0 +1,83 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.FutureProg.Variables;
+using MudSharp.GameItems;
+using MudSharp.Framework.Revision;
+using MudSharp.Work.Loot;
+
+namespace MudSharp.FutureProg.Functions.GameItem;
+
+internal sealed class LoadLootTableFunction : BuiltInFunction
+{
+	private readonly IFuturemud _gameworld;
+	private readonly ProgVariableTypes _targetType;
+	private readonly bool _seeded;
+
+	private LoadLootTableFunction(IList<IFunction> parameters, IFuturemud gameworld, ProgVariableTypes targetType, bool seeded) : base(parameters)
+	{
+		_gameworld = gameworld;
+		_targetType = targetType;
+		_seeded = seeded;
+	}
+
+	public override ProgVariableTypes ReturnType { get => ProgVariableTypes.Text; protected set { } }
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error) return StatementResult.Error;
+		var id = (long)(decimal)ParameterFunctions[0].Result.GetObject;
+		var revision = (int)(decimal)ParameterFunctions[1].Result.GetObject;
+		var table = _gameworld.LootTables.Get(id, revision);
+		if (table is null) return Receipt("ERROR code=TABLE_NOT_FOUND message=The exact LootTable revision does not exist.");
+		if (!table.Status.In(RevisionStatus.Current, RevisionStatus.Revised)) return Receipt("ERROR code=TABLE_NOT_APPROVED message=The exact LootTable revision is not approved.");
+		var variant = ParameterFunctions[3].Result.GetObject?.ToString() ?? string.Empty;
+		var seed = _seeded ? (long)(decimal)ParameterFunctions[4].Result.GetObject : Random.Shared.NextInt64(long.MaxValue);
+		if (seed < 0) return Receipt("ERROR code=INVALID_SEED message=The seed must be non-negative.");
+		var materialiser = new LootTableMaterialiser(_gameworld);
+		var target = ParameterFunctions[2].Result?.GetObject;
+		LootMaterialisationResult result;
+		if (_targetType == ProgVariableTypes.Location && target is ICell cell) result = materialiser.Materialise(table, variant, seed, cell);
+		else if (_targetType == ProgVariableTypes.Item && target is IGameItem item) result = materialiser.Materialise(table, variant, seed, item);
+		else if (_targetType == ProgVariableTypes.Character && target is ICharacter character) result = materialiser.Materialise(table, variant, seed, character);
+		else return Receipt("ERROR code=NULL_TARGET message=The LootTable target was null or invalid.");
+		return Receipt(result.Receipt);
+	}
+
+	private StatementResult Receipt(string text)
+	{
+		Result = new TextVariable(text);
+		return StatementResult.Normal;
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		foreach (var targetType in new[] { ProgVariableTypes.Location, ProgVariableTypes.Item, ProgVariableTypes.Character })
+		{
+			Register(targetType, false);
+			Register(targetType, true);
+		}
+	}
+
+	private static void Register(ProgVariableTypes targetType, bool seeded)
+	{
+		var types = seeded
+			? new[] { ProgVariableTypes.Number, ProgVariableTypes.Number, targetType, ProgVariableTypes.Text, ProgVariableTypes.Number }
+			: new[] { ProgVariableTypes.Number, ProgVariableTypes.Number, targetType, ProgVariableTypes.Text };
+		var names = seeded
+			? new List<string> { "tableId", "revision", "target", "variant", "seed" }
+			: new List<string> { "tableId", "revision", "target", "variant" };
+		var descriptions = seeded
+			? new List<string> { "The LootTable ID", "The exact revision", "The destination", "The variant key", "A non-negative deterministic seed" }
+			: new List<string> { "The LootTable ID", "The exact revision", "The destination", "The variant key" };
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"loadloottable", types,
+			(pars, gameworld) => new LoadLootTableFunction(pars, gameworld, targetType, seeded),
+			names, descriptions,
+			"Atomically materialises an exact LootTable revision into a location, container item, or character inventory. Returns a canonical OK or ERROR receipt.",
+			"Items", ProgVariableTypes.Text));
+	}
+}

--- a/MudSharpCore/Work/Loot/LootTable.cs
+++ b/MudSharpCore/Work/Loot/LootTable.cs
@@ -225,7 +225,11 @@ public sealed class LootTable : EditableItem, ILootTable
 
 	protected override IEnumerable<IEditableRevisableItem> GetAllSameId() => Gameworld.LootTables.GetAll(Id);
 
-	private const string BuildingHelp = @"Use NAME <name>, VARIANT ADD|REMOVE|RENAME, GROUP ADD|REPEAT|DESTINATION|SWAP|REMOVE, CHOICE ADD|WEIGHT|VARIABLES|REMOVE. See HELP LOOTTABLE for syntax.";
+	private const string BuildingHelp = @"Edit this LootTable with NAME, VARIANT, GROUP or CHOICE.
+
+Groups run in displayed order. An item choice may provide a local key with AS <key>; later groups use GROUP ... DESTINATION <key> to put their results inside that generated container. Nested tables inherit the destination of the group that invokes them.
+
+Use HELP LOOTTABLE for complete syntax and an example.";
 
 	public override bool BuildingCommand(ICharacter actor, StringStack command)
 	{
@@ -325,7 +329,11 @@ public sealed class LootTable : EditableItem, ILootTable
 			{
 				case "nothing": choice.Kind = LootChoiceKind.Nothing; break;
 				case "item" when long.TryParse(command.PopSpeech(), out var proto): choice.Kind = LootChoiceKind.Item; choice.ItemPrototypeId = proto; choice.ItemPrototypeRevision = Gameworld.ItemProtos.Get(proto)?.RevisionNumber ?? 0; ParseItemOptions(choice, command); break;
-				case "commodity" when long.TryParse(command.PopSpeech(), out var material): choice.Kind = LootChoiceKind.Commodity; choice.CommodityMaterialId = material; ParseCommodityOptions(choice, command); break;
+				case "commodity" when long.TryParse(command.PopSpeech(), out var material):
+					choice.Kind = LootChoiceKind.Commodity;
+					choice.CommodityMaterialId = material;
+					if (!ParseCommodityOptions(choice, command, actor)) return false;
+					break;
 				case "table" when long.TryParse(command.PopSpeech(), out var table) && int.TryParse(command.PopSpeech(), out var revision) && !command.IsFinished: choice.Kind = LootChoiceKind.LootTable; choice.NestedTableId = table; choice.NestedTableRevision = revision; choice.NestedVariant = command.PopSpeech().ToLowerInvariant(); break;
 				default: actor.Send("Invalid choice type or arguments."); return false;
 			}
@@ -349,15 +357,29 @@ public sealed class LootTable : EditableItem, ILootTable
 		}
 	}
 
-	private static void ParseCommodityOptions(LootChoiceDefinition choice, StringStack command)
+	private bool ParseCommodityOptions(LootChoiceDefinition choice, StringStack command, ICharacter actor)
 	{
 		while (!command.IsFinished)
 		{
 			switch (command.PopSpeech().ToLowerInvariant())
 			{
 				case "tag" when long.TryParse(command.PopSpeech(), out var tag): choice.CommodityTagId = tag; break;
-				case "mass" when double.TryParse(command.PopSpeech(), out var min) && double.TryParse(command.PopSpeech(), out var max): choice.MassMinimum = min; choice.MassMaximum = max; break;
+				case "mass":
+					var minimumText = command.PopSpeech();
+					var maximumText = command.PopSpeech();
+					if (!TryParseMass(minimumText, actor, out var min) || !TryParseMass(maximumText, actor, out var max))
+					{
+						actor.Send("Mass ranges must be numbers in engine base units or values with explicit units, such as 125g or 1.5kg.");
+						return false;
+					}
+					choice.MassMinimum = min;
+					choice.MassMaximum = max;
+					break;
 			}
 		}
+		return true;
 	}
+
+	private bool TryParseMass(string text, ICharacter actor, out double value) =>
+		double.TryParse(text, out value) || Gameworld.UnitManager.TryGetBaseUnits(text, UnitType.Mass, actor, out value);
 }

--- a/MudSharpCore/Work/Loot/LootTable.cs
+++ b/MudSharpCore/Work/Loot/LootTable.cs
@@ -311,16 +311,18 @@ Use HELP LOOTTABLE for complete syntax and an example.";
 		else if (action == "weight" && choice is not null && long.TryParse(command.PopSpeech(), out var weight)) choice.Weight = weight;
 		else if (action == "variables" && choice is not null && choice.Kind == LootChoiceKind.Item)
 		{
-			choice.Characteristics.Clear();
+			var characteristics = new List<LootCharacteristicValue>();
 			if (!command.PeekSpeech().EqualTo("clear"))
 			{
 				while (!command.IsFinished)
 				{
 					var pair = command.PopSpeech().Split('=', 2);
 					if (pair.Length != 2 || !long.TryParse(pair[0], out var definition) || !long.TryParse(pair[1], out var value)) { actor.Send("Variables must be exact numeric definition=value pairs."); return false; }
-					choice.Characteristics.Add(new LootCharacteristicValue { DefinitionId = definition, ValueId = value });
+					characteristics.Add(new LootCharacteristicValue { DefinitionId = definition, ValueId = value });
 				}
 			}
+			choice.Characteristics.Clear();
+			choice.Characteristics.AddRange(characteristics);
 		}
 		else if (action == "add" && choice is null && long.TryParse(command.PopSpeech(), out var newWeight))
 		{

--- a/MudSharpCore/Work/Loot/LootTable.cs
+++ b/MudSharpCore/Work/Loot/LootTable.cs
@@ -233,7 +233,8 @@ public sealed class LootTable : EditableItem, ILootTable
 	{
 		var action = command.PopSpeech().ToLowerInvariant();
 		var variant = Definition.Variants.FirstOrDefault(x => x.Key.EqualTo(command.PopSpeech()));
-		var group = variant?.Groups.FirstOrDefault(x => x.Key.EqualTo(command.PopSpeech()));
+		var groupKey = command.PopSpeech();
+		var group = variant?.Groups.FirstOrDefault(x => x.Key.EqualTo(groupKey));
 		if (group is null) { actor.Send("There is no such variant/group."); return false; }
 		var key = command.PopSpeech().ToLowerInvariant();
 		var choice = group.Choices.FirstOrDefault(x => x.Key.EqualTo(key));

--- a/MudSharpCore/Work/Loot/LootTable.cs
+++ b/MudSharpCore/Work/Loot/LootTable.cs
@@ -1,0 +1,298 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using MudSharp.Accounts;
+using MudSharp.Character;
+using MudSharp.Database;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.Models;
+using EditableItem = MudSharp.Framework.Revision.EditableItem;
+using DbLootTable = MudSharp.Models.LootTable;
+
+namespace MudSharp.Work.Loot;
+
+public sealed class LootTable : EditableItem, ILootTable
+{
+	public const int CurrentAlgorithm = LootTableDefinition.CurrentAlgorithmVersion;
+
+	public LootTable(DbLootTable row, IFuturemud gameworld) : base(row.EditableItem)
+	{
+		Gameworld = gameworld;
+		_id = row.Id;
+		_name = row.Name;
+		Definition = LootTableDefinition.Load(row.Definition);
+		if (row.AlgorithmVersion != Definition.AlgorithmVersion)
+		{
+			throw new InvalidOperationException($"LootTable #{row.Id}r{row.RevisionNumber} algorithm column does not match its canonical definition.");
+		}
+	}
+
+	public LootTable(IAccount originator, string name) : base(originator)
+	{
+		Gameworld = originator.Gameworld;
+		_name = name.TitleCase();
+		Definition = new LootTableDefinition();
+		Definition.Variants.Add(new LootVariantDefinition { Key = "default" });
+		using (new FMDB())
+		{
+			var row = new DbLootTable
+			{
+				Id = Gameworld.LootTables.NextID(),
+				RevisionNumber = 0,
+				Name = _name,
+				AlgorithmVersion = AlgorithmVersion,
+				Definition = Definition.ToCanonicalXml(),
+				EditableItem = new Models.EditableItem
+				{
+					BuilderAccountId = BuilderAccountID,
+					BuilderDate = BuilderDate,
+					RevisionNumber = 0,
+					RevisionStatus = (int)Status
+				}
+			};
+			FMDB.Context.LootTables.Add(row);
+			FMDB.Context.SaveChanges();
+			_id = row.Id;
+		}
+	}
+
+	public override string FrameworkItemType => "LootTable";
+	public int AlgorithmVersion => Definition.AlgorithmVersion;
+	public LootTableDefinition Definition { get; private set; }
+	public string DefinitionHash => Definition.ComputeHash();
+
+	public override string EditHeader() => $"Loot Table {Name} ({Id:N0}r{RevisionNumber:N0})";
+
+	public override bool CanSubmit() => LootTableValidator.Validate(this, Gameworld).Count == 0;
+	public override string WhyCannotSubmit() =>
+		string.Join("\n", LootTableValidator.Validate(this, Gameworld).Select(x => $"- {x}"));
+
+	public override string Show(ICharacter actor)
+	{
+		var sb = new StringBuilder();
+		sb.AppendLine($"Loot Table #{Id.ToStringN0(actor)}r{RevisionNumber.ToStringN0(actor)} - {Name.ColourName()} - {Status.DescribeColour()}");
+		sb.AppendLine($"Algorithm: {AlgorithmVersion.ToString().ColourValue()}");
+		sb.AppendLine($"Definition Hash: {DefinitionHash.ColourValue()}");
+		foreach (var variant in Definition.Variants)
+		{
+			sb.AppendLine($"Variant {variant.Key.ColourName()}");
+			for (var i = 0; i < variant.Groups.Count; i++)
+			{
+				var group = variant.Groups[i];
+				sb.AppendLine($"  {i + 1}. {group.Key.ColourName()} repeat {group.RepeatMinimum}-{group.RepeatMaximum} into {group.DestinationKey.ColourValue()}");
+				var total = group.Choices.Sum(x => x.Weight);
+				for (var j = 0; j < group.Choices.Count; j++)
+				{
+					var choice = group.Choices[j];
+					sb.AppendLine($"     {j + 1}. {choice.Key.ColourName()} weight {choice.Weight:N0} ({(total > 0 ? (double)choice.Weight / total : 0.0):P2}) {DescribeChoice(choice)}");
+				}
+			}
+		}
+		var errors = LootTableValidator.Validate(this, Gameworld);
+		if (errors.Count > 0)
+		{
+			sb.AppendLine("Validation errors:".ColourError());
+			foreach (var error in errors) sb.AppendLine($"  - {error}".ColourError());
+		}
+		return sb.ToString();
+	}
+
+	private static string DescribeChoice(LootChoiceDefinition choice) => choice.Kind switch
+	{
+		LootChoiceKind.Nothing => "nothing",
+		LootChoiceKind.Item => $"item #{choice.ItemPrototypeId}r{choice.ItemPrototypeRevision} x{choice.QuantityMinimum}-{choice.QuantityMaximum} quality {choice.QualityMinimum}-{choice.QualityMaximum}{(string.IsNullOrEmpty(choice.ResultKey) ? "" : $" as {choice.ResultKey}")}",
+		LootChoiceKind.Commodity => $"commodity material #{choice.CommodityMaterialId}{(choice.CommodityTagId is null ? "" : $" tag #{choice.CommodityTagId}")} mass {choice.MassMinimum:R}-{choice.MassMaximum:R}",
+		LootChoiceKind.LootTable => $"table #{choice.NestedTableId}r{choice.NestedTableRevision} variant {choice.NestedVariant}",
+		_ => "unknown"
+	};
+
+	public override IEditableRevisableItem CreateNewRevision(ICharacter initiator)
+	{
+		using (new FMDB())
+		{
+			var revision = FMDB.Context.LootTables.Where(x => x.Id == Id).Select(x => x.RevisionNumber)
+			                     .AsEnumerable().DefaultIfEmpty(-1).Max() + 1;
+			var row = new DbLootTable
+			{
+				Id = Id,
+				RevisionNumber = revision,
+				Name = Name,
+				AlgorithmVersion = AlgorithmVersion,
+				Definition = Definition.ToCanonicalXml(),
+				EditableItem = new Models.EditableItem
+				{
+					BuilderAccountId = initiator.Account.Id,
+					BuilderDate = DateTime.UtcNow,
+					RevisionNumber = revision,
+					RevisionStatus = (int)RevisionStatus.UnderDesign
+				}
+			};
+			FMDB.Context.LootTables.Add(row);
+			FMDB.Context.SaveChanges();
+			return new LootTable(row, Gameworld);
+		}
+	}
+
+	public LootTable Clone(IAccount originator, string name)
+	{
+		var clone = new LootTable(originator, name) { Definition = Definition.Clone() };
+		clone.Changed = true;
+		return clone;
+	}
+
+	public override void Save()
+	{
+		using (new FMDB())
+		{
+			var row = FMDB.Context.LootTables.Find(Id, RevisionNumber);
+			if (row is null) return;
+			if (_statusChanged) base.Save(row.EditableItem);
+			row.Name = Name;
+			row.AlgorithmVersion = AlgorithmVersion;
+			row.Definition = Definition.ToCanonicalXml();
+			FMDB.Context.SaveChanges();
+		}
+		Changed = false;
+	}
+
+	protected override IEnumerable<IEditableRevisableItem> GetAllSameId() => Gameworld.LootTables.GetAll(Id);
+
+	private const string BuildingHelp = @"Use NAME <name>, VARIANT ADD|REMOVE|RENAME, GROUP ADD|REPEAT|DESTINATION|SWAP|REMOVE, CHOICE ADD|WEIGHT|VARIABLES|REMOVE. See HELP LOOTTABLE for syntax.";
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		var verb = command.PopSpeech().ToLowerInvariant();
+		return verb switch
+		{
+			"name" => SetName(actor, command),
+			"variant" => SetVariant(actor, command),
+			"group" => SetGroup(actor, command),
+			"choice" => SetChoice(actor, command),
+			_ => SendHelp(actor)
+		};
+	}
+
+	private static bool SendHelp(ICharacter actor) { actor.Send(BuildingHelp); return false; }
+	private bool SetName(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished) { actor.Send("What name should this loot table have?"); return false; }
+		_name = command.SafeRemainingArgument.TitleCase(); Changed = true; actor.Send($"Name set to {Name.ColourName()}."); return true;
+	}
+
+	private bool SetVariant(ICharacter actor, StringStack command)
+	{
+		var action = command.PopSpeech().ToLowerInvariant();
+		var key = command.PopSpeech().ToLowerInvariant();
+		if (string.IsNullOrWhiteSpace(key)) return SendHelp(actor);
+		var existing = Definition.Variants.FirstOrDefault(x => x.Key.EqualTo(key));
+		switch (action)
+		{
+			case "add" when existing is null: Definition.Variants.Add(new LootVariantDefinition { Key = key }); break;
+			case "remove" when existing is not null: Definition.Variants.Remove(existing); break;
+			case "rename" when existing is not null && !command.IsFinished: existing.Key = command.PopSpeech().ToLowerInvariant(); break;
+			default: actor.Send("That variant action is invalid or conflicts with an existing/missing variant."); return false;
+		}
+		Changed = true; actor.Send("Variant updated."); return true;
+	}
+
+	private bool SetGroup(ICharacter actor, StringStack command)
+	{
+		var action = command.PopSpeech().ToLowerInvariant();
+		var variant = Definition.Variants.FirstOrDefault(x => x.Key.EqualTo(command.PopSpeech()));
+		if (variant is null) { actor.Send("There is no such variant."); return false; }
+		var key = command.PopSpeech();
+		var group = variant.Groups.FirstOrDefault(x => x.Key.EqualTo(key));
+		if (action == "add")
+		{
+			if (group is not null || string.IsNullOrWhiteSpace(key)) { actor.Send("That group already exists or has no key."); return false; }
+			group = new LootRollGroupDefinition { Key = key.ToLowerInvariant() };
+			variant.Groups.Add(group);
+			while (!command.IsFinished)
+			{
+				switch (command.PopSpeech().ToLowerInvariant())
+				{
+					case "repeat" when int.TryParse(command.PopSpeech(), out var min) && int.TryParse(command.PopSpeech(), out var max): group.RepeatMinimum = min; group.RepeatMaximum = max; break;
+					case "into" when !command.IsFinished: group.DestinationKey = command.PopSpeech().ToLowerInvariant(); break;
+				}
+			}
+		}
+		else if (group is null) { actor.Send("There is no such group."); return false; }
+		else if (action == "remove") variant.Groups.Remove(group);
+		else if (action == "repeat" && int.TryParse(command.PopSpeech(), out var min) && int.TryParse(command.PopSpeech(), out var max)) { group.RepeatMinimum = min; group.RepeatMaximum = max; }
+		else if (action == "destination" && !command.IsFinished) group.DestinationKey = command.PopSpeech().ToLowerInvariant();
+		else if (action == "swap" && int.TryParse(command.PopSpeech(), out var position) && position >= 1 && position <= variant.Groups.Count) { variant.Groups.Remove(group); variant.Groups.Insert(position - 1, group); }
+		else { actor.Send("Invalid group action."); return false; }
+		Changed = true; actor.Send("Group updated."); return true;
+	}
+
+	private bool SetChoice(ICharacter actor, StringStack command)
+	{
+		var action = command.PopSpeech().ToLowerInvariant();
+		var variant = Definition.Variants.FirstOrDefault(x => x.Key.EqualTo(command.PopSpeech()));
+		var group = variant?.Groups.FirstOrDefault(x => x.Key.EqualTo(command.PopSpeech()));
+		if (group is null) { actor.Send("There is no such variant/group."); return false; }
+		var key = command.PopSpeech().ToLowerInvariant();
+		var choice = group.Choices.FirstOrDefault(x => x.Key.EqualTo(key));
+		if (action == "remove" && choice is not null) group.Choices.Remove(choice);
+		else if (action == "weight" && choice is not null && long.TryParse(command.PopSpeech(), out var weight)) choice.Weight = weight;
+		else if (action == "variables" && choice is not null && choice.Kind == LootChoiceKind.Item)
+		{
+			choice.Characteristics.Clear();
+			if (!command.PeekSpeech().EqualTo("clear"))
+			{
+				while (!command.IsFinished)
+				{
+					var pair = command.PopSpeech().Split('=', 2);
+					if (pair.Length != 2 || !long.TryParse(pair[0], out var definition) || !long.TryParse(pair[1], out var value)) { actor.Send("Variables must be exact numeric definition=value pairs."); return false; }
+					choice.Characteristics.Add(new LootCharacteristicValue { DefinitionId = definition, ValueId = value });
+				}
+			}
+		}
+		else if (action == "add" && choice is null && long.TryParse(command.PopSpeech(), out var newWeight))
+		{
+			var kind = command.PopSpeech().ToLowerInvariant();
+			choice = new LootChoiceDefinition { Key = key, Weight = newWeight };
+			switch (kind)
+			{
+				case "nothing": choice.Kind = LootChoiceKind.Nothing; break;
+				case "item" when long.TryParse(command.PopSpeech(), out var proto): choice.Kind = LootChoiceKind.Item; choice.ItemPrototypeId = proto; choice.ItemPrototypeRevision = Gameworld.ItemProtos.Get(proto)?.RevisionNumber ?? 0; ParseItemOptions(choice, command); break;
+				case "commodity" when long.TryParse(command.PopSpeech(), out var material): choice.Kind = LootChoiceKind.Commodity; choice.CommodityMaterialId = material; ParseCommodityOptions(choice, command); break;
+				case "table" when long.TryParse(command.PopSpeech(), out var table) && int.TryParse(command.PopSpeech(), out var revision) && !command.IsFinished: choice.Kind = LootChoiceKind.LootTable; choice.NestedTableId = table; choice.NestedTableRevision = revision; choice.NestedVariant = command.PopSpeech().ToLowerInvariant(); break;
+				default: actor.Send("Invalid choice type or arguments."); return false;
+			}
+			group.Choices.Add(choice);
+		}
+		else { actor.Send("Invalid choice action."); return false; }
+		Changed = true; actor.Send("Choice updated."); return true;
+	}
+
+	private static void ParseItemOptions(LootChoiceDefinition choice, StringStack command)
+	{
+		while (!command.IsFinished)
+		{
+			switch (command.PopSpeech().ToLowerInvariant())
+			{
+				case "revision" when int.TryParse(command.PopSpeech(), out var revision): choice.ItemPrototypeRevision = revision; break;
+				case "quantity" when int.TryParse(command.PopSpeech(), out var min) && int.TryParse(command.PopSpeech(), out var max): choice.QuantityMinimum = min; choice.QuantityMaximum = max; break;
+				case "quality" when int.TryParse(command.PopSpeech(), out var min) && int.TryParse(command.PopSpeech(), out var max): choice.QualityMinimum = min; choice.QualityMaximum = max; break;
+				case "as" when !command.IsFinished: choice.ResultKey = command.PopSpeech().ToLowerInvariant(); break;
+			}
+		}
+	}
+
+	private static void ParseCommodityOptions(LootChoiceDefinition choice, StringStack command)
+	{
+		while (!command.IsFinished)
+		{
+			switch (command.PopSpeech().ToLowerInvariant())
+			{
+				case "tag" when long.TryParse(command.PopSpeech(), out var tag): choice.CommodityTagId = tag; break;
+				case "mass" when double.TryParse(command.PopSpeech(), out var min) && double.TryParse(command.PopSpeech(), out var max): choice.MassMinimum = min; choice.MassMaximum = max; break;
+			}
+		}
+	}
+}

--- a/MudSharpCore/Work/Loot/LootTable.cs
+++ b/MudSharpCore/Work/Loot/LootTable.cs
@@ -9,6 +9,8 @@ using MudSharp.Character;
 using MudSharp.Database;
 using MudSharp.Framework;
 using MudSharp.Framework.Revision;
+using MudSharp.Framework.Units;
+using MudSharp.GameItems;
 using MudSharp.Models;
 using EditableItem = MudSharp.Framework.Revision.EditableItem;
 using DbLootTable = MudSharp.Models.LootTable;
@@ -74,23 +76,45 @@ public sealed class LootTable : EditableItem, ILootTable
 	public override string Show(ICharacter actor)
 	{
 		var sb = new StringBuilder();
-		sb.AppendLine($"Loot Table #{Id.ToStringN0(actor)}r{RevisionNumber.ToStringN0(actor)} - {Name.ColourName()} - {Status.DescribeColour()}");
+		sb.AppendLine($"Loot Table #{Id.ToStringN0(actor)}r{RevisionNumber.ToStringN0(actor)}: {Name.ColourName()}");
+		sb.AppendLine();
+		sb.AppendLine($"Status: {Status.DescribeColour()}");
 		sb.AppendLine($"Algorithm: {AlgorithmVersion.ToString().ColourValue()}");
 		sb.AppendLine($"Definition Hash: {DefinitionHash.ColourValue()}");
 		foreach (var variant in Definition.Variants)
 		{
-			sb.AppendLine($"Variant {variant.Key.ColourName()}");
+			sb.AppendLine();
+			sb.AppendLine($"Variant: {variant.Key.ColourName()}");
+			var rows = new List<List<string>>();
 			for (var i = 0; i < variant.Groups.Count; i++)
 			{
 				var group = variant.Groups[i];
-				sb.AppendLine($"  {i + 1}. {group.Key.ColourName()} repeat {group.RepeatMinimum}-{group.RepeatMaximum} into {group.DestinationKey.ColourValue()}");
 				var total = group.Choices.Sum(x => x.Weight);
+				if (group.Choices.Count == 0)
+				{
+					rows.Add([
+						$"{i + 1}. {group.Key}", DescribeRange(group.RepeatMinimum, group.RepeatMaximum),
+						DescribeDestination(group.DestinationKey), "(none)", "", "No choices configured"
+					]);
+					continue;
+				}
+
 				for (var j = 0; j < group.Choices.Count; j++)
 				{
 					var choice = group.Choices[j];
-					sb.AppendLine($"     {j + 1}. {choice.Key.ColourName()} weight {choice.Weight:N0} ({(total > 0 ? (double)choice.Weight / total : 0.0):P2}) {DescribeChoice(choice)}");
+					rows.Add([
+						$"{i + 1}. {group.Key}", DescribeRange(group.RepeatMinimum, group.RepeatMaximum),
+						DescribeDestination(group.DestinationKey), $"{j + 1}. {choice.Key}",
+						total > 0 ? $"{choice.Weight:N0} ({(double)choice.Weight / total:P2})" : $"{choice.Weight:N0}",
+						DescribeChoice(choice, actor)
+					]);
 				}
 			}
+			sb.AppendLine(variant.Groups.Count == 0
+				? "(no groups)".ColourError()
+				: StringUtilities.GetTextTable(rows,
+					["Group", "Repeat", "Destination", "Choice", "Weight / Chance", "Result"], actor,
+					Telnet.Cyan, truncatableColumnIndex: 5));
 		}
 		var errors = LootTableValidator.Validate(this, Gameworld);
 		if (errors.Count > 0)
@@ -101,14 +125,54 @@ public sealed class LootTable : EditableItem, ILootTable
 		return sb.ToString();
 	}
 
-	private static string DescribeChoice(LootChoiceDefinition choice) => choice.Kind switch
+	private static string DescribeRange(int minimum, int maximum) => minimum == maximum ? minimum.ToString("N0") : $"{minimum:N0}-{maximum:N0}";
+	private static string DescribeDestination(string key) => key.EqualTo("target") ? "Outer target" : $"Inside '{key}'";
+
+	private string DescribeChoice(LootChoiceDefinition choice, ICharacter actor) => choice.Kind switch
 	{
-		LootChoiceKind.Nothing => "nothing",
-		LootChoiceKind.Item => $"item #{choice.ItemPrototypeId}r{choice.ItemPrototypeRevision} x{choice.QuantityMinimum}-{choice.QuantityMaximum} quality {choice.QualityMinimum}-{choice.QualityMaximum}{(string.IsNullOrEmpty(choice.ResultKey) ? "" : $" as {choice.ResultKey}")}",
-		LootChoiceKind.Commodity => $"commodity material #{choice.CommodityMaterialId}{(choice.CommodityTagId is null ? "" : $" tag #{choice.CommodityTagId}")} mass {choice.MassMinimum:R}-{choice.MassMaximum:R}",
-		LootChoiceKind.LootTable => $"table #{choice.NestedTableId}r{choice.NestedTableRevision} variant {choice.NestedVariant}",
+		LootChoiceKind.Nothing => "Nothing",
+		LootChoiceKind.Item => DescribeItemChoice(choice),
+		LootChoiceKind.Commodity => DescribeCommodityChoice(choice, actor),
+		LootChoiceKind.LootTable => DescribeNestedChoice(choice),
 		_ => "unknown"
 	};
+
+	private string DescribeItemChoice(LootChoiceDefinition choice)
+	{
+		var proto = Gameworld.ItemProtos.Get(choice.ItemPrototypeId, choice.ItemPrototypeRevision);
+		var quantity = DescribeRange(choice.QuantityMinimum, choice.QuantityMaximum);
+		var quality = choice.QualityMinimum == choice.QualityMaximum
+			? ((ItemQuality)choice.QualityMinimum).Describe()
+			: $"{((ItemQuality)choice.QualityMinimum).Describe()}-{((ItemQuality)choice.QualityMaximum).Describe()}";
+		var variables = choice.Characteristics.Select(x =>
+		{
+			var definition = Gameworld.Characteristics.Get(x.DefinitionId);
+			var value = Gameworld.CharacteristicValues.Get(x.ValueId);
+			return definition is null || value is null
+				? $"#{x.DefinitionId}=#{x.ValueId}"
+				: $"{definition.Name}={value.Name}";
+		}).ToList();
+		return $"Item #{choice.ItemPrototypeId}r{choice.ItemPrototypeRevision} {(proto?.ShortDescription ?? "(missing prototype)")}; quantity {quantity}; quality {quality}" +
+		       (string.IsNullOrEmpty(choice.ResultKey) ? "" : $"; provides key '{choice.ResultKey}'") +
+		       (variables.Count == 0 ? "" : $"; variables {string.Join(", ", variables)}");
+	}
+
+	private string DescribeCommodityChoice(LootChoiceDefinition choice, ICharacter actor)
+	{
+		var material = Gameworld.Materials.Get(choice.CommodityMaterialId);
+		var tag = choice.CommodityTagId is null ? null : Gameworld.Tags.Get(choice.CommodityTagId.Value);
+		var mass = choice.MassMinimum == choice.MassMaximum
+			? Gameworld.UnitManager.DescribeExact(choice.MassMinimum, UnitType.Mass, actor)
+			: $"{Gameworld.UnitManager.DescribeExact(choice.MassMinimum, UnitType.Mass, actor)}-{Gameworld.UnitManager.DescribeExact(choice.MassMaximum, UnitType.Mass, actor)}";
+		return $"Commodity #{choice.CommodityMaterialId} {material?.Name ?? "(missing material)"}; mass {mass}" +
+		       (choice.CommodityTagId is null ? "" : $"; tag #{choice.CommodityTagId} {tag?.Name ?? "(missing tag)"}");
+	}
+
+	private string DescribeNestedChoice(LootChoiceDefinition choice)
+	{
+		var nested = Gameworld.LootTables.Get(choice.NestedTableId, choice.NestedTableRevision);
+		return $"LootTable #{choice.NestedTableId}r{choice.NestedTableRevision} {nested?.Name ?? "(missing table)"}; variant '{choice.NestedVariant}'";
+	}
 
 	public override IEditableRevisableItem CreateNewRevision(ICharacter initiator)
 	{

--- a/MudSharpCore/Work/Loot/LootTable.cs
+++ b/MudSharpCore/Work/Loot/LootTable.cs
@@ -153,6 +153,7 @@ public sealed class LootTable : EditableItem, ILootTable
 				: $"{definition.Name}={value.Name}";
 		}).ToList();
 		return $"Item #{choice.ItemPrototypeId}r{choice.ItemPrototypeRevision} {(proto?.ShortDescription ?? "(missing prototype)")}; quantity {quantity}; quality {quality}" +
+		       (choice.StartsLocked ? "; starts closed and locked" : choice.StartsClosed ? "; starts closed" : "") +
 		       (string.IsNullOrEmpty(choice.ResultKey) ? "" : $"; provides key '{choice.ResultKey}'") +
 		       (variables.Count == 0 ? "" : $"; variables {string.Join(", ", variables)}");
 	}
@@ -352,6 +353,8 @@ Use HELP LOOTTABLE for complete syntax and an example.";
 				case "revision" when int.TryParse(command.PopSpeech(), out var revision): choice.ItemPrototypeRevision = revision; break;
 				case "quantity" when int.TryParse(command.PopSpeech(), out var min) && int.TryParse(command.PopSpeech(), out var max): choice.QuantityMinimum = min; choice.QuantityMaximum = max; break;
 				case "quality" when int.TryParse(command.PopSpeech(), out var min) && int.TryParse(command.PopSpeech(), out var max): choice.QualityMinimum = min; choice.QualityMaximum = max; break;
+				case "closed": choice.StartsClosed = true; break;
+				case "locked": choice.StartsClosed = true; choice.StartsLocked = true; break;
 				case "as" when !command.IsFinished: choice.ResultKey = command.PopSpeech().ToLowerInvariant(); break;
 			}
 		}

--- a/MudSharpCore/Work/Loot/LootTableMaterialiser.cs
+++ b/MudSharpCore/Work/Loot/LootTableMaterialiser.cs
@@ -1,0 +1,167 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MudSharp.Body;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Events;
+using MudSharp.Form.Characteristics;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.GameItems.Prototypes;
+
+namespace MudSharp.Work.Loot;
+
+public sealed record LootMaterialisationResult(bool Success, string Receipt, LootTablePlan? Plan = null);
+
+public sealed class LootTableMaterialiser
+{
+	private readonly IFuturemud _gameworld;
+
+	public LootTableMaterialiser(IFuturemud gameworld)
+	{
+		_gameworld = gameworld;
+	}
+
+	public LootTablePlanResult Preview(ILootTable table, string variant, long seed) => Planner().CreatePlan(Source(table), variant, seed);
+
+	public LootMaterialisationResult Materialise(ILootTable table, string variant, long seed, ICell target) =>
+		Materialise(table, variant, seed, new Destination(target, null, null));
+
+	public LootMaterialisationResult Materialise(ILootTable table, string variant, long seed, IGameItem target) =>
+		Materialise(table, variant, seed, new Destination(null, target, null));
+
+	public LootMaterialisationResult Materialise(ILootTable table, string variant, long seed, ICharacter target) =>
+		Materialise(table, variant, seed, new Destination(null, null, target));
+
+	private LootMaterialisationResult Materialise(ILootTable table, string variant, long seed, Destination destination)
+	{
+		var planned = Preview(table, variant, seed);
+		if (!planned.Success) return Error(planned.ErrorCode!, planned.ErrorMessage!);
+		var plan = planned.Plan!;
+		var created = new List<IGameItem>();
+		IReadOnlyList<(LootPlannedLeaf Leaf, IGameItem Item)> plannedItems = [];
+		var keyed = new Dictionary<string, IGameItem>(StringComparer.Ordinal);
+		try
+		{
+			plannedItems = LootAtomicBatch.Execute<LootPlannedLeaf, (LootPlannedLeaf Leaf, IGameItem Item)>(
+				plan.Leaves,
+				leaf => CreateLeaf(leaf).Select(item => (leaf, item)),
+				items =>
+				{
+					foreach (var grouping in items.Where(x => x.Leaf.ResultKey is not null).GroupBy(x => x.Leaf.ResultKey!))
+					{
+						if (grouping.Count() != 1 || !keyed.TryAdd(grouping.Key, grouping.Single().Item)) throw new LootMaterialisationException("INVALID_RESULT_KEY", "A result key did not resolve to exactly one item.");
+					}
+					PreflightDestinations(items, keyed, destination);
+				},
+				items =>
+				{
+					foreach (var pair in items.Where(x => x.Leaf.DestinationKey != "target"))
+					{
+						var target = keyed[pair.Leaf.DestinationKey];
+						target.GetItemType<IContainer>().Put(null, pair.Item, allowMerge: false);
+						if (!ReferenceEquals(pair.Item.ContainedIn, target)) throw new LootMaterialisationException("PLACEMENT_FAILED", "A planned item was not inserted into its local container.");
+					}
+					foreach (var item in items.Where(x => x.Leaf.DestinationKey == "target").Select(x => x.Item)) PlaceRoot(destination, item);
+					foreach (var item in items.Select(x => x.Item))
+					{
+						_gameworld.Add(item);
+						item.HandleEvent(EventType.ItemFinishedLoading, item);
+						item.Login();
+					}
+				},
+				items => Cleanup(items.Select(x => x.Item)));
+			created.AddRange(plannedItems.Select(x => x.Item));
+			var roots = plannedItems.Where(x => x.Leaf.DestinationKey == "target").Select(x => x.Item).ToList();
+			var rootIds = string.Join(',', roots.Select(x => x.Id));
+			return new LootMaterialisationResult(true,
+				$"OK table={table.Id}r{table.RevisionNumber} hash={table.DefinitionHash} algorithm={table.AlgorithmVersion} variant={variant} seed={seed} roots={rootIds} created={created.Count} digest={plan.Digest}", plan);
+		}
+		catch (LootMaterialisationException ex)
+		{
+			return Error(ex.Code, ex.Message);
+		}
+		catch (Exception ex)
+		{
+			return Error("MATERIALISATION_FAILED", ex.Message);
+		}
+	}
+
+	private IEnumerable<IGameItem> CreateLeaf(LootPlannedLeaf leaf)
+	{
+		if (leaf.Kind == LootChoiceKind.Commodity)
+		{
+			var material = _gameworld.Materials.Get(leaf.CommodityMaterialId) ?? throw new LootMaterialisationException("MATERIAL_NOT_FOUND", "A planned material no longer exists.");
+			var tag = leaf.CommodityTagId is null ? null : _gameworld.Tags.Get(leaf.CommodityTagId.Value) ?? throw new LootMaterialisationException("TAG_NOT_FOUND", "A planned commodity tag no longer exists.");
+			return [CommodityGameItemComponentProto.CreateNewCommodity(material, leaf.Mass, tag)];
+		}
+
+		var proto = _gameworld.ItemProtos.Get(leaf.ItemPrototypeId, leaf.ItemPrototypeRevision) ?? throw new LootMaterialisationException("PROTOTYPE_NOT_FOUND", "A planned exact item prototype no longer exists.");
+		if (proto.Components.Any(x => x.PreventManualLoad)) throw new LootMaterialisationException("PROTOTYPE_NOT_LOADABLE", "A planned item prototype prevents loading.");
+		var variables = leaf.Characteristics.Select(x =>
+		{
+			var definition = _gameworld.Characteristics.Get(x.DefinitionId) ?? throw new LootMaterialisationException("CHARACTERISTIC_NOT_FOUND", "A planned characteristic definition no longer exists.");
+			var value = _gameworld.CharacteristicValues.Get(x.ValueId) ?? throw new LootMaterialisationException("CHARACTERISTIC_VALUE_NOT_FOUND", "A planned characteristic value no longer exists.");
+			if (value.Definition.Id != definition.Id) throw new LootMaterialisationException("CHARACTERISTIC_MISMATCH", "A planned characteristic value does not belong to its definition.");
+			return (definition, value);
+		}).ToList();
+		var items = proto.CreateNew(null!, null!, leaf.Quantity, variables).ToList();
+		foreach (var item in items) item.Quality = (ItemQuality)leaf.Quality;
+		return items;
+	}
+
+	private static void PreflightDestinations(IEnumerable<(LootPlannedLeaf Leaf, IGameItem Item)> items, IReadOnlyDictionary<string, IGameItem> keyed, Destination root)
+	{
+		if (root.Item is not null && root.Item.GetItemType<IContainer>() is null) throw new LootMaterialisationException("TARGET_NOT_CONTAINER", "The target item is not a container.");
+		foreach (var pair in items)
+		{
+			if (pair.Leaf.DestinationKey == "target")
+			{
+				if (root.Item is not null && !root.Item.GetItemType<IContainer>().CanPut(pair.Item)) throw new LootMaterialisationException("TARGET_REJECTED_ITEM", "The target container rejected a planned item.");
+				if (root.Character is not null && !root.Character.Body.CanGet(pair.Item, 0)) throw new LootMaterialisationException("TARGET_REJECTED_ITEM", "The target character cannot receive a planned item.");
+				continue;
+			}
+			if (!keyed.TryGetValue(pair.Leaf.DestinationKey, out var destination)) throw new LootMaterialisationException("DESTINATION_NOT_FOUND", "A planned local destination was not created.");
+			var container = destination.GetItemType<IContainer>() ?? throw new LootMaterialisationException("DESTINATION_NOT_CONTAINER", "A planned local destination is not a container.");
+			if (!container.CanPut(pair.Item)) throw new LootMaterialisationException("DESTINATION_REJECTED_ITEM", "A planned local container rejected an item.");
+		}
+	}
+
+	private static void PlaceRoot(Destination target, IGameItem item)
+	{
+		if (target.Cell is not null)
+		{
+			target.Cell.Insert(item, newStack: true);
+			if (!ReferenceEquals(item.Location, target.Cell)) throw new LootMaterialisationException("PLACEMENT_FAILED", "A planned item was not inserted into the target location.");
+		}
+		else if (target.Item is not null)
+		{
+			target.Item.GetItemType<IContainer>().Put(null, item, allowMerge: false);
+			if (!ReferenceEquals(item.ContainedIn, target.Item)) throw new LootMaterialisationException("PLACEMENT_FAILED", "A planned item was not inserted into the target container.");
+		}
+		else if (target.Character is not null)
+		{
+			if (target.Character.Body.GetWithoutMerge(item, silent: true) is null) throw new LootMaterialisationException("PLACEMENT_FAILED", "A planned item was not inserted into the target inventory.");
+		}
+		else throw new LootMaterialisationException("NULL_TARGET", "The materialisation target was null.");
+	}
+
+	private static void Cleanup(IEnumerable<IGameItem> items)
+	{
+		foreach (var item in items.Reverse().Where(x => !x.Deleted)) item.Delete();
+	}
+
+	private LootTablePlanner Planner() => new((id, revision) =>
+	{
+		var nested = _gameworld.LootTables.Get(id, revision);
+		return nested is null ? null : Source(nested);
+	});
+
+	private static LootTablePlanSource Source(ILootTable table) => new(table.Id, table.RevisionNumber, table.DefinitionHash, table.Definition);
+	private static LootMaterialisationResult Error(string code, string message) => new(false, $"ERROR code={code} message={message}");
+	private sealed record Destination(ICell? Cell, IGameItem? Item, ICharacter? Character);
+	private sealed class LootMaterialisationException(string code, string message) : Exception(message) { public string Code { get; } = code; }
+}

--- a/MudSharpCore/Work/Loot/LootTableMaterialiser.cs
+++ b/MudSharpCore/Work/Loot/LootTableMaterialiser.cs
@@ -66,6 +66,10 @@ public sealed class LootTableMaterialiser
 						if (!ReferenceEquals(pair.Item.ContainedIn, target)) throw new LootMaterialisationException("PLACEMENT_FAILED", "A planned item was not inserted into its local container.");
 					}
 					foreach (var item in items.Where(x => x.Leaf.DestinationKey == "target").Select(x => x.Item)) PlaceRoot(destination, item);
+					foreach (var pair in items.Where(x => x.Leaf.Kind == LootChoiceKind.Item))
+					{
+						ApplyInitialState(pair.Item, pair.Leaf.StartsClosed, pair.Leaf.StartsLocked);
+					}
 					foreach (var item in items.Select(x => x.Item))
 					{
 						_gameworld.Add(item);
@@ -111,6 +115,35 @@ public sealed class LootTableMaterialiser
 		var items = proto.CreateNew(null!, null!, leaf.Quantity, variables).ToList();
 		foreach (var item in items) item.Quality = (ItemQuality)leaf.Quality;
 		return items;
+	}
+
+	public static void ApplyInitialState(IGameItem item, bool startsClosed, bool startsLocked)
+	{
+		if (startsClosed)
+		{
+			var openable = item.GetItemType<IOpenable>() ??
+			               throw new LootMaterialisationException("ITEM_NOT_OPENABLE", "A planned item cannot start closed because it is not openable.");
+			if (openable.IsOpen)
+			{
+				openable.Close();
+			}
+			if (openable.IsOpen)
+			{
+				throw new LootMaterialisationException("ITEM_STATE_FAILED", "A planned item could not be closed.");
+			}
+		}
+
+		if (!startsLocked)
+		{
+			return;
+		}
+
+		var lockComponent = item.GetItemType<ILock>() ??
+		                    throw new LootMaterialisationException("ITEM_NOT_LOCKABLE", "A planned item cannot start locked because it has no built-in lock.");
+		if (!lockComponent.SetLocked(true, false) || !lockComponent.IsLocked)
+		{
+			throw new LootMaterialisationException("ITEM_STATE_FAILED", "A planned item could not be locked.");
+		}
 	}
 
 	private static void PreflightDestinations(IEnumerable<(LootPlannedLeaf Leaf, IGameItem Item)> items, IReadOnlyDictionary<string, IGameItem> keyed, Destination root)

--- a/MudSharpCore/Work/Loot/LootTableMaterialiser.cs
+++ b/MudSharpCore/Work/Loot/LootTableMaterialiser.cs
@@ -43,7 +43,7 @@ public sealed class LootTableMaterialiser
 		var plan = planned.Plan!;
 		var created = new List<IGameItem>();
 		IReadOnlyList<(LootPlannedLeaf Leaf, IGameItem Item)> plannedItems = [];
-		var keyed = new Dictionary<string, IGameItem>(StringComparer.Ordinal);
+		var keyed = new Dictionary<string, IGameItem>(StringComparer.OrdinalIgnoreCase);
 		try
 		{
 			plannedItems = LootAtomicBatch.Execute<LootPlannedLeaf, (LootPlannedLeaf Leaf, IGameItem Item)>(
@@ -112,7 +112,16 @@ public sealed class LootTableMaterialiser
 			if (value.Definition.Id != definition.Id) throw new LootMaterialisationException("CHARACTERISTIC_MISMATCH", "A planned characteristic value does not belong to its definition.");
 			return (definition, value);
 		}).ToList();
-		var items = proto.CreateNew(null!, null!, leaf.Quantity, variables).ToList();
+		var items = new List<IGameItem>();
+		var quantityPerCreation = proto.IsItemType<IStackablePrototype>() ? leaf.Quantity : 1;
+		for (var remaining = leaf.Quantity; remaining > 0; remaining -= quantityPerCreation)
+		{
+			items.AddRange(proto.CreateNew(null!, null!, quantityPerCreation, variables));
+		}
+		if (items.Count == 0)
+		{
+			throw new LootMaterialisationException("PROTOTYPE_CREATE_FAILED", "A planned item prototype did not create an item.");
+		}
 		foreach (var item in items) item.Quality = (ItemQuality)leaf.Quality;
 		return items;
 	}
@@ -184,7 +193,17 @@ public sealed class LootTableMaterialiser
 
 	private static void Cleanup(IEnumerable<IGameItem> items)
 	{
-		foreach (var item in items.Reverse().Where(x => !x.Deleted)) item.Delete();
+		foreach (var item in items.Reverse().Where(x => !x.Deleted))
+		{
+			try
+			{
+				item.Delete();
+			}
+			catch
+			{
+				// Preserve the original materialisation failure while attempting every remaining cleanup.
+			}
+		}
 	}
 
 	private LootTablePlanner Planner() => new((id, revision) =>

--- a/MudSharpCore/Work/Loot/LootTableValidator.cs
+++ b/MudSharpCore/Work/Loot/LootTableValidator.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.GameItems.Prototypes;
+
+namespace MudSharp.Work.Loot;
+
+public static class LootTableValidator
+{
+	public static IReadOnlyList<string> Validate(ILootTable table, IFuturemud gameworld)
+	{
+		var errors = new List<string>();
+		var definition = table.Definition;
+		if (definition.AlgorithmVersion != LootTableDefinition.CurrentAlgorithmVersion) errors.Add("The deterministic algorithm version is unsupported.");
+		if (definition.Variants.Count == 0) errors.Add("At least one variant is required.");
+		foreach (var duplicate in definition.Variants.GroupBy(x => x.Key, StringComparer.OrdinalIgnoreCase).Where(x => x.Count() > 1)) errors.Add($"Variant key '{duplicate.Key}' is duplicated.");
+		foreach (var variant in definition.Variants)
+		{
+			if (string.IsNullOrWhiteSpace(variant.Key)) errors.Add("Variant keys cannot be empty.");
+			if (variant.Groups.Count == 0) errors.Add($"Variant '{variant.Key}' has no groups.");
+			var availableKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "target" };
+			foreach (var group in variant.Groups)
+			{
+				var path = $"{variant.Key}/{group.Key}";
+					if (string.IsNullOrWhiteSpace(group.Key)) errors.Add($"{path}: group key is empty.");
+				if (group.RepeatMinimum < 0 || group.RepeatMaximum < group.RepeatMinimum) errors.Add($"{path}: repetition range is invalid.");
+				if (!availableKeys.Contains(group.DestinationKey)) errors.Add($"{path}: destination '{group.DestinationKey}' is not an earlier stable item key.");
+				if (group.Choices.Count == 0) errors.Add($"{path}: group has no choices.");
+				foreach (var duplicate in group.Choices.GroupBy(x => x.Key, StringComparer.OrdinalIgnoreCase).Where(x => x.Count() > 1)) errors.Add($"{path}: choice key '{duplicate.Key}' is duplicated.");
+				foreach (var choice in group.Choices)
+				{
+					var choicePath = $"{path}/{choice.Key}";
+					if (string.IsNullOrWhiteSpace(choice.Key)) errors.Add($"{choicePath}: choice key is empty.");
+					if (choice.Weight <= 0) errors.Add($"{choicePath}: weight must be positive.");
+					switch (choice.Kind)
+					{
+						case LootChoiceKind.Item:
+							var proto = gameworld.ItemProtos.Get(choice.ItemPrototypeId, choice.ItemPrototypeRevision);
+							if (proto is null) errors.Add($"{choicePath}: exact item prototype does not exist.");
+							else if (proto.Status != RevisionStatus.Current) errors.Add($"{choicePath}: exact item prototype is not approved/current.");
+							if (choice.QuantityMinimum < 1 || choice.QuantityMaximum < choice.QuantityMinimum) errors.Add($"{choicePath}: quantity range is invalid.");
+							if (choice.QualityMinimum < 0 || choice.QualityMaximum > 11 || choice.QualityMaximum < choice.QualityMinimum) errors.Add($"{choicePath}: quality range is invalid.");
+							foreach (var value in choice.Characteristics)
+							{
+								var definitionValue = gameworld.Characteristics.Get(value.DefinitionId);
+								var characteristicValue = gameworld.CharacteristicValues.Get(value.ValueId);
+								if (definitionValue is null || characteristicValue is null || characteristicValue.Definition.Id != definitionValue.Id) errors.Add($"{choicePath}: characteristic #{value.DefinitionId}=#{value.ValueId} is invalid.");
+							}
+							foreach (var duplicate in choice.Characteristics.GroupBy(x => x.DefinitionId).Where(x => x.Count() > 1)) errors.Add($"{choicePath}: characteristic definition #{duplicate.Key} is assigned more than once.");
+							break;
+						case LootChoiceKind.Commodity:
+							if (gameworld.Materials.Get(choice.CommodityMaterialId) is null) errors.Add($"{choicePath}: material does not exist.");
+							if (choice.CommodityTagId is not null && gameworld.Tags.Get(choice.CommodityTagId.Value) is null) errors.Add($"{choicePath}: tag does not exist.");
+							if (!double.IsFinite(choice.MassMinimum) || !double.IsFinite(choice.MassMaximum) || choice.MassMinimum <= 0.0 || choice.MassMaximum < choice.MassMinimum) errors.Add($"{choicePath}: mass range is invalid.");
+							break;
+						case LootChoiceKind.LootTable:
+							var nested = gameworld.LootTables.Get(choice.NestedTableId, choice.NestedTableRevision);
+							if (nested is null) errors.Add($"{choicePath}: exact nested table does not exist.");
+							else if (nested.Status != RevisionStatus.Current && nested.Id != table.Id) errors.Add($"{choicePath}: exact nested table is not approved/current.");
+							else if (!nested.Definition.Variants.Any(x => x.Key.EqualTo(choice.NestedVariant))) errors.Add($"{choicePath}: nested variant does not exist.");
+							break;
+					}
+				}
+				var stableKeys = group.Choices.Where(x => x.Kind == LootChoiceKind.Item && !string.IsNullOrWhiteSpace(x.ResultKey)).Select(x => x.ResultKey!).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+				foreach (var key in stableKeys)
+				{
+					var producers = group.Choices.Where(x => x.ResultKey.EqualTo(key)).ToList();
+					if (group.RepeatMinimum == 1 && group.RepeatMaximum == 1 && producers.Count == group.Choices.Count && producers.All(x =>
+					    x.QuantityMinimum == 1 && x.QuantityMaximum == 1 &&
+					    gameworld.ItemProtos.Get(x.ItemPrototypeId, x.ItemPrototypeRevision)?.Components.Any(y => y is IContainerPrototype) == true)) availableKeys.Add(key);
+					else errors.Add($"{path}: result key '{key}' is not produced exactly once on every selectable path.");
+				}
+			}
+		}
+
+		var planner = new LootTablePlanner((id, revision) =>
+		{
+			var nested = gameworld.LootTables.Get(id, revision);
+			return nested is null ? null : new LootTablePlanSource(nested.Id, nested.RevisionNumber, nested.DefinitionHash, nested.Definition);
+		});
+		foreach (var variant in definition.Variants)
+		{
+			var plan = planner.CreatePlan(new LootTablePlanSource(table.Id, table.RevisionNumber, table.DefinitionHash, table.Definition), variant.Key, 0);
+			if (!plan.Success && plan.ErrorCode is "CYCLE" or "EXPANSION_LIMIT") errors.Add($"Nesting validation failed for '{variant.Key}': {plan.ErrorCode} {plan.ErrorMessage}");
+		}
+		return errors.Distinct().ToList();
+	}
+}

--- a/MudSharpCore/Work/Loot/LootTableValidator.cs
+++ b/MudSharpCore/Work/Loot/LootTableValidator.cs
@@ -66,6 +66,9 @@ public static class LootTableValidator
 							else if (nested.Status != RevisionStatus.Current && nested.Id != table.Id) errors.Add($"{choicePath}: exact nested table is not approved/current.");
 							else if (!nested.Definition.Variants.Any(x => x.Key.EqualTo(choice.NestedVariant))) errors.Add($"{choicePath}: nested variant does not exist.");
 							break;
+						default:
+							errors.Add($"{choicePath}: choice kind is invalid.");
+							break;
 					}
 				}
 				var stableKeys = group.Choices.Where(x => x.Kind == LootChoiceKind.Item && !string.IsNullOrWhiteSpace(x.ResultKey)).Select(x => x.ResultKey!).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
@@ -80,16 +83,106 @@ public static class LootTableValidator
 			}
 		}
 
-		var planner = new LootTablePlanner((id, revision) =>
-		{
-			var nested = gameworld.LootTables.Get(id, revision);
-			return nested is null ? null : new LootTablePlanSource(nested.Id, nested.RevisionNumber, nested.DefinitionHash, nested.Definition);
-		});
-		foreach (var variant in definition.Variants)
-		{
-			var plan = planner.CreatePlan(new LootTablePlanSource(table.Id, table.RevisionNumber, table.DefinitionHash, table.Definition), variant.Key, 0);
-			if (!plan.Success && plan.ErrorCode is "CYCLE" or "EXPANSION_LIMIT") errors.Add($"Nesting validation failed for '{variant.Key}': {plan.ErrorCode} {plan.ErrorMessage}");
-		}
+		ValidateEveryNestingPath(table, gameworld, errors);
 		return errors.Distinct().ToList();
 	}
+
+	private static void ValidateEveryNestingPath(ILootTable root, IFuturemud gameworld, ICollection<string> errors)
+	{
+		foreach (var variant in root.Definition.Variants)
+		{
+			var maximum = MaximumGeneratedItems(root, variant.Key, gameworld, new HashSet<NestingIdentity>(),
+				errors, $"{root.Id}r{root.RevisionNumber}/{variant.Key}");
+			if (maximum > LootTablePlanner.MaximumPlannedItems)
+			{
+				errors.Add($"Nesting validation failed for '{variant.Key}': the maximum expansion exceeds {LootTablePlanner.MaximumPlannedItems:N0} generated items.");
+			}
+		}
+	}
+
+	private static long MaximumGeneratedItems(ILootTable table, string variantKey, IFuturemud gameworld,
+		ISet<NestingIdentity> ancestry, ICollection<string> errors, string path)
+	{
+		var variant = table.Definition.Variants.SingleOrDefault(x => x.Key.EqualTo(variantKey));
+		if (variant is null)
+		{
+			return 0;
+		}
+
+		var identity = new NestingIdentity(table.Id, table.RevisionNumber, variant.Key);
+		if (!ancestry.Add(identity))
+		{
+			errors.Add($"Nesting validation failed at '{path}': a nested LootTable cycle was encountered.");
+			return 0;
+		}
+
+		try
+		{
+			long total = 0;
+			foreach (var group in variant.Groups)
+			{
+				long maximumChoice = 0;
+				foreach (var choice in group.Choices)
+				{
+					var choicePath = $"{path}/{group.Key}/{choice.Key}";
+					var generatedItems = choice.Kind switch
+					{
+						LootChoiceKind.Item => Math.Max(0, choice.QuantityMaximum),
+						LootChoiceKind.Commodity => 1,
+						LootChoiceKind.LootTable => MaximumNestedGeneratedItems(choice, gameworld, ancestry, errors,
+							choicePath),
+						_ => 0
+					};
+					maximumChoice = Math.Max(maximumChoice, generatedItems);
+				}
+
+				total = AddCapped(total, MultiplyCapped(Math.Max(0, group.RepeatMaximum), maximumChoice));
+				if (total > LootTablePlanner.MaximumPlannedItems)
+				{
+					return total;
+				}
+			}
+
+			return total;
+		}
+		finally
+		{
+			ancestry.Remove(identity);
+		}
+	}
+
+	private static long MaximumNestedGeneratedItems(LootChoiceDefinition choice, IFuturemud gameworld,
+		ISet<NestingIdentity> ancestry, ICollection<string> errors, string path)
+	{
+		var nested = gameworld.LootTables.Get(choice.NestedTableId, choice.NestedTableRevision);
+		return nested is null
+			? 0
+			: MaximumGeneratedItems(nested, choice.NestedVariant, gameworld, ancestry, errors, path);
+	}
+
+	private static long AddCapped(long left, long right)
+	{
+		if (left > LootTablePlanner.MaximumPlannedItems || right > LootTablePlanner.MaximumPlannedItems ||
+		    left > LootTablePlanner.MaximumPlannedItems - right)
+		{
+			return LootTablePlanner.MaximumPlannedItems + 1L;
+		}
+
+		return left + right;
+	}
+
+	private static long MultiplyCapped(long left, long right)
+	{
+		if (left == 0 || right == 0)
+		{
+			return 0;
+		}
+
+		return left > LootTablePlanner.MaximumPlannedItems || right > LootTablePlanner.MaximumPlannedItems ||
+		       left > LootTablePlanner.MaximumPlannedItems / right
+			? LootTablePlanner.MaximumPlannedItems + 1L
+			: left * right;
+	}
+
+	private sealed record NestingIdentity(long TableId, int Revision, string Variant);
 }

--- a/MudSharpCore/Work/Loot/LootTableValidator.cs
+++ b/MudSharpCore/Work/Loot/LootTableValidator.cs
@@ -42,6 +42,9 @@ public static class LootTableValidator
 							var proto = gameworld.ItemProtos.Get(choice.ItemPrototypeId, choice.ItemPrototypeRevision);
 							if (proto is null) errors.Add($"{choicePath}: exact item prototype does not exist.");
 							else if (proto.Status != RevisionStatus.Current) errors.Add($"{choicePath}: exact item prototype is not approved/current.");
+							if (choice.StartsClosed && proto?.Components.Any(x => x is IOpenablePrototype) != true) errors.Add($"{choicePath}: a closed item must use an openable prototype.");
+							if (choice.StartsLocked && !choice.StartsClosed) errors.Add($"{choicePath}: a locked item must also start closed.");
+							if (choice.StartsLocked && proto?.Components.Any(x => x is ILockPrototype) != true) errors.Add($"{choicePath}: a locked item must have a built-in lock.");
 							if (choice.QuantityMinimum < 1 || choice.QuantityMaximum < choice.QuantityMinimum) errors.Add($"{choicePath}: quantity range is invalid.");
 							if (choice.QualityMinimum < 0 || choice.QualityMaximum > 11 || choice.QualityMaximum < choice.QualityMinimum) errors.Add($"{choicePath}: quality range is invalid.");
 							foreach (var value in choice.Characteristics)

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContext.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContext.cs
@@ -270,6 +270,7 @@ namespace MudSharp.Database
         public virtual DbSet<ForagableProfilesHourlyYieldGains> ForagableProfilesHourlyYieldGains { get; set; }
         public virtual DbSet<ForagableProfilesMaximumYields> ForagableProfilesMaximumYields { get; set; }
         public virtual DbSet<Foragable> Foragables { get; set; }
+		public virtual DbSet<LootTable> LootTables { get; set; }
         public virtual DbSet<Models.FutureProg> FutureProgs { get; set; }
         public virtual DbSet<FutureProgsParameter> FutureProgsParameters { get; set; }
         public virtual DbSet<GameItemComponentProto> GameItemComponentProtos { get; set; }

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextShopDeals.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextShopDeals.cs
@@ -24,6 +24,7 @@ namespace MudSharp.Database
 			ConfigureRouteCells(modelBuilder);
 			ConfigureVehicleRoutesAndServices(modelBuilder);
 			ConfigureSeederManagedRecords(modelBuilder);
+			ConfigureLootTables(modelBuilder);
 
 			modelBuilder.Entity<ShopDeal>(entity =>
             {
@@ -103,6 +104,26 @@ namespace MudSharp.Database
                       .HasDefaultValue(0.01m);
             });
         }
+
+		private static void ConfigureLootTables(ModelBuilder modelBuilder)
+		{
+			modelBuilder.Entity<LootTable>(entity =>
+			{
+				entity.ToTable("LootTables");
+				entity.HasKey(e => new { e.Id, e.RevisionNumber }).HasName("PRIMARY");
+				entity.HasIndex(e => e.EditableItemId).HasDatabaseName("FK_LootTables_EditableItems_idx");
+				entity.Property(e => e.Id).HasColumnType("bigint(20)");
+				entity.Property(e => e.RevisionNumber).HasColumnType("int(11)");
+				entity.Property(e => e.EditableItemId).HasColumnType("bigint(20)");
+				entity.Property(e => e.Name).IsRequired().HasColumnType("varchar(200)")
+				      .HasCharSet("utf8mb4").UseCollation("utf8mb4_unicode_ci");
+				entity.Property(e => e.Definition).IsRequired().HasColumnType("mediumtext")
+				      .HasCharSet("utf8mb4").UseCollation("utf8mb4_unicode_ci");
+				entity.Property(e => e.AlgorithmVersion).HasColumnType("int(11)");
+				entity.HasOne(e => e.EditableItem).WithMany(e => e.LootTables)
+				      .HasForeignKey(e => e.EditableItemId).HasConstraintName("FK_LootTables_EditableItems");
+			});
+		}
 
 		private static void ConfigureOutfitTemplates(ModelBuilder modelBuilder)
 		{

--- a/MudsharpDatabaseLibrary/Migrations/20260816094719_AddLootTables.Designer.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260816094719_AddLootTables.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MudSharp.Database;
 
@@ -11,9 +12,11 @@ using MudSharp.Database;
 namespace MudSharp.Migrations
 {
     [DbContext(typeof(FuturemudDatabaseContext))]
-    partial class FutureMUDContextModelSnapshot : ModelSnapshot
+    [Migration("20260816094719_AddLootTables")]
+    partial class AddLootTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -13074,11 +13077,6 @@ namespace MudSharp.Migrations
                         .HasColumnType("double")
                         .HasDefaultValue(0.5);
 
-                    b.Property<int>("ConsentPolicy")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int(11)")
-                        .HasDefaultValue(0);
-
                     b.Property<string>("Description")
                         .IsRequired()
                         .HasColumnType("mediumtext")
@@ -21422,40 +21420,6 @@ namespace MudSharp.Migrations
                         .HasDatabaseName("FK_TraitExpressionParameters_TraitExpression");
 
                     b.ToTable("TraitExpressionParameters");
-                });
-
-            modelBuilder.Entity("MudSharp.Models.TrapTemplate", b =>
-                {
-                    b.Property<long>("Id")
-                        .HasColumnType("bigint(20)");
-
-                    b.Property<int>("RevisionNumber")
-                        .HasColumnType("int(11)");
-
-                    b.Property<string>("Definition")
-                        .IsRequired()
-                        .HasColumnType("mediumtext")
-                        .UseCollation("utf8mb4_unicode_ci");
-
-                    MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Definition"), "utf8mb4");
-
-                    b.Property<long>("EditableItemId")
-                        .HasColumnType("bigint(20)");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasColumnType("varchar(200)")
-                        .UseCollation("utf8mb4_unicode_ci");
-
-                    MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Name"), "utf8mb4");
-
-                    b.HasKey("Id", "RevisionNumber")
-                        .HasName("PRIMARY");
-
-                    b.HasIndex("EditableItemId")
-                        .HasDatabaseName("FK_TrapTemplates_EditableItems_idx");
-
-                    b.ToTable("TrapTemplates");
                 });
 
             modelBuilder.Entity("MudSharp.Models.UnitOfMeasure", b =>
@@ -33795,18 +33759,6 @@ namespace MudSharp.Migrations
                     b.Navigation("TraitExpression");
                 });
 
-            modelBuilder.Entity("MudSharp.Models.TrapTemplate", b =>
-                {
-                    b.HasOne("MudSharp.Models.EditableItem", "EditableItem")
-                        .WithMany("TrapTemplates")
-                        .HasForeignKey("EditableItemId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("FK_TrapTemplates_EditableItems");
-
-                    b.Navigation("EditableItem");
-                });
-
             modelBuilder.Entity("MudSharp.Models.Vehicle", b =>
                 {
                     b.HasOne("MudSharp.Models.VehiclePropulsionProfileProto", "ActivePropulsionProfileProto")
@@ -36092,8 +36044,6 @@ namespace MudSharp.Migrations
                     b.Navigation("Npctemplates");
 
                     b.Navigation("Projects");
-
-                    b.Navigation("TrapTemplates");
                 });
 
             modelBuilder.Entity("MudSharp.Models.Election", b =>

--- a/MudsharpDatabaseLibrary/Migrations/20260816094719_AddLootTables.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260816094719_AddLootTables.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MudSharp.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLootTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "LootTables",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint(20)", nullable: false),
+                    RevisionNumber = table.Column<int>(type: "int(11)", nullable: false),
+                    EditableItemId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    Name = table.Column<string>(type: "varchar(200)", nullable: false, collation: "utf8mb4_unicode_ci")
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Definition = table.Column<string>(type: "mediumtext", nullable: false, collation: "utf8mb4_unicode_ci")
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    AlgorithmVersion = table.Column<int>(type: "int(11)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PRIMARY", x => new { x.Id, x.RevisionNumber });
+                    table.ForeignKey(
+                        name: "FK_LootTables_EditableItems",
+                        column: x => x.EditableItemId,
+                        principalTable: "EditableItems",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_LootTables_EditableItems_idx",
+                table: "LootTables",
+                column: "EditableItemId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LootTables");
+        }
+    }
+}

--- a/MudsharpDatabaseLibrary/Models/EditableItem.cs
+++ b/MudsharpDatabaseLibrary/Models/EditableItem.cs
@@ -14,6 +14,7 @@ namespace MudSharp.Models
             Foragables = new HashSet<Foragable>();
             GameItemComponentProtos = new HashSet<GameItemComponentProto>();
             GameItemProtos = new HashSet<GameItemProto>();
+			LootTables = new HashSet<LootTable>();
             Npctemplates = new HashSet<NpcTemplate>();
             Projects = new HashSet<Project>();
             TrapTemplates = new HashSet<TrapTemplate>();
@@ -37,6 +38,7 @@ namespace MudSharp.Models
         public virtual ICollection<Foragable> Foragables { get; set; }
         public virtual ICollection<GameItemComponentProto> GameItemComponentProtos { get; set; }
         public virtual ICollection<GameItemProto> GameItemProtos { get; set; }
+		public virtual ICollection<LootTable> LootTables { get; set; }
         public virtual ICollection<NpcTemplate> Npctemplates { get; set; }
         public virtual ICollection<Project> Projects { get; set; }
         public virtual ICollection<TrapTemplate> TrapTemplates { get; set; }

--- a/MudsharpDatabaseLibrary/Models/LootTable.cs
+++ b/MudsharpDatabaseLibrary/Models/LootTable.cs
@@ -1,0 +1,13 @@
+namespace MudSharp.Models;
+
+public class LootTable
+{
+	public long Id { get; set; }
+	public int RevisionNumber { get; set; }
+	public long EditableItemId { get; set; }
+	public string Name { get; set; }
+	public string Definition { get; set; }
+	public int AlgorithmVersion { get; set; }
+
+	public virtual EditableItem EditableItem { get; set; }
+}


### PR DESCRIPTION
## What changed

- adds revisioned, builder-authored loot tables with deterministic nested planning and atomic materialisation
- adds seeded and unseeded `loadloottable` FutureProg overloads for location, container item, and character inventory destinations
- integrates builder editing, review acceptance, help, display, registry, load, save, copy, and validation paths
- supports optional initial closed and locked state for generated containers
- adds the exact `20260816094719_AddLootTables` schema migration and model bindings

## Why

Loot generation needs a reusable editable definition that can plan complete nested output deterministically and either materialise the whole result or fail without leaving partial items behind. The implementation keeps planning separate from placement and exposes the same six typed destination/seed variants through FutureProg.

## Validation

- `LootTableDefinitionTests`: 20/20 passed
- complete `MudSharpCore Unit Tests`: 2,361/2,361 passed on the final head
  - 2,339 tests ran together
  - 20 safe `ForagingRuntimeTests` ran separately
  - 2 foraging rows using the existing uninitialized-`Futuremud` fixture ran in their own host to avoid that fixture's finalizer crash
- EF `migrations has-pending-model-changes`: passed
- generated an idempotent migration script for the exact `20260816012516_HospitalServiceConsentPolicy` to `20260816094719_AddLootTables` boundary without applying it
- `git diff --check`: passed

## Reconciliation and patch identity

The branch is based on current `origin/master`. Current upstream added TrapTemplate registry, loader, and review paths adjacent to the accepted LootTable changes. Those additive paths are preserved alongside LootTables. The last four accepted commits retain exact stable patch IDs; the first two have reconciled patch IDs because their shared registry/review context now includes the upstream TrapTemplate additions. `git range-diff` confirms the LootTable contract remains unchanged, and the branch contains only the six publication commits above the fresh upstream base.

## Contract and migration

Final-head coverage closes registry and builder provisioning; revision creation, save, load, copy, review, and first-consumer paths; all six advertised destination/seed variants; exact nested references; declared semantic ordering and canonical digest/XML; and atomic failure behavior. Spatial topology beyond the three declared destinations is not advertised. The migration identifier is unique on current upstream, the final model snapshot contains both upstream TrapTemplates and LootTables, and no game-specific numeric IDs, content bindings, or local data migration are introduced.
