### PR TITLE
Harden loot table rollback boundaries

### DIFF
--- a/Design Documents/Features/LootTables.md
+++ b/Design Documents/Features/LootTables.md
@@ -1,6 +1,6 @@
 # Loot Tables
 
-Loot tables let a builder describe a package of generated items and commodities in a form that another human can inspect. The engine plans the whole package first and then creates it atomically: item existence and placement either complete as a package or are rolled back. Prototype on-load scripts are ordinary engine side effects and must be safe to run in this context.
+Loot tables let a builder describe a package of generated items and commodities in a form that another human can inspect. The engine plans, creates and places the whole package before committing it: item existence and placement either complete as a package or are rolled back. Prototype OnLoad scripts and other hooks are not database transactions, so they run only after the package has committed and must be idempotent.
 
 A caller supplies an exact table revision, variant, destination and optional deterministic seed. Tables do not own depletion, one-shot state, Region bindings or gameplay conditions.
 
@@ -88,7 +88,9 @@ loadloottable(Number tableId, Number revision, Character target, Text variant) -
 loadloottable(Number tableId, Number revision, Character target, Text variant, Number seed) -> Text
 ```
 
-Success returns a canonical `OK` receipt with exact revision/hash, algorithm, variant, actual seed, root item IDs, created count and plan digest. Failure returns a stable `ERROR code=...` receipt. Creation is staged, all destinations are preflighted, merging is disabled, and any creation, placement, event or persistence failure attempts to delete every staged object. Item existence and placement are rollback-safe; prototype on-load FutureProg side effects execute during creation and therefore must themselves be safe to run in this context, because arbitrary script side effects cannot be unwound by the loot system.
+Success returns a canonical `OK` receipt with exact revision/hash, algorithm, variant, actual seed, root item IDs, created count and plan digest. Failure before commitment returns a stable `ERROR code=...` receipt. Creation is staged without prototype OnLoad execution, initial item-state validity and all destinations are preflighted, merging is disabled, and any pre-commit creation, placement or persistence failure attempts to delete every staged object.
+
+After every item is physically placed and registered with the game world, the materialiser crosses its commit boundary. It then executes prototype OnLoad progs, `ItemFinishedLoading`, and `Login` for the committed items. These operations can make arbitrary external changes and therefore cannot be rolled back; a post-commit failure is reported to administrators and the successful receipt includes `postcommitwarnings=<count>`, while the completed package remains in the world. Character destinations deliberately do not fire `CharacterGotItem`, `ItemGotten`, inventory-change, or witness hooks: loading a loot package is not a player `get` action, and suppressing those hooks prevents a later staging failure from granting an irreversible reward.
 
 ## Persistence
 

--- a/FutureMUDLibrary/Body/IInventory.cs
+++ b/FutureMUDLibrary/Body/IInventory.cs
@@ -401,8 +401,12 @@ namespace MudSharp.Body
         IGameItem? Get(IGameItem item, int quantity, IEmote? playerEmote, bool silent, ItemCanGetIgnore ignoreFlags,
             IEnumerable<IHandleEvents> witnessHandlers);
 
-		/// <summary>Places a complete item into held inventory without merging it into an existing stack.</summary>
-		IGameItem? GetWithoutMerge(IGameItem item, bool silent = true);
+		/// <summary>
+		/// Places a complete item into held inventory without merging it into an existing stack.
+		/// Set <paramref name="triggerEvents"/> to false only when a caller is staging a larger atomic operation
+		/// and will not represent the insertion as a normal player get.
+		/// </summary>
+		IGameItem? GetWithoutMerge(IGameItem item, bool silent = true, bool triggerEvents = true);
 
         void Get(IGameItem item, IGameItem containerItem, int quantity = 0, IEmote? playerEmote = null, bool silent = false, ItemCanGetIgnore ignoreFlags = ItemCanGetIgnore.None);
 

--- a/FutureMUDLibrary/GameItems/IGameItemProto.cs
+++ b/FutureMUDLibrary/GameItems/IGameItemProto.cs
@@ -58,6 +58,9 @@ namespace MudSharp.GameItems
         IGameItem CreateNew(ICharacter? loader = null);
         IEnumerable<IGameItem> CreateNew(ICharacter loader, IGameItemSkin skin, int quantity, string loadString);
         IEnumerable<IGameItem> CreateNew<T>(ICharacter loader, IGameItemSkin skin, int quantity, T variables) where T : IEnumerable<(ICharacteristicDefinition Definition, ICharacteristicValue Value)>;
+        IEnumerable<IGameItem> CreateNew<T>(ICharacter loader, IGameItemSkin skin, int quantity, T variables,
+            bool executeOnLoadProgs) where T : IEnumerable<(ICharacteristicDefinition Definition, ICharacteristicValue Value)>;
+        void ExecuteOnLoadProgs(IGameItem item, ICharacter? loader);
 
         bool CheckForComponentPrototypeUpdates();
         IGameItemProto Clone(ICharacter builder);

--- a/MudSharpCore Unit Tests/LootTableDefinitionTests.cs
+++ b/MudSharpCore Unit Tests/LootTableDefinitionTests.cs
@@ -8,6 +8,7 @@ using MudSharp.Framework.Revision;
 using MudSharp.Framework.Save;
 using MudSharp.Framework.Units;
 using MudSharp.Character;
+using MudSharp.Construction;
 using MudSharp.Form.Characteristics;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Interfaces;
@@ -646,7 +647,7 @@ public class LootTableDefinitionTests
 		prototype.SetupGet(x => x.Components).Returns(Array.Empty<IGameItemComponentProto>());
 		prototype.Setup(x => x.CreateNew<List<(ICharacteristicDefinition Definition, ICharacteristicValue Value)>>(
 				It.IsAny<ICharacter>(), It.IsAny<IGameItemSkin>(), 1,
-				It.IsAny<List<(ICharacteristicDefinition Definition, ICharacteristicValue Value)>>()))
+				It.IsAny<List<(ICharacteristicDefinition Definition, ICharacteristicValue Value)>>(), false))
 			.Returns([item.Object]);
 		var prototypes = new Mock<IUneditableRevisableAll<IGameItemProto>>();
 		prototypes.Setup(x => x.Get(501, 2)).Returns(prototype.Object);
@@ -663,7 +664,61 @@ public class LootTableDefinitionTests
 		Assert.AreEqual(12, created.Count);
 		prototype.Verify(x => x.CreateNew<List<(ICharacteristicDefinition Definition, ICharacteristicValue Value)>>(
 			It.IsAny<ICharacter>(), It.IsAny<IGameItemSkin>(), 1,
-			It.IsAny<List<(ICharacteristicDefinition Definition, ICharacteristicValue Value)>>()), Times.Exactly(12));
+			It.IsAny<List<(ICharacteristicDefinition Definition, ICharacteristicValue Value)>>(), false), Times.Exactly(12));
+	}
+
+	[TestMethod]
+	public void Materialiser_PostCommitOnLoadFailure_LeavesCommittedPackageAndReportsWarning()
+	{
+		var definition = new LootTableDefinition();
+		var variant = new LootVariantDefinition { Key = "default" };
+		var group = new LootRollGroupDefinition { Key = "root" };
+		group.Choices.Add(new LootChoiceDefinition
+		{
+			Key = "item",
+			Kind = LootChoiceKind.Item,
+			ItemPrototypeId = 501,
+			ItemPrototypeRevision = 2,
+			QuantityMinimum = 1,
+			QuantityMaximum = 1,
+			QualityMinimum = 5,
+			QualityMaximum = 5
+		});
+		variant.Groups.Add(group);
+		definition.Variants.Add(variant);
+		var table = LootTableMock(17, 0, definition);
+		table.SetupGet(x => x.AlgorithmVersion).Returns(LootTableDefinition.CurrentAlgorithmVersion);
+		var cell = new Mock<ICell>();
+		var item = new Mock<IGameItem>();
+		item.SetupGet(x => x.Id).Returns(75L);
+		item.SetupGet(x => x.Deleted).Returns(false);
+		item.SetupGet(x => x.Location).Returns(cell.Object);
+		var committed = false;
+		var prototype = new Mock<IGameItemProto>();
+		prototype.SetupGet(x => x.Components).Returns(Array.Empty<IGameItemComponentProto>());
+		prototype.Setup(x => x.IsItemType<IStackablePrototype>()).Returns(false);
+		prototype.Setup(x => x.CreateNew<List<(ICharacteristicDefinition Definition, ICharacteristicValue Value)>>(
+				It.IsAny<ICharacter>(), It.IsAny<IGameItemSkin>(), 1,
+				It.IsAny<List<(ICharacteristicDefinition Definition, ICharacteristicValue Value)>>(), false))
+			.Returns([item.Object]);
+		prototype.Setup(x => x.ExecuteOnLoadProgs(item.Object, null))
+			.Callback(() => Assert.IsTrue(committed, "OnLoad must execute only after the package commits."))
+			.Throws<InvalidOperationException>();
+		item.SetupGet(x => x.Prototype).Returns(prototype.Object);
+		var prototypes = new Mock<IUneditableRevisableAll<IGameItemProto>>();
+		prototypes.Setup(x => x.Get(501, 2)).Returns(prototype.Object);
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.ItemProtos).Returns(prototypes.Object);
+		gameworld.Setup(x => x.Add(item.Object)).Callback(() => committed = true);
+		var materialiser = new LootTableMaterialiser(gameworld.Object);
+
+		var result = materialiser.Materialise(table.Object, "default", 12, cell.Object);
+
+		Assert.IsTrue(result.Success, result.Receipt);
+		StringAssert.Contains(result.Receipt, "postcommitwarnings=1");
+		prototype.Verify(x => x.ExecuteOnLoadProgs(item.Object, null), Times.Once);
+		gameworld.Verify(x => x.Add(item.Object), Times.Once);
+		item.Verify(x => x.Delete(), Times.Never);
 	}
 
 	private static LootTableDefinition RepresentativeDefinition()

--- a/MudSharpCore/Body/Implementations/BodyInventory.cs
+++ b/MudSharpCore/Body/Implementations/BodyInventory.cs
@@ -1607,13 +1607,14 @@ public partial class Body
 		return GetInternal(item, quantity, playerEmote, silent, ignoreFlags, witnessHandlers, true);
 	}
 
-	public IGameItem? GetWithoutMerge(IGameItem item, bool silent = true)
+	public IGameItem? GetWithoutMerge(IGameItem item, bool silent = true, bool triggerEvents = true)
 	{
-		return GetInternal(item, 0, null, silent, ItemCanGetIgnore.None, null, false);
+		return GetInternal(item, 0, null, silent, ItemCanGetIgnore.None, null, false, triggerEvents);
 	}
 
 	private IGameItem? GetInternal(IGameItem item, int quantity, IEmote? playerEmote, bool silent,
-		ItemCanGetIgnore ignoreFlags, IEnumerable<IHandleEvents> witnessHandlers, bool allowMerge)
+		ItemCanGetIgnore ignoreFlags, IEnumerable<IHandleEvents> witnessHandlers, bool allowMerge,
+		bool triggerEvents = true)
     {
         if (!CanGet(item, quantity, ignoreFlags))
         {
@@ -1697,22 +1698,26 @@ public partial class Body
             OutputHandler.Handle(output);
         }
 
-        OnInventoryChange?.Invoke(InventoryState.Dropped, InventoryState.Held, gottenItem);
-        gottenItem.InvokeInventoryChange(InventoryState.Dropped, InventoryState.Held);
-        // Handle events
-        HandleEvent(EventType.CharacterGotItem, Actor, gottenItem);
-        gottenItem.HandleEvent(EventType.ItemGotten, Actor, gottenItem);
-        foreach (IHandleEvents witness in FilterWitnessHandlers(witnessHandlers, Actor))
+        if (triggerEvents)
         {
-            witness.HandleEvent(EventType.CharacterGotItemWitness, Actor, gottenItem, witness);
+            OnInventoryChange?.Invoke(InventoryState.Dropped, InventoryState.Held, gottenItem);
+            gottenItem.InvokeInventoryChange(InventoryState.Dropped, InventoryState.Held);
+            // Handle events
+            HandleEvent(EventType.CharacterGotItem, Actor, gottenItem);
+            gottenItem.HandleEvent(EventType.ItemGotten, Actor, gottenItem);
+            foreach (IHandleEvents witness in FilterWitnessHandlers(witnessHandlers, Actor))
+            {
+                witness.HandleEvent(EventType.CharacterGotItemWitness, Actor, gottenItem, witness);
+            }
+
+            foreach (IGameItem witness in FilterExternalItemWitnesses(witnessHandlers, gottenItem))
+            {
+                witness.HandleEvent(EventType.CharacterGotItemWitness, Actor, gottenItem, witness);
+            }
+
+            CheckConsequences();
         }
 
-        foreach (IGameItem witness in FilterExternalItemWitnesses(witnessHandlers, gottenItem))
-        {
-            witness.HandleEvent(EventType.CharacterGotItemWitness, Actor, gottenItem, witness);
-        }
-
-        CheckConsequences();
         return gottenItem;
     }
 

--- a/MudSharpCore/FutureProg/Functions/GameItem/LoadLootTableFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/GameItem/LoadLootTableFunction.cs
@@ -77,7 +77,7 @@ internal sealed class LoadLootTableFunction : BuiltInFunction
 			"loadloottable", types,
 			(pars, gameworld) => new LoadLootTableFunction(pars, gameworld, targetType, seeded),
 			names, descriptions,
-			"Atomically materialises an exact LootTable revision into a location, container item, or character inventory. Returns a canonical OK or ERROR receipt.",
+			"Atomically stages and commits an exact LootTable revision into a location, container item, or character inventory. Returns a canonical OK or ERROR receipt.",
 			"Items", ProgVariableTypes.Text));
 	}
 }

--- a/MudSharpCore/GameItems/GameItemProto.cs
+++ b/MudSharpCore/GameItems/GameItemProto.cs
@@ -295,6 +295,12 @@ public class GameItemProto : EditableItem, IGameItemProto, IEditableUniqueName
 
     public IEnumerable<IGameItem> CreateNew<T>(ICharacter loader, IGameItemSkin skin, int quantity, T variables) where T : IEnumerable<(ICharacteristicDefinition Definition, ICharacteristicValue Value)>
     {
+        return CreateNew(loader, skin, quantity, variables, true);
+    }
+
+    public IEnumerable<IGameItem> CreateNew<T>(ICharacter loader, IGameItemSkin skin, int quantity, T variables,
+        bool executeOnLoadProgs) where T : IEnumerable<(ICharacteristicDefinition Definition, ICharacteristicValue Value)>
+    {
         List<IGameItem> items = new();
         StackableGameItemComponentProto stackableProto = GetItemType<StackableGameItemComponentProto>();
         if (stackableProto is null && quantity > 1)
@@ -306,7 +312,7 @@ public class GameItemProto : EditableItem, IGameItemProto, IEditableUniqueName
 
             for (int i = 0; i < quantity; i++)
             {
-                items.Add(CreateNew(loader, skin, 1, variables).First());
+                items.Add(CreateNew(loader, skin, 1, variables, executeOnLoadProgs).First());
             }
 
             return items;
@@ -336,12 +342,20 @@ public class GameItemProto : EditableItem, IGameItemProto, IEditableUniqueName
         IStackable stackable = newItem.GetItemType<IStackable>();
         stackable?.Quantity = quantity;
 
-        foreach (IFutureProg prog in OnLoadProgs)
+        if (executeOnLoadProgs)
         {
-            prog.Execute(newItem, loader);
+            ExecuteOnLoadProgs(newItem, loader);
         }
 
         return items;
+    }
+
+    public void ExecuteOnLoadProgs(IGameItem item, ICharacter? loader)
+    {
+        foreach (IFutureProg prog in OnLoadProgs)
+        {
+            prog.Execute(item, loader);
+        }
     }
 
     public IEnumerable<IGameItem> CreateNew(ICharacter loader, IGameItemSkin skin, int quantity, string loadString)

--- a/MudSharpCore/Work/Loot/LootTableMaterialiser.cs
+++ b/MudSharpCore/Work/Loot/LootTableMaterialiser.cs
@@ -51,6 +51,10 @@ public sealed class LootTableMaterialiser
 				leaf => CreateLeaf(leaf).Select(item => (leaf, item)),
 				items =>
 				{
+					foreach (var pair in items.Where(x => x.Leaf.Kind == LootChoiceKind.Item))
+					{
+						ValidateInitialState(pair.Item, pair.Leaf.StartsClosed, pair.Leaf.StartsLocked);
+					}
 					foreach (var grouping in items.Where(x => x.Leaf.ResultKey is not null).GroupBy(x => x.Leaf.ResultKey!))
 					{
 						if (grouping.Count() != 1 || !keyed.TryAdd(grouping.Key, grouping.Single().Item)) throw new LootMaterialisationException("INVALID_RESULT_KEY", "A result key did not resolve to exactly one item.");
@@ -73,16 +77,16 @@ public sealed class LootTableMaterialiser
 					foreach (var item in items.Select(x => x.Item))
 					{
 						_gameworld.Add(item);
-						item.HandleEvent(EventType.ItemFinishedLoading, item);
-						item.Login();
 					}
 				},
 				items => Cleanup(items.Select(x => x.Item)));
 			created.AddRange(plannedItems.Select(x => x.Item));
+			var postCommitWarnings = FinaliseCommittedItems(created);
 			var roots = plannedItems.Where(x => x.Leaf.DestinationKey == "target").Select(x => x.Item).ToList();
 			var rootIds = string.Join(',', roots.Select(x => x.Id));
+			var warningReceipt = postCommitWarnings == 0 ? string.Empty : $" postcommitwarnings={postCommitWarnings}";
 			return new LootMaterialisationResult(true,
-				$"OK table={table.Id}r{table.RevisionNumber} hash={table.DefinitionHash} algorithm={table.AlgorithmVersion} variant={variant} seed={seed} roots={rootIds} created={created.Count} digest={plan.Digest}", plan);
+				$"OK table={table.Id}r{table.RevisionNumber} hash={table.DefinitionHash} algorithm={table.AlgorithmVersion} variant={variant} seed={seed} roots={rootIds} created={created.Count} digest={plan.Digest}{warningReceipt}", plan);
 		}
 		catch (LootMaterialisationException ex)
 		{
@@ -116,7 +120,7 @@ public sealed class LootTableMaterialiser
 		var quantityPerCreation = proto.IsItemType<IStackablePrototype>() ? leaf.Quantity : 1;
 		for (var remaining = leaf.Quantity; remaining > 0; remaining -= quantityPerCreation)
 		{
-			items.AddRange(proto.CreateNew(null!, null!, quantityPerCreation, variables));
+			items.AddRange(proto.CreateNew(null!, null!, quantityPerCreation, variables, executeOnLoadProgs: false));
 		}
 		if (items.Count == 0)
 		{
@@ -124,6 +128,19 @@ public sealed class LootTableMaterialiser
 		}
 		foreach (var item in items) item.Quality = (ItemQuality)leaf.Quality;
 		return items;
+	}
+
+	private static void ValidateInitialState(IGameItem item, bool startsClosed, bool startsLocked)
+	{
+		if (startsClosed && item.GetItemType<IOpenable>() is null)
+		{
+			throw new LootMaterialisationException("ITEM_NOT_OPENABLE", "A planned item cannot start closed because it is not openable.");
+		}
+
+		if (startsLocked && item.GetItemType<ILock>() is null)
+		{
+			throw new LootMaterialisationException("ITEM_NOT_LOCKABLE", "A planned item cannot start locked because it has no built-in lock.");
+		}
 	}
 
 	public static void ApplyInitialState(IGameItem item, bool startsClosed, bool startsLocked)
@@ -186,9 +203,52 @@ public sealed class LootTableMaterialiser
 		}
 		else if (target.Character is not null)
 		{
-			if (target.Character.Body.GetWithoutMerge(item, silent: true) is null) throw new LootMaterialisationException("PLACEMENT_FAILED", "A planned item was not inserted into the target inventory.");
+			if (target.Character.Body.GetWithoutMerge(item, silent: true, triggerEvents: false) is null) throw new LootMaterialisationException("PLACEMENT_FAILED", "A planned item was not inserted into the target inventory.");
 		}
 		else throw new LootMaterialisationException("NULL_TARGET", "The materialisation target was null.");
+	}
+
+	private int FinaliseCommittedItems(IEnumerable<IGameItem> items)
+	{
+		var warnings = 0;
+		foreach (var item in items)
+		{
+			warnings += TryFinalise(item, "OnLoad", () => item.Prototype.ExecuteOnLoadProgs(item, null));
+		}
+
+		foreach (var item in items)
+		{
+			warnings += TryFinalise(item, "ItemFinishedLoading", () => item.HandleEvent(EventType.ItemFinishedLoading, item));
+		}
+
+		foreach (var item in items)
+		{
+			warnings += TryFinalise(item, "Login", item.Login);
+		}
+
+		return warnings;
+	}
+
+	private int TryFinalise(IGameItem item, string operation, Action action)
+	{
+		try
+		{
+			action();
+			return 0;
+		}
+		catch (Exception ex)
+		{
+			try
+			{
+				_gameworld.SystemMessage($"LootTable post-commit {operation} failed for item #{item.Id:N0}: {ex.Message}", true);
+			}
+			catch
+			{
+				// A diagnostics failure must not make a committed loot package look as though it rolled back.
+			}
+
+			return 1;
+		}
 	}
 
 	private static void Cleanup(IEnumerable<IGameItem> items)


### PR DESCRIPTION
## Summary
- Defer item OnLoad progs until the staged loot package has committed.
- Suppress normal character-get inventory and witness hooks during loot placement.
- Keep committed items when post-commit loading hooks fail, report admin diagnostics, and return postcommitwarnings in the receipt.
- Update the loot-table design and FutureProg documentation.

## Validation
- MudSharpCore build succeeded.
- LootTableDefinitionTests: 28/28 passed.
- Full MudSharpCore Unit Tests: 2391/2391 passed.
- git diff --check passed.

Arbitrary custom component and placement code remains outside a database transaction; post-commit hooks are intentionally not rolled back.