### PR TITLE
Version update to 2.6.0

### DIFF
--- a/FutureMUD.Web/Content/PatchNotes/2026-08-18-engine-2-6-0.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-08-18-engine-2-6-0.md
@@ -1,0 +1,41 @@
+---
+title: FutureMUD Engine 2.6.0
+summary: Adds configurable traps, atomic loot tables and ordinary-item salvage, with faster FutureProg execution and runtime improvements.
+date: 2026-08-18
+tags: engine, release, upgrade, builders, performance
+---
+**Upgrade note:** Apply the normal database upgrades before starting Engine 2.6.0. This release keeps the .NET 10 and MySQL 8.0 requirements and the Windows x64, Linux x64 and Linux ARM64 package set.
+
+## Traps And Explosive Triggers
+
+Engine 2.6.0 introduces a complete, revisioned trap system for mechanical, magical and natural hazards. Templates can combine triggers and ordered payloads, with configurable detection, avoidance, disarming, charges, cooldowns and lifecycle. They can be anchored to items, cells, characters or a particular side of an exit, and support damage, gas, liquid, restraint, spell, FutureProg, signal and detonation outcomes.
+
+Builders begin with `traptemplate` (also `trapt` or `tt`) to create and review template revisions. Its `set trigger`, `set payload` and `component add` controls describe the permitted settings and physical component requirements as they are authored. Players and builders can discover and operate deployed traps through `trap types`, `trap inspect`, `trap lay`, `trap disarm` and `trap recover`; `help trap` and `help traptemplate` cover the complete workflow.
+
+The item-component workflow now also includes countdown, clock, pin-pull, radio and signal detonators. These can be configured as ordinary explosive items or used by mechanical trap templates, supporting everything from a physical tripwire to an automation-driven device without special-case item types.
+
+## Loot Tables And Salvage
+
+Added revisioned, atomic loot tables. Builders use `loottable` (or `lt`) to author ordered weighted groups of item, commodity, nested-table and empty choices. `loottable validate` checks the complete package, `loottable preview` shows a deterministic result without creating it, and the administrator `loottable load` path exercises it in the world. FutureProg authors can create an exact table revision through `loadloottable` and receive a stable success or failure receipt.
+
+Ordinary item prototypes can now receive the revisioned `Salvageable` component through the normal `item component` workflow. Its builder controls define the check, optional tool tag, staged emotes and explicit commodity or item products; players then use `salvage <item>` to dismantle the authored item. This provides a safe, general salvage path for wrecks, parts and other non-organic objects without treating them as corpses.
+
+## Scripting, Operations And Game Workflows
+
+FutureProg now has structured noise support: use `emitnoise` to control propagation and presentation, and `canhearnoise` to test whether a particular character should hear it. This makes it possible to write world scripts with more deliberate audible range and receiver-aware outcomes.
+
+Operators using a Web MUD Client proxy can now declare the exact trusted proxy addresses on the optional third line of `Connection.config`. The Engine applies the resulting client address consistently to site bans, duplicate-registration checks and flood protection. Hospital implant services now include an explicit patient-consent step, while crafting and foraging retain the exact inputs and yields their authored workflows require.
+
+## Performance
+
+- FutureProg execution now allocates less and runs faster for parameter binding, branching, loops, collection and dictionary work, type operations and fully-static results. Existing script syntax and semantics are preserved.
+- Bank-account transaction histories are demand-loaded and processed in bounded idle-time batches instead of requiring an ever-growing history to be loaded at once.
+- Noise and proximity delivery, recurring fire processing and hook dispatch have tighter bounds, reducing unnecessary work and preventing one high-frequency source from degrading the rest of the game loop.
+
+## Reliability And Presentation
+
+- Improved the resilience of physical item interaction, combat target selection, crawling and clinch transitions, while keeping established gameplay rules intact.
+- Improved visible game output and command help in a number of edge cases, including liquid descriptions, prepared-food doses, alerts, board output and closed transparent containers.
+- Strengthened connection shutdown and proxy identity handling so normal client disconnects and remote-address reporting remain reliable under load.
+
+Use [/downloads](/downloads) for the release archives and checksums, [/getting-started](/getting-started) for installation requirements, and [/docs/commands](/docs/commands) for the published Engine reference.

--- a/MudSharpCore Unit Tests/LootTableDefinitionTests.cs
+++ b/MudSharpCore Unit Tests/LootTableDefinitionTests.cs
@@ -487,7 +487,7 @@ public class LootTableDefinitionTests
 			StringAssert.Contains(shown, heading);
 		StringAssert.Contains(shown, "1. selection");
 		StringAssert.Contains(shown, "Outer target");
-		StringAssert.Contains(shown, "3 (100.00%)");
+		StringAssert.Contains(shown, $"{3:N0} ({1.0:P2})");
 		StringAssert.Contains(shown, "Nothing");
 	}
 

--- a/MudSharpCore/MudSharpCore.csproj
+++ b/MudSharpCore/MudSharpCore.csproj
@@ -10,9 +10,9 @@
 	<Product>FutureMUD</Product>
 	<ApplicationIcon>FM Logo.ico</ApplicationIcon>
 	<AssemblyName>MudSharp</AssemblyName>
-	<Version>2.5.0</Version>
-	<AssemblyVersion>2.5.0</AssemblyVersion>
-	<FileVersion>2.5.0</FileVersion>
+	<Version>2.6.0</Version>
+	<AssemblyVersion>2.6.0</AssemblyVersion>
+	<FileVersion>2.6.0</FileVersion>
   </PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
## Summary
- Align the MudSharpCore Version, AssemblyVersion and FileVersion at 2.6.0.
- Add the public Engine 2.6.0 patch note, grouped around traps and explosives, loot and salvage, scripting, operations and performance.

## Validation
- `dotnet test "MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj" -c Release --no-restore -m:1 -p:NuGetAudit=false -p:NoWarn=NU1902%3BNU1510` (2,390 passed)
- `dotnet test "FutureMUD.Web.Tests/FutureMUD.Web.Tests.csproj" -c Release --no-restore -m:1 -p:NuGetAudit=false -p:NoWarn=NU1902%3BNU1510` (51 passed)
- Representative win-x64 framework-dependent, single-file, untrimmed package with native-library extraction and embedded symbols.
- Documentation catalogue export with source revision `43397eac280e7173393f359be69a19d1e2349207`; all five metadata families were populated.
- `git diff --check`