### PR TITLE
Fix breathable gas counts-as checks

### DIFF
--- a/MudSharpCore Unit Tests/BreathingStrategyTests.cs
+++ b/MudSharpCore Unit Tests/BreathingStrategyTests.cs
@@ -1,0 +1,37 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Body;
+using MudSharp.Character.Heritage;
+using MudSharp.Construction;
+using MudSharp.Form.Material;
+using MudSharp.Health.Breathing;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class BreathingStrategyTests
+{
+	[TestMethod]
+	public void PartlessBreather_CanBreathe_WhenAtmosphereCountsAsRaceBreathableGas()
+	{
+		var canonicalAtmosphere = new Mock<IGas>();
+		var equivalentAtmosphere = new Mock<IGas>();
+		var race = new Mock<IRace>();
+		race.SetupGet(x => x.BreathableFluids).Returns(new IFluid[] { canonicalAtmosphere.Object });
+		race.Setup(x => x.CanBreatheFluid(equivalentAtmosphere.Object)).Returns((true, 1.0));
+
+		var cell = new Mock<ICell>();
+		cell.Setup(x => x.IsUnderwaterLayer(RoomLayer.GroundLevel)).Returns(false);
+		cell.SetupGet(x => x.Atmosphere).Returns(equivalentAtmosphere.Object);
+
+		var body = new Mock<IBody>();
+		body.SetupGet(x => x.Race).Returns(race.Object);
+		body.SetupGet(x => x.Location).Returns(cell.Object);
+		body.SetupGet(x => x.RoomLayer).Returns(RoomLayer.GroundLevel);
+
+		Assert.IsTrue(new PartlessBreather().CanBreathe(body.Object));
+		race.Verify(x => x.CanBreatheFluid(equivalentAtmosphere.Object), Times.Once);
+	}
+}

--- a/MudSharpCore/Character/Heritage/Race.cs
+++ b/MudSharpCore/Character/Heritage/Race.cs
@@ -1841,16 +1841,20 @@ public partial class Race : SaveableItem, IRace
 
     public (bool Truth, double RateMultiplier) CanBreatheFluid(IFluid fluid)
     {
-        KeyValuePair<IFluid, double> best = _fluidBreathingMultipliers
-            .Where(x => !_removeBreathableFluids.Contains(x.Key))
-            .Where(x => fluid.CountsAs(x.Key) && fluid.CountAsQuality(x.Key) != ItemQuality.Terrible)
-            .FirstMax(x => x.Value / fluid.CountsAsMultiplier(x.Key));
-        if (best.Value <= 0.0)
+        if (fluid is null || _removeBreathableFluids.Contains(fluid))
         {
             return (false, 0.0);
         }
 
-        return (true, best.Value);
+        KeyValuePair<IFluid, double> best = _fluidBreathingMultipliers
+            .Where(x => fluid.CountsAs(x.Key) && fluid.CountAsQuality(x.Key) != ItemQuality.Terrible)
+            .FirstMax(x => x.Value / fluid.CountsAsMultiplier(x.Key));
+        if (best.Value > 0.0)
+        {
+            return (true, best.Value);
+        }
+
+        return ParentRace?.CanBreatheFluid(fluid) ?? (false, 0.0);
     }
 
     public ITraitExpression BreathingVolumeExpression { get; set; }

--- a/MudSharpCore/Health/Breathing/BlowholeBreather.cs
+++ b/MudSharpCore/Health/Breathing/BlowholeBreather.cs
@@ -18,7 +18,7 @@ public class BlowholeBreather : IBreathingStrategy
 
     public bool CanBreathe(IBody body)
     {
-        if (!body.Race.BreathableFluids.Contains(BreathingFluid(body)))
+        if (!BreathingStrategyHelper.CanBreatheFluid(body, BreathingFluid(body)))
         {
             return false;
         }

--- a/MudSharpCore/Health/Breathing/BreathingStrategyHelper.cs
+++ b/MudSharpCore/Health/Breathing/BreathingStrategyHelper.cs
@@ -1,0 +1,14 @@
+#nullable enable
+
+using MudSharp.Body;
+using MudSharp.Form.Material;
+
+namespace MudSharp.Health.Breathing;
+
+internal static class BreathingStrategyHelper
+{
+	public static bool CanBreatheFluid(IBody body, IFluid? fluid)
+	{
+		return fluid is not null && body.Race.CanBreatheFluid(fluid).Truth;
+	}
+}

--- a/MudSharpCore/Health/Breathing/GillBreather.cs
+++ b/MudSharpCore/Health/Breathing/GillBreather.cs
@@ -18,7 +18,7 @@ public class GillBreather : IBreathingStrategy
 
     public bool CanBreathe(IBody body)
     {
-        if (!body.Race.BreathableFluids.Contains(BreathingFluid(body)))
+        if (!BreathingStrategyHelper.CanBreatheFluid(body, BreathingFluid(body)))
         {
             return false;
         }

--- a/MudSharpCore/Health/Breathing/LungBreather.cs
+++ b/MudSharpCore/Health/Breathing/LungBreather.cs
@@ -27,7 +27,7 @@ public class LungBreather : IBreathingStrategy
         IFluid breathingFluid = BreathingFluid(body);
         bool additionalBreathing = body.CombinedEffectsOfType<IAdditionalBreathableFluidEffect>()
             .Any(x => x.Applies() && x.AppliesToFluid(breathingFluid));
-        if (!body.Race.BreathableFluids.Contains(breathingFluid) && !additionalBreathing)
+        if (!BreathingStrategyHelper.CanBreatheFluid(body, breathingFluid) && !additionalBreathing)
         {
             return false;
         }

--- a/MudSharpCore/Health/Breathing/PartlessBreather.cs
+++ b/MudSharpCore/Health/Breathing/PartlessBreather.cs
@@ -17,7 +17,7 @@ public class PartlessBreather : IBreathingStrategy
 
     public bool CanBreathe(IBody body)
     {
-        if (!body.Race.BreathableFluids.Contains(BreathingFluid(body)))
+        if (!BreathingStrategyHelper.CanBreatheFluid(body, BreathingFluid(body)))
         {
             return false;
         }


### PR DESCRIPTION
## Summary
- Make every breathing strategy honor `Race.CanBreatheFluid`, including gases that count as a configured breathable gas.
- Restore parent-race fallback and keep the fluid lookup null-safe.
- Add a regression test for an atmosphere that counts as the race's breathable gas.

## Validation
- `dotnet test 'MudSharpCore Unit Tests\\MudSharpCore Unit Tests.csproj' -c Debug --no-build -m:1 --verbosity minimal` (2,414 passed)
- Focused `BreathingStrategyTests` (1 passed)
- Focused `CoreDataSeederGasTests` (3 passed)
- `git diff --cached --check`
