### PR TITLE
Fix reported runtime edge cases

### DIFF
--- a/Design Documents/Characters/Character_Creation_Builder_Workflows.md
+++ b/Design Documents/Characters/Character_Creation_Builder_Workflows.md
@@ -85,7 +85,7 @@ The `SkillPicker` storyboard can pre-select editable skill suggestions from earl
 - `chargen set suggestedskills <prog>` to configure a FutureProg returning a collection of traits from one `chargen` parameter
 - `chargen set suggestedskills none` to clear it
 
-Suggested skills are not free grants. They consume normal picks and resources and remain removable on the skill screen. Keep profession or background mapping in the prog; the screen itself only filters its results to distinct, currently selectable skills and applies them in returned order up to the pick limit.
+Suggested skills are not free grants. They consume normal picks and resources and remain removable on the skill screen. Keep profession or background mapping in the prog; the screen itself only filters its results to distinct, currently selectable skills and applies them in returned order up to the pick limit. If the picks prog depends on current chargen state, its allowance is recalculated for every suggested skill and again before the player can finish the screen.
 
 ## Resources
 Chargen resources are general-purpose account resources.

--- a/Design Documents/Characters/Character_Creation_Runtime.md
+++ b/Design Documents/Characters/Character_Creation_Runtime.md
@@ -69,7 +69,7 @@ The screen treats free and earlier picks as already selected. It only shows the 
 ### Suggested Skill Selection
 `SkillPicker` can optionally execute a `SuggestedSkillsProg` with the signature `(chargen) -> collection of traits` when the screen opens. This is intended for earlier selections such as profession roles to recommend an initial skill package without granting those skills for free.
 
-Returned traits are considered in prog order. The screen ignores duplicates, free skills, hidden traits, non-skill traits, and skills that are not currently available in chargen, and stops accepting suggestions at the normal skill-pick limit. Accepted suggestions are ordinary selections: they count toward costs and the pick limit and can be removed or replaced by the player. A missing or zero prog leaves the existing manual-selection behaviour unchanged.
+Returned traits are considered in prog order. The screen ignores duplicates, free skills, hidden traits, non-skill traits, and skills that are not currently available in chargen, and evaluates the normal skill-pick limit afresh for each suggestion. It also revalidates that limit when the player finishes the screen, so a dynamic limit prog cannot leave an over-limit selection. Accepted suggestions are ordinary selections: they count toward costs and the pick limit and can be removed or replaced by the player. A missing or zero prog leaves the existing manual-selection behaviour unchanged.
 
 ## Application Types
 Chargen tracks `ApplicationType` explicitly:

--- a/Design Documents/Combat/Multi_Target_Combat_Attacks.md
+++ b/Design Documents/Combat/Multi_Target_Combat_Attacks.md
@@ -29,7 +29,7 @@ Auxiliary actions use `auxiliary set targets <1-100>`. Setting the value to `1` 
 
 ## Target Eligibility
 
-The explicitly selected target is always first. Additional targets must be hostile characters in the same combat, must pass the same target-specific attack eligibility as the primary victim (including authored bodypart-shape requirements), and must not be allies of the assailant. Auxiliary actions evaluate their usability prog for each victim.
+The explicitly selected target is always first. Each child move records that selected victim as its primary target, so contact/vehicle checks and post-hit control effects cannot instead use the assailant's pre-existing combat target. Additional targets must be hostile characters in the same combat, must pass the same target-specific attack eligibility as the primary victim (including authored bodypart-shape requirements), and must not be allies of the assailant. Auxiliary actions evaluate their usability prog for each victim.
 
 For ordinary melee weapon, natural, and auxiliary moves, an additional victim must:
 

--- a/Design Documents/Health/Health_Core_Runtime.md
+++ b/Design Documents/Health/Health_Core_Runtime.md
@@ -188,7 +188,7 @@ The wound model cares about sequence and local state. Examples:
 - Wounds with lodged objects block several other treatments until the object is removed.
 - Wounds must generally be trauma-controlled before they can be closed.
 - Bone fractures must be relocated before non-surgical immobilization is valid.
-- A worn immobilising component derives its active fracture association from the bones beneath its wear profile. Removing or changing the worn profile clears that association, while load-time inventory restoration recomputes it without a separate persistence record.
+- A worn immobilising component derives its active fracture association from its actual stored wear locations, rather than re-evaluating a potentially state-dependent wear profile. Removing or changing the worn profile clears that association; another immobiliser can take it over only when it is directly worn over the same fracture, while load-time inventory restoration recomputes it without a separate persistence record.
 - Robot wounds use fluid-leak and repair semantics rather than organic infection and antiseptic logic.
 - Robot wounds do not contribute pain, while robot status still hinges on organ function, stun, fluid loss, positronic-brain integrity, and power-core integrity.
 

--- a/Design Documents/Items/Item_System_Presentation_and_Integration.md
+++ b/Design Documents/Items/Item_System_Presentation_and_Integration.md
@@ -117,7 +117,7 @@ Common examples:
 - `IImplant`
 - `IProsthetic`
 
-Inventory output treats belted attachments as part of the wearer's equipment, not loose room contents. If the belt is covered, attached items such as scabbards should still appear in inventory with the same covered or partially covered marker style used by worn items rather than disappearing from the list.
+Inventory output treats belted attachments as part of the wearer's equipment, not loose room contents. If the belt is covered, attached items such as scabbards should still appear in inventory with the same covered or partially covered marker style used by worn items rather than disappearing from the list. A belt attachment is nevertheless not directly worn for mechanics that depend on actual wear coverage, such as fracture immobilisation.
 
 MXP links in inventory presentation must pass player-authored names and descriptions through attribute-value escaping. Covered and partially covered hints use the shared `MXPSend` path so apostrophes, quotation marks, angle brackets, ampersands, and embedded MXP control characters cannot alter the generated `SEND` attributes.
 

--- a/Design Documents/World/Room_Layer_System_Primer.md
+++ b/Design Documents/World/Room_Layer_System_Primer.md
@@ -757,7 +757,7 @@ Do not describe the surface layer as the seabed just because its enum name is `G
 
 ### 10. A roof edge with a real fall
 
-Use `rooftopsonly` for the roof. Add an explicit downward fall/climb exit to the street or courtyard below. The roof remains the normal landing surface, but a fall that takes the downward endpoint can continue into the lower cell.
+Use `rooftopsonly` for the roof. Add an explicit downward fall/climb exit to the street or courtyard below. The roof remains the normal supported landing surface, so an occupant already on `OnRooftops` does not repeat fall processing; a fall descending from the air can still take the downward endpoint into the lower cell.
 
 This pattern is better than inventing a nonexistent `GroundLevel` inside a roofscape cell. It keeps the street and roof descriptions separate and makes the vertical danger explicit.
 

--- a/MudSharpCore Unit Tests/CharacterCreation/SkillPickerScreenTests.cs
+++ b/MudSharpCore Unit Tests/CharacterCreation/SkillPickerScreenTests.cs
@@ -24,7 +24,7 @@ public class SkillPickerScreenTests
 		var skill = Skill(TraitType.Skill, false, "language");
 
 		var result = SkillPickerScreenStoryboard.SkillPickerScreen.CanSelectSuggestedSkill(
-			skill, [], [skill], [], 1.0);
+			skill, [], [skill], [], () => 1.0);
 
 		Assert.IsTrue(result);
 	}
@@ -40,15 +40,15 @@ public class SkillPickerScreenTests
 		var available = new[] { freeSkill, hiddenSkill, attribute, selectedSkill };
 
 		Assert.IsFalse(SkillPickerScreenStoryboard.SkillPickerScreen.CanSelectSuggestedSkill(
-			freeSkill, [freeSkill], available, [freeSkill], 2.0));
+			freeSkill, [freeSkill], available, [freeSkill], () => 2.0));
 		Assert.IsFalse(SkillPickerScreenStoryboard.SkillPickerScreen.CanSelectSuggestedSkill(
-			hiddenSkill, [], available, [], 2.0));
+			hiddenSkill, [], available, [], () => 2.0));
 		Assert.IsFalse(SkillPickerScreenStoryboard.SkillPickerScreen.CanSelectSuggestedSkill(
-			attribute, [], available, [], 2.0));
+			attribute, [], available, [], () => 2.0));
 		Assert.IsFalse(SkillPickerScreenStoryboard.SkillPickerScreen.CanSelectSuggestedSkill(
-			unavailableSkill, [], available, [], 2.0));
+			unavailableSkill, [], available, [], () => 2.0));
 		Assert.IsFalse(SkillPickerScreenStoryboard.SkillPickerScreen.CanSelectSuggestedSkill(
-			selectedSkill, [], available, [selectedSkill], 2.0));
+			selectedSkill, [], available, [selectedSkill], () => 2.0));
 	}
 
 	[TestMethod]
@@ -63,7 +63,7 @@ public class SkillPickerScreenTests
 		foreach (var suggestion in new[] { first, first, second, third })
 		{
 			if (SkillPickerScreenStoryboard.SkillPickerScreen.CanSelectSuggestedSkill(
-					suggestion, [], available, selected, 2.0))
+					suggestion, [], available, selected, () => 2.0))
 			{
 				selected.Add(suggestion);
 			}
@@ -72,7 +72,40 @@ public class SkillPickerScreenTests
 		CollectionAssert.AreEqual(new[] { first, second }, selected);
 		selected.Remove(first);
 		Assert.IsTrue(SkillPickerScreenStoryboard.SkillPickerScreen.CanSelectSuggestedSkill(
-			first, [], available, selected, 2.0));
+			first, [], available, selected, () => 2.0));
+	}
+
+	[TestMethod]
+	public void CanSelectSuggestedSkill_DynamicPickLimit_ReevaluatesBeforeEachSuggestion()
+	{
+		var first = Skill();
+		var second = Skill();
+		var selected = new List<ITraitDefinition>();
+		var available = new[] { first, second };
+
+		foreach (var suggestion in new[] { first, second })
+		{
+			if (SkillPickerScreenStoryboard.SkillPickerScreen.CanSelectSuggestedSkill(
+					suggestion,
+					[],
+					available,
+					selected,
+					() => selected.Count == 0 ? 2.0 : 1.0))
+			{
+				selected.Add(suggestion);
+			}
+		}
+
+		CollectionAssert.AreEqual(new[] { first }, selected);
+	}
+
+	[TestMethod]
+	public void DoesNotExceedSkillPickLimit_CurrentLimitDropsBelowExistingSelections_ReturnsFalse()
+	{
+		Assert.IsFalse(SkillPickerScreenStoryboard.SkillPickerScreen.DoesNotExceedSkillPickLimit(
+			[],
+			[Skill(), Skill()],
+			1.0));
 	}
 
 	[TestMethod]

--- a/MudSharpCore Unit Tests/MedicalRuntimeRegressionTests.cs
+++ b/MudSharpCore Unit Tests/MedicalRuntimeRegressionTests.cs
@@ -61,35 +61,32 @@ public class MedicalRuntimeRegressionTests
 	}
 
 	[TestMethod]
-	public void WoundsCoveredByProfile_ReturnsFracturesUnderCoveredWearLocations()
+	public void WoundsCoveredByWearLocations_UsesActualWornLimb()
 	{
-		var bone = new Mock<IBone>();
-		var wearLocation = new Mock<IWear>();
-		wearLocation.SetupGet(x => x.BoneInfo)
+		var leftBone = new Mock<IBone>();
+		var rightBone = new Mock<IBone>();
+		var leftWearLocation = new Mock<IWear>();
+		leftWearLocation.SetupGet(x => x.BoneInfo)
 		            .Returns(new Dictionary<IBone, BodypartInternalInfo>
 		            {
-			            [bone.Object] = new BodypartInternalInfo(1.0, true, "arm")
+		            [leftBone.Object] = new BodypartInternalInfo(1.0, true, "left arm")
 		            });
-		var wearProfile = new Mock<IWearProfile>();
 		var body = new Mock<IBody>();
-		wearProfile.Setup(x => x.Profile(body.Object))
-		           .Returns(new Dictionary<IWear, IWearlocProfile>
-		           {
-			           [wearLocation.Object] = Mock.Of<IWearlocProfile>()
-		           });
-		var covered = new Mock<IImmobilisableWound>();
-		covered.SetupGet(x => x.Bodypart).Returns(bone.Object);
-		var uncovered = new Mock<IImmobilisableWound>();
-		uncovered.SetupGet(x => x.Bodypart).Returns(Mock.Of<IBone>());
-		body.SetupGet(x => x.Wounds).Returns(new IWound[] { covered.Object, uncovered.Object });
+		var leftFracture = new Mock<IImmobilisableWound>();
+		leftFracture.SetupGet(x => x.Bodypart).Returns(leftBone.Object);
+		var rightFracture = new Mock<IImmobilisableWound>();
+		rightFracture.SetupGet(x => x.Bodypart).Returns(rightBone.Object);
+		body.SetupGet(x => x.Wounds).Returns(new IWound[] { leftFracture.Object, rightFracture.Object });
 
-		var result = ImmobilisingGameItemComponent.WoundsCoveredByProfile(body.Object, wearProfile.Object).ToList();
+		var result = ImmobilisingGameItemComponent
+			.WoundsCoveredByWearLocations(body.Object, [leftWearLocation.Object])
+			.ToList();
 
-		CollectionAssert.AreEqual(new[] { covered.Object }, result);
+		CollectionAssert.AreEqual(new[] { leftFracture.Object }, result);
 	}
 
 	[TestMethod]
-	public void FindReplacementImmobilisingItem_UsesAnotherWornSplintCoveringTheFracture()
+	public void FindReplacementImmobilisingItem_UsesOnlyActuallyWornSplints()
 	{
 		var bone = new Mock<IBone>();
 		var wearLocation = new Mock<IWear>();
@@ -98,24 +95,27 @@ public class MedicalRuntimeRegressionTests
 		            {
 			            [bone.Object] = new BodypartInternalInfo(1.0, true, "arm")
 		            });
-		var wearProfile = new Mock<IWearProfile>();
 		var body = new Mock<IBody>();
-		wearProfile.Setup(x => x.Profile(body.Object))
-		           .Returns(new Dictionary<IWear, IWearlocProfile>
-		           {
-			           [wearLocation.Object] = Mock.Of<IWearlocProfile>()
-		           });
 		var wound = new Mock<IImmobilisableWound>();
 		wound.SetupGet(x => x.Bodypart).Returns(bone.Object);
 		body.SetupGet(x => x.Wounds).Returns(new IWound[] { wound.Object });
-		var remainingSplint = Mock.Of<IGameItem>();
+		var wornSplint = new Mock<IGameItem>();
+		wornSplint.Setup(x => x.IsItemType<IImmobilise>()).Returns(true);
+		var beltAttachedSplint = new Mock<IGameItem>();
+		beltAttachedSplint.Setup(x => x.IsItemType<IImmobilise>()).Returns(true);
+		body.SetupGet(x => x.WornItems).Returns([wornSplint.Object, beltAttachedSplint.Object]);
+		body.SetupGet(x => x.WornItemsFullInfo).Returns([
+			(wornSplint.Object, wearLocation.Object, Mock.Of<IWearlocProfile>())
+		]);
+		var removedSplint = Mock.Of<IGameItem>();
 
 		var result = ImmobilisingGameItemComponent.FindReplacementImmobilisingItem(
 			body.Object,
 			wound.Object,
-			new[] { (remainingSplint, wearProfile.Object) });
+			removedSplint);
 
-		Assert.AreSame(remainingSplint, result);
+		Assert.AreSame(wornSplint.Object, result);
+		body.VerifyGet(x => x.WornItems, Times.Never);
 	}
 
 }

--- a/MudSharpCore Unit Tests/MultiTargetCombatMoveTests.cs
+++ b/MudSharpCore Unit Tests/MultiTargetCombatMoveTests.cs
@@ -9,6 +9,7 @@ using MudSharp.Combat.Moves;
 using MudSharp.Construction;
 using MudSharp.Framework;
 using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
 using MudSharp.RPG.Checks;
 using System.Collections.Generic;
 using System.Linq;
@@ -25,6 +26,41 @@ public class MultiTargetCombatMoveTests
 			(int)BuiltInCombatMoveType.PullToMelee);
 		Assert.AreEqual((int)BuiltInCombatMoveType.PullToMelee + 1,
 			(int)BuiltInCombatMoveType.PullToMeleeUnarmed);
+	}
+
+	[TestMethod]
+	public void MeleeWeaponAttack_ExplicitSecondaryTarget_IsThePrimaryTarget()
+	{
+		var assailant = new Mock<ICharacter>();
+		var originalTarget = new Mock<ICharacter>();
+		var secondaryTarget = new Mock<ICharacter>();
+		assailant.SetupGet(x => x.CombatTarget).Returns(originalTarget.Object);
+		assailant.Setup(x => x.ColocatedWith(secondaryTarget.Object)).Returns(true);
+
+		var move = new MeleeWeaponAttack(
+			assailant.Object,
+			new Mock<IMeleeWeapon>().Object,
+			new Mock<IWeaponAttack>().Object,
+			secondaryTarget.Object);
+
+		Assert.AreSame(secondaryTarget.Object, move.PrimaryTarget);
+		CollectionAssert.Contains(move.CharacterTargets.ToList(), secondaryTarget.Object);
+	}
+
+	[TestMethod]
+	public void NaturalAttackMove_ExplicitSecondaryTarget_IsThePrimaryTarget()
+	{
+		var assailant = new Mock<ICharacter>();
+		var originalTarget = new Mock<ICharacter>();
+		var secondaryTarget = new Mock<ICharacter>();
+		var naturalAttack = new Mock<INaturalAttack>();
+		naturalAttack.SetupGet(x => x.Attack).Returns(new Mock<IWeaponAttack>().Object);
+		assailant.SetupGet(x => x.CombatTarget).Returns(originalTarget.Object);
+
+		var move = new NaturalAttackMove(assailant.Object, naturalAttack.Object, secondaryTarget.Object);
+
+		Assert.AreSame(secondaryTarget.Object, move.PrimaryTarget);
+		CollectionAssert.Contains(move.CharacterTargets.ToList(), secondaryTarget.Object);
 	}
 
 	[TestMethod]

--- a/MudSharpCore Unit Tests/TerrainLayerModelTests.cs
+++ b/MudSharpCore Unit Tests/TerrainLayerModelTests.cs
@@ -71,6 +71,27 @@ public class TerrainLayerModelTests
 	}
 
 	[TestMethod]
+	public void RooftopsOnlyLayer_IsSupportedAndDoesNotRepeatFallProcessing()
+	{
+		var rooftopOnly = CreateCell(CreateTerrain("rooftopsonly"));
+		var ordinaryRooftops = CreateCell(CreateTerrain("rooftops"));
+		var perceiver = new Mock<IPerceiver>();
+
+		Assert.IsTrue(PerceiverItem.IsSupportedRooftopsOnlyLayer(
+			rooftopOnly.Object,
+			perceiver.Object,
+			RoomLayer.OnRooftops));
+		Assert.IsFalse(PerceiverItem.IsSupportedRooftopsOnlyLayer(
+			rooftopOnly.Object,
+			perceiver.Object,
+			RoomLayer.InAir));
+		Assert.IsFalse(PerceiverItem.IsSupportedRooftopsOnlyLayer(
+			ordinaryRooftops.Object,
+			perceiver.Object,
+			RoomLayer.OnRooftops));
+	}
+
+	[TestMethod]
 	public void LayerExits_CharacterOverload_UsesCharactersCurrentLayer()
 	{
 		var character = new Mock<ICharacter>();

--- a/MudSharpCore/Character/CharacterMovement.cs
+++ b/MudSharpCore/Character/CharacterMovement.cs
@@ -1554,6 +1554,11 @@ public partial class Character
             return false;
         }
 
+        if (IsSupportedRooftopsOnlyLayer(Location, this, RoomLayer))
+        {
+            return false;
+        }
+
         if (!RoomLayer.IsHigherThan(RoomLayer.GroundLevel))
         {
             return false;

--- a/MudSharpCore/CharacterCreation/Screens/SkillPickerScreen.cs
+++ b/MudSharpCore/CharacterCreation/Screens/SkillPickerScreen.cs
@@ -167,11 +167,10 @@ public class SkillPickerScreenStoryboard : ChargenScreenStoryboard
                                 .ToList();
             Chargen.SelectedSkills.AddRange(FreeSkills);
             SetCurrentSelectables();
-            double maximumSkillPicks = Convert.ToDouble(storyboard.NumberOfSkillPicksProg.Execute(chargen));
             foreach (ITraitDefinition skill in storyboard.SuggestedSkillsProg?.ExecuteCollection<ITraitDefinition>(chargen) ?? [])
             {
                 if (!CanSelectSuggestedSkill(skill, FreeSkills, CurrentSelectables, Chargen.SelectedSkills,
-                        maximumSkillPicks))
+                        () => Convert.ToDouble(storyboard.NumberOfSkillPicksProg.Execute(chargen))))
                 {
                     continue;
                 }
@@ -185,7 +184,7 @@ public class SkillPickerScreenStoryboard : ChargenScreenStoryboard
 
         internal static bool CanSelectSuggestedSkill(ITraitDefinition skill,
             IEnumerable<ITraitDefinition> freeSkills, IEnumerable<ITraitDefinition> currentSelectables,
-            IEnumerable<ITraitDefinition> selectedSkills, double maximumSkillPicks)
+            IEnumerable<ITraitDefinition> selectedSkills, Func<double> maximumSkillPicks)
         {
             return skill is not null &&
                    skill.TraitType == TraitType.Skill &&
@@ -193,7 +192,13 @@ public class SkillPickerScreenStoryboard : ChargenScreenStoryboard
                    !freeSkills.Contains(skill) &&
                    currentSelectables.Contains(skill) &&
                    !selectedSkills.Contains(skill) &&
-                   selectedSkills.Except(freeSkills).Count() < maximumSkillPicks;
+                   selectedSkills.Except(freeSkills).Count() < maximumSkillPicks();
+        }
+
+        internal static bool DoesNotExceedSkillPickLimit(IEnumerable<ITraitDefinition> freeSkills,
+            IEnumerable<ITraitDefinition> selectedSkills, double maximumSkillPicks)
+        {
+            return selectedSkills.Except(freeSkills).Count() <= maximumSkillPicks;
         }
 
         public override ChargenStage AssociatedStage => ChargenStage.SelectSkills;
@@ -274,13 +279,25 @@ Type the name of the skill you would like to select, or type {"done".Colour(Teln
 
         private bool CanProgress()
         {
-            return !Chargen.SelectedSkills.All(x => Chargen.Gameworld.Languages.All(y => y.LinkedTrait != x));
+            return DoesNotExceedSkillPickLimit(
+                       FreeSkills,
+                       Chargen.SelectedSkills,
+                       Convert.ToDouble(Storyboard.NumberOfSkillPicksProg.Execute(Chargen))) &&
+                   !Chargen.SelectedSkills.All(x => Chargen.Gameworld.Languages.All(y => y.LinkedTrait != x));
 
             // TODO - other reasons why skill selection couldn't continue
         }
 
         private string WhyCannotProgress()
         {
+            if (!DoesNotExceedSkillPickLimit(
+                    FreeSkills,
+                    Chargen.SelectedSkills,
+                    Convert.ToDouble(Storyboard.NumberOfSkillPicksProg.Execute(Chargen))))
+            {
+                return "You have selected more skills than your current skill-pick allowance. Remove a skill before continuing.";
+            }
+
             if (Chargen.SelectedSkills.All(x => Chargen.Gameworld.Languages.All(y => y.LinkedTrait != x)))
             {
                 return

--- a/MudSharpCore/Combat/Moves/CombatMoveBase.cs
+++ b/MudSharpCore/Combat/Moves/CombatMoveBase.cs
@@ -45,6 +45,8 @@ public abstract class CombatMoveBase : ICombatMove
 
     public IEnumerable<IPerceiver> Targets => _targets;
 
+    protected ICharacter? PrimaryCharacterTarget => PrimaryTarget as ICharacter ?? CharacterTargets.FirstOrDefault();
+
     public virtual IPerceiver PrimaryTarget
     {
         get => _targets.FirstOrDefault() ??

--- a/MudSharpCore/Combat/Moves/CouchedLanceMove.cs
+++ b/MudSharpCore/Combat/Moves/CouchedLanceMove.cs
@@ -48,7 +48,7 @@ public class CouchedLanceMove : MeleeWeaponAttack
 		Assailant.OffensiveAdvantage += mountSpeed * Math.Max(1, reach) / MaximumChargeReach;
 
 		var result = base.ResolveMove(defenderMove);
-		var target = CharacterTargets.FirstOrDefault();
+		var target = PrimaryCharacterTarget;
 		if (target?.RidingMount is not null && result.MoveWasSuccessful && result.AttackerOutcome.IsPass())
 		{
 			target.OutputHandler.Handle(new EmoteOutput(new Emote(

--- a/MudSharpCore/Combat/Moves/MeleeWeaponAttack.cs
+++ b/MudSharpCore/Combat/Moves/MeleeWeaponAttack.cs
@@ -25,16 +25,13 @@ public class MeleeWeaponAttack : WeaponAttackMove
             throw new ApplicationException("Melee attack at range!");
         }
 #endif
+        if (target is not null)
+        {
+            PrimaryTarget = target;
+        }
+
         Assailant = owner;
         Weapon = weapon;
-        if (target == null && owner.CombatTarget is ICharacter ct)
-        {
-            _characterTargets.Add(ct);
-        }
-        else if (target != null)
-        {
-            _characterTargets.Add(target);
-        }
     }
 
     public override BuiltInCombatMoveType MoveType => BuiltInCombatMoveType.UseWeaponAttack;
@@ -81,7 +78,7 @@ public class MeleeWeaponAttack : WeaponAttackMove
 
     public override CombatMoveResult ResolveMove(ICombatMove defenderMove)
     {
-		var boundaryTarget = CharacterTargets.FirstOrDefault();
+		var boundaryTarget = PrimaryCharacterTarget;
 		if (boundaryTarget is not null &&
 		    !VehicleCombatService.Instance.CanCrossVehicleBoundary(Assailant, boundaryTarget, false, false,
 			    out var boundaryReason))
@@ -91,7 +88,7 @@ public class MeleeWeaponAttack : WeaponAttackMove
 		}
         if (defenderMove == null)
         {
-            defenderMove = new HelplessDefenseMove { Assailant = CharacterTargets.First() };
+            defenderMove = new HelplessDefenseMove { Assailant = PrimaryCharacterTarget ?? CharacterTargets.First() };
         }
 
         WorsenCombatPosition(defenderMove.Assailant, Assailant);

--- a/MudSharpCore/Combat/Moves/NaturalAttackMove.cs
+++ b/MudSharpCore/Combat/Moves/NaturalAttackMove.cs
@@ -14,16 +14,13 @@ public class NaturalAttackMove : WeaponAttackMove
 {
     public NaturalAttackMove(ICharacter owner, INaturalAttack attack, ICharacter target) : base(attack.Attack)
     {
+        if (target is not null)
+        {
+            PrimaryTarget = target;
+        }
+
         Assailant = owner;
         NaturalAttack = attack;
-        if (target == null && owner.CombatTarget is ICharacter ct)
-        {
-            _characterTargets.Add(ct);
-        }
-        else if (target != null)
-        {
-            _characterTargets.Add(target);
-        }
     }
 
     #region Overrides of CombatMoveBase
@@ -70,7 +67,7 @@ public class NaturalAttackMove : WeaponAttackMove
 
     public override CombatMoveResult ResolveMove(ICombatMove defenderMove)
     {
-		var boundaryTarget = CharacterTargets.FirstOrDefault();
+		var boundaryTarget = PrimaryCharacterTarget;
 		if (boundaryTarget is not null &&
 		    !VehicleCombatService.Instance.CanCrossVehicleBoundary(Assailant, boundaryTarget, false, false,
 			    out var boundaryReason))
@@ -80,7 +77,7 @@ public class NaturalAttackMove : WeaponAttackMove
 		}
         if (defenderMove == null)
         {
-            defenderMove = new HelplessDefenseMove { Assailant = Assailant.CombatTarget as ICharacter };
+            defenderMove = new HelplessDefenseMove { Assailant = PrimaryCharacterTarget ?? CharacterTargets.First() };
         }
 
         WorsenCombatPosition(defenderMove.Assailant, Assailant);

--- a/MudSharpCore/Combat/Moves/PullToMeleeMove.cs
+++ b/MudSharpCore/Combat/Moves/PullToMeleeMove.cs
@@ -19,8 +19,8 @@ public class PullToMeleeMove : MeleeWeaponAttack
 	public override CombatMoveResult ResolveMove(ICombatMove defenderMove)
 	{
 		var result = base.ResolveMove(defenderMove);
-		var target = CharacterTargets.First();
-		if (!ShouldResolvePull(result, target))
+		var target = PrimaryCharacterTarget;
+		if (target is null || !ShouldResolvePull(result, target))
 		{
 			return result;
 		}

--- a/MudSharpCore/Combat/Moves/PullToMeleeUnarmedMove.cs
+++ b/MudSharpCore/Combat/Moves/PullToMeleeUnarmedMove.cs
@@ -18,8 +18,8 @@ public class PullToMeleeUnarmedMove : NaturalAttackMove
 	public override CombatMoveResult ResolveMove(ICombatMove defenderMove)
 	{
 		var result = base.ResolveMove(defenderMove);
-		var target = CharacterTargets.First();
-		if (!ShouldResolvePull(result, target))
+		var target = PrimaryCharacterTarget;
+		if (target is null || !ShouldResolvePull(result, target))
 		{
 			return result;
 		}

--- a/MudSharpCore/Framework/PerceiverItem.cs
+++ b/MudSharpCore/Framework/PerceiverItem.cs
@@ -347,6 +347,12 @@ public abstract class PerceiverItem : PerceivedItem, IPerceiver
 
     #endregion
 
+    internal static bool IsSupportedRooftopsOnlyLayer(ICell? location, IPerceiver perceiver, RoomLayer roomLayer)
+    {
+        return roomLayer == RoomLayer.OnRooftops &&
+               location?.Terrain(perceiver).TerrainLayers.Contains(RoomLayer.GroundLevel) == false;
+    }
+
     public virtual bool ShouldFall()
     {
         if (PositionState?.SafeFromFalling == true)
@@ -360,6 +366,11 @@ public abstract class PerceiverItem : PerceivedItem, IPerceiver
         }
 
         if (ZeroGravityMovementHelper.IsZeroGravity(Location, RoomLayer, this))
+        {
+            return false;
+        }
+
+        if (IsSupportedRooftopsOnlyLayer(Location, this, RoomLayer))
         {
             return false;
         }

--- a/MudSharpCore/GameItems/Components/ImmobilisingGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/ImmobilisingGameItemComponent.cs
@@ -42,19 +42,25 @@ public class ImmobilisingGameItemComponent : WearableGameItemComponent, IImmobil
             return;
         }
 
-        foreach (var wound in WoundsCoveredByProfile(body, profile))
+        foreach (var wound in WoundsCoveredByWearLocations(
+                     body,
+                     body.WornItemsFullInfo
+                         .Where(x => x.Item == Parent)
+                         .Select(x => x.Wearloc)))
         {
             wound.ImmobilisingItem ??= Parent;
         }
     }
 
-    internal static IEnumerable<IImmobilisableWound> WoundsCoveredByProfile(IBody body, IWearProfile profile)
+    internal static IEnumerable<IImmobilisableWound> WoundsCoveredByWearLocations(
+        IBody body,
+        IEnumerable<IWear> wearLocations)
     {
-        var coveredBones = profile.Profile(body)
-                                  .SelectMany(x => x.Key.BoneInfo.Keys)
-                                  .ToHashSet();
+        var coveredBones = wearLocations
+            .SelectMany(x => x.BoneInfo.Keys)
+            .ToHashSet();
         return body.Wounds.OfType<IImmobilisableWound>()
-                   .Where(x => coveredBones.Contains(x.Bodypart));
+            .Where(x => coveredBones.Contains(x.Bodypart));
     }
 
     private void ClearImmobilisedWounds()
@@ -67,22 +73,26 @@ public class ImmobilisingGameItemComponent : WearableGameItemComponent, IImmobil
         foreach (var wound in WornBy.Wounds.OfType<IImmobilisableWound>()
                                     .Where(x => x.ImmobilisingItem == Parent))
         {
-            wound.ImmobilisingItem = FindReplacementImmobilisingItem(
-                WornBy,
-                wound,
-                WornBy.WornItems
-                      .Where(x => x != Parent && x.IsItemType<IImmobilise>())
-                      .Select(x => (Item: x, Profile: x.GetItemType<IWearable>()?.CurrentProfile))
-                      .Where(x => x.Profile is not null));
+            wound.ImmobilisingItem = FindReplacementImmobilisingItem(WornBy, wound, Parent);
         }
     }
 
     internal static IGameItem FindReplacementImmobilisingItem(
         IBody body,
         IImmobilisableWound wound,
-        IEnumerable<(IGameItem Item, IWearProfile Profile)> candidates)
+        IGameItem removedItem)
     {
-        return candidates.FirstOrDefault(x => WoundsCoveredByProfile(body, x.Profile).Contains(wound)).Item;
+        foreach (var candidate in body.WornItemsFullInfo
+                     .Where(x => x.Item != removedItem && x.Item.IsItemType<IImmobilise>())
+                     .GroupBy(x => x.Item))
+        {
+            if (WoundsCoveredByWearLocations(body, candidate.Select(x => x.Wearloc)).Contains(wound))
+            {
+                return candidate.Key;
+            }
+        }
+
+        return null;
     }
 
     #endregion


### PR DESCRIPTION
Fixes immobiliser wear-location and replacement selection, rooftop-only repeated falling, multi-target primary-victim selection, and dynamic skill-pick limits. Adds regression coverage and updates the related health, item, combat, world-layer, and character-creation design documents. The multi-projectile report was investigated; current initialization ordering prevents the claimed invalid lodged-item reference, so no code change was made for that report. Validation: focused regressions 34/34; full MudSharpCore suite 2419/2419; git diff --check clean.