### PR TITLE
Add accelerated combat simulation

### DIFF
--- a/Design Documents/Combat/Accelerated_Combat_Simulation.md
+++ b/Design Documents/Combat/Accelerated_Combat_Simulation.md
@@ -1,0 +1,93 @@
+# Accelerated Combat Simulation
+
+## Purpose
+
+The accelerated combat simulator is a founder diagnostic for testing ordinary combat strategies without waiting for wall-clock combat delays. It supports two or more named teams and accepts both loaded characters and current NPC templates. The simulator uses the real combat move, health, effect, item and heartbeat code; it is not a separate statistical combat model.
+
+The workflow is staged under `impdebug combatsim`. A founder selects a scene, adds combatants to teams, reviews preflight warnings, and then runs the staged scenario. The completed session retains a summary and a bounded transcript until it is replaced or cleared. The same staged scenario can also be run as a bounded batch across a deterministic sequence of seeds to compare aggregate outcomes.
+
+## Runtime model
+
+The command executes synchronously on the command/game-loop thread. While it runs, ordinary connection input, game-loop scheduling, clock advancement and save-loop work do not run. A flow-local runtime scope replaces the game world's scheduler, effect scheduler, heartbeat manager and save manager for simulation code. A virtual `TimeProvider` advances directly to the next due main or effect schedule, and an ambient seeded `Random` removes variation from both the engine's shared random source and ExpressionEngine `rand`/`drand`/`dice` functions. The scope is active before source effects are serialised and before characters or NPC templates are materialised, so load hooks see the simulation clock and seeded random source.
+
+Gameplay code that needs current UTC uses the ambient `RuntimeClock.UtcNow`. Outside an isolated runtime scope it delegates to `TimeProvider.System`; inside a simulation it returns advancing virtual time. Operational timestamps such as login history, builder edit dates and persistence audit chronology deliberately remain on the system clock, as do the wall-clock execution guards.
+
+The simulation starts a private heartbeat at one virtual-second intervals. Character and body constructors therefore subscribe their stamina, bleeding, healing, drug, breathing, biological and other heartbeat processes to the private manager. Combat recovery schedules and expiring effects share the virtual clock. Execution stops when no more than one active team remains, no schedule remains, the configured virtual-time, fired-event or wall-clock guard is reached, or no combat-relevant participant state changes for 30 virtual seconds and 1,000 fired schedules. The latter is reported as a stalemate with an actionable no-input warning rather than consuming the whole event budget.
+
+Team combat uses `SimpleMeleeCombat` with a simulation-only target policy. When an actor needs a target, the policy chooses an engageable, able member of another team. This preserves the normal move selection and response pipeline while allowing fights larger than one-on-one.
+
+## Scene and combatant materialisation
+
+The scene is a transient negative-ID `Cell` that borrows the selected cell's room and overlay environment but owns its characters and items independently. It has no exits, so strategies that require actual room-to-room flight may reach a guard limit rather than successfully flee. Saved effects on the source cell are cloned when possible.
+
+Loaded-character sources are never placed in combat. The simulator creates a non-player transient character with the source's identity template, race, traits, descriptions, merits, blood, stamina, active and latent drug doses, position, combat settings, strategy, saved character/body effects, wounds, infections, and deep copies of worn, wielded and held inventory. Wounds are reconstructed through the target body's health strategy and then assigned their live damage, pain, shock, stun and bleeding values; infections retain their type, intensity, immunity, virulence, stage and wound/bodypart relationship. Special wound implementation state, lodged-item relationships, unsaved non-saving effects, clan/party/project state and arbitrary external relationships are not guaranteed to clone exactly.
+
+NPC-template sources are materialised as simulation-only NPCs. Template load additions, the on-load FutureProg and the `NPCOnGameLoadFinished` event run so template equipment and AI setup match ordinary NPC spawning. These extension points are also part of the non-transactional risk boundary described below.
+
+## Outcomes and reporting
+
+Per-combatant terminal outcomes are:
+
+- death;
+- incapacitation, including ordinary non-able character states;
+- full grapple control (`IBeingGrappled.UnderControl`);
+- successful departure while using the flee strategy;
+- another combat withdrawal;
+- survival on the winning team; or
+- stalemate when a guard ends the run.
+
+`Surrendered` remains part of the report contract, but the current automatic combat strategy pipeline has no general surrender transition to emit it. Fully manual combat, manual movement/position management, fully manual ranged or inventory management, zero automatic attack weighting, and NPC on-load progs are surfaced during preflight because they can stall or broaden a no-input simulation.
+
+The individual report includes run ID, seed, winning team, stop reason, virtual and wall-clock duration, fired-event count, participant state, blood and stamina ratios, wounds, terminal outcome, and a full versioned execution fingerprint. The current `v1` fingerprint is a SHA-256 digest over materialisation order, seeded random draws, private scheduler ticks, simulation output and the canonical terminal state. It excludes wall-clock duration, run IDs and transient object IDs. Transcript entries carry virtual timestamps and participant labels. The default limits are 30 virtual minutes, 100,000 fired schedules, 10,000 transcript entries, and 60 wall-clock seconds.
+
+## Batch tournaments
+
+`batch` reuses the currently staged scene and combatants for 1 to 100 sequential runs. It starts from the staged seed unless `seed` is supplied, and increases it by one unless `step` is supplied; a zero step is permitted when intentionally replaying the same seed. The batch validates that every generated seed remains a 32-bit integer. One UTC epoch is captured at the start of the batch and reused by every run, preventing real elapsed time between repetitions from changing absolute-time-sensitive gameplay decisions. Separate batch invocations intentionally capture new epochs.
+
+Each run retains only its compact result, not its transcript, so a 100-run tournament cannot consume transcript memory. The aggregate report shows team wins and win rates, run-status counts, combatant-outcome counts, total, average and range virtual duration, and both summed simulation and whole-batch wall-clock duration. The final individual result remains available through `report`, but its batch transcript is intentionally empty. `batchreport` repeats the aggregate report; `batchreport runs [<start>] [<count>]` pages the per-run seed, status, winner, timing, event count and short trace fingerprint. `batchreport trace <run> <random|state|materialisation> [<start>] [<count>]` pages the captured diagnostic trace for one run, making the first divergence in an intentionally repeated seed inspectable without retaining full combat transcripts.
+
+When a batch intentionally repeats a seed (normally by using `step 0`), the aggregate report groups those runs and compares their full execution fingerprints. Matching runs are marked as replay matches; a mismatch is a prominent warning and can be inspected through the paged run report. For engine-controlled scenarios with unchanged staged sources and a shared batch epoch, matching fingerprints are the exact-replay criterion. The fingerprint is diagnostic evidence, not a way to make external hooks, direct Dapper writes, unseeded random sources, or asynchronous work deterministic.
+
+The batch has a hard ten-minute aggregate wall-clock guard in addition to the per-run wall-clock guard. If the aggregate guard expires, completed runs are still reported and the report explains that remaining runs were skipped. A batch has the same production confirmation and warning/`force` requirements as an individual run.
+
+## Persistence and safety boundary
+
+The live save queue is left untouched while the simulation runs. Simulation code receives a flow-local `FMDB` context and a private save manager, so pre-existing pending saves neither enter the simulation transaction nor prevent a run when an unrelated live save is currently invalid. The simulation-specific EF context suppresses every `SaveChanges` call, including persistence initiated directly by a combat-time tick; an EF transaction remains a defence-in-depth rollback boundary. The simulation save manager likewise discards ordinary saves. Actors, bodies, items and the transient cell newly registered during the run are removed from the game-world registries in cleanup.
+
+Legality queries still run, including `ActLawfully` decisions, but actual crime creation is suppressed by the same flow-local runtime policy. A simulation therefore cannot add crimes to a legal authority or the game-world registry, notify witnesses or victims, invoke crime storyteller hooks, or queue crime persistence. Ordinary execution on other flows is unaffected.
+
+This is a development-first diagnostic, not a complete process sandbox. The following cannot be guaranteed to unwind:
+
+- SQL issued through the separate `FMDB.Connection` Dapper connection;
+- email, Discord, files, HTTP calls or other external services;
+- hooks, AI or FutureProgs that mutate pre-existing in-memory objects;
+- work started asynchronously that outlives the simulation scope.
+
+Simulation character death uses a reduced death path, so it does not post death-board entries, update statistics, send email/Discord notifications, create estates or destroy a live character. Other authored hooks and progs remain the responsibility of the tester.
+
+`FUTUREMUD_ENVIRONMENT` values `development`, `dev`, `test`, `testing` and `local` are treated as non-production. The variable being unset, `production`, `staging`, or any unrecognised value is treated as production. Every production run requires the literal `confirm-production` option; it is deliberately not remembered. Preflight warnings additionally require `force`.
+
+## Founder workflow
+
+```text
+impdebug combatsim new [<cell>]
+impdebug combatsim add character <loaded character> team <team>
+impdebug combatsim add template <NPC template> team <team> [count <number>]
+impdebug combatsim remove <slot>
+impdebug combatsim set scene <cell>
+impdebug combatsim set seed <number>
+impdebug combatsim set maxtime <timespan>
+impdebug combatsim set maxevents <number>
+impdebug combatsim set transcript <number>
+impdebug combatsim show
+impdebug combatsim validate
+impdebug combatsim run [force] [confirm-production]
+impdebug combatsim batch <runs> [seed <start>] [step <increment>] [force] [confirm-production]
+impdebug combatsim batchreport [runs [<start>] [<count>]]
+impdebug combatsim batchreport trace <run> <random|state|materialisation> [<start>] [<count>]
+impdebug combatsim report
+impdebug combatsim transcript [<start>] [<count>]
+impdebug combatsim clear
+```
+
+For comparable runs within one batch, keep the source state, active NPC-template revision and selected scene unchanged; use a zero seed step for an exact seeded replay. The seed controls the engine's shared random source, expression evaluation uses call-local parameter values rather than shared mutable dictionaries, and all runs share the batch epoch. Repeated runs should therefore have the same `v1` execution fingerprint unless authored or external code escapes those controlled services. Separate invocations use their own starting epoch. `report` repeats the summary; `transcript` defaults to the first 100 entries and accepts a one-based start plus a maximum count of 1,000.

--- a/Design Documents/README.md
+++ b/Design Documents/README.md
@@ -29,6 +29,7 @@ This folder is organised by subsystem so implementation notes, builder workflows
 - [Multiple Simultaneous Body Instances Design](./Characters/Multiple_Simultaneous_Body_Instances_Design.md)
 
 ## Combat
+- [Accelerated Combat Simulation](./Combat/Accelerated_Combat_Simulation.md)
 - [Combat Arenas Design](./Combat/Combat_Arenas_Design.md)
 - [Combat Arenas Implementation Plan](./Combat/Combat_Arenas_Implementation_Plan.md)
 - [Combat Settings Defaults Design](./Combat/Combat_Settings_Defaults_Design.md)

--- a/ExpressionEngine Unit Tests/ExpressionEngineTests.cs
+++ b/ExpressionEngine Unit Tests/ExpressionEngineTests.cs
@@ -50,6 +50,30 @@ public class ExpressionEngineTests
 		}
 	}
 
+	[TestMethod]
+	public void PushRandom_SameSeed_ReplaysExpressionSequence()
+	{
+		var expression = new Expression("rand(1,1000000) + dice(3,1000000)");
+		double[] first;
+		double[] second;
+
+		using (Expression.PushRandom(new Random(8675309)))
+		{
+			first = Enumerable.Range(0, 10)
+				.Select(_ => expression.EvaluateDouble())
+				.ToArray();
+		}
+
+		using (Expression.PushRandom(new Random(8675309)))
+		{
+			second = Enumerable.Range(0, 10)
+				.Select(_ => expression.EvaluateDouble())
+				.ToArray();
+		}
+
+		CollectionAssert.AreEqual(first, second);
+	}
+
 	[DataTestMethod]
 	[DataRow("not(0)", 1.0)]
 	[DataRow("not(1)", 0.0)]
@@ -73,14 +97,21 @@ public class ExpressionEngineTests
 	}
 
 	[TestMethod]
-	public void Evaluate_EnumParameter_UsesUnderlyingNumericValue()
+	public void EvaluateWith_EnumParameter_UsesUnderlyingNumericValue()
 	{
-		var expression = new Expression("enum")
-		{
-			Parameters = { ["enum"] = Difficulty.Insane }
-		};
+		var expression = new Expression("enum");
 
-		Assert.AreEqual(9.0, expression.EvaluateDouble());
+		Assert.AreEqual(9.0, expression.EvaluateDoubleWith(("enum", Difficulty.Insane)));
+	}
+
+	[TestMethod]
+	public void EvaluateWith_MissingValues_ResetToZeroForEachCall()
+	{
+		var expression = new Expression("first + second");
+
+		Assert.AreEqual(7.0, expression.EvaluateDoubleWith(("first", 7)));
+		Assert.AreEqual(11.0, expression.EvaluateDoubleWith(("second", 11)));
+		Assert.AreEqual(0.0, expression.EvaluateDouble());
 	}
 
 	[TestMethod]

--- a/ExpressionEngine/Expression.cs
+++ b/ExpressionEngine/Expression.cs
@@ -4,8 +4,10 @@ using NCalc.Extensions;
 using NCalc.Handlers;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http.Headers;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 namespace ExpressionEngine
 {
@@ -15,66 +17,88 @@ namespace ExpressionEngine
         public const int MaximumDiceSides = 100000;
 
         public static event EventHandler<string> ExpressionError;
-        public static Random RandomInstance { get; } = new();
+        private static readonly Random SystemRandom = new();
+        private static readonly AsyncLocal<Random> AmbientRandom = new();
+        public static Random RandomInstance => AmbientRandom.Value ?? SystemRandom;
 
-        private NCalc.Expression _expression;
+        public static IDisposable PushRandom(Random random)
+        {
+            ArgumentNullException.ThrowIfNull(random);
+            var previous = AmbientRandom.Value;
+            AmbientRandom.Value = random;
+            return new AmbientRandomScope(previous);
+        }
+
+        private sealed class AmbientRandomScope(Random previous) : IDisposable
+        {
+            private bool _disposed;
+
+            public void Dispose()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                AmbientRandom.Value = previous;
+                _disposed = true;
+            }
+        }
+
+        private readonly NCalc.Expression _parsedExpression;
+        private readonly ExpressionOptions _options;
+        private readonly IReadOnlyList<string> _parameterNames;
+        private readonly bool _hasErrors;
 
         public string OriginalExpression { get; private set; }
-
-        private Dictionary<string, object> _parameters;
-
-        public Dictionary<string, object> Parameters
-        {
-            get => _parameters ??= new Dictionary<string, object>(); set => _parameters = value;
-        }
 
         private static readonly Regex _regex = new(@"(?:(?<numdice>\d+)d(?<sides>\d+))", RegexOptions.IgnoreCase);
 
         public object Evaluate()
         {
-            foreach (KeyValuePair<string, object> parameter in Parameters)
+            return EvaluateWith(Array.Empty<(string Name, object Value)>());
+        }
+
+        public object EvaluateWith(IReadOnlyDictionary<string, object> values)
+        {
+            ArgumentNullException.ThrowIfNull(values);
+            return EvaluateWith(values.Select(x => (x.Key, x.Value)).ToArray());
+        }
+
+        public object EvaluateWith(params (string Name, object Value)[] values)
+        {
+            ArgumentNullException.ThrowIfNull(values);
+
+            if (_hasErrors)
             {
-                if (parameter.Value is Enum)
-                {
-                    _expression.Parameters[parameter.Key] = Convert.ToInt64(parameter.Value);
-                    continue;
-                }
-                _expression.Parameters[parameter.Key] = parameter.Value;
+                return ReportError(new NCalcParserException(_parsedExpression.Error?.Message ?? "The expression has parsing errors."));
             }
+
+            var expression = CreateEvaluationExpression(values);
 
             try
             {
-                return _expression.Evaluate();
+                return expression.Evaluate();
             }
             catch (NCalcFunctionNotFoundException e)
             {
-                Console.WriteLine($"Exception in expression {OriginalExpression}:\n\nFunction Not Found: {e.FunctionName}\n\n{e}");
-                ExpressionError?.Invoke(this, $"Exception in expression {OriginalExpression}:\n\nFunction Not Found: {e.FunctionName}\n\n{e}");
-                return 0.0;
+                return ReportError($"Exception in expression {OriginalExpression}:\n\nFunction Not Found: {e.FunctionName}\n\n{e}");
             }
             catch (NCalcParameterNotDefinedException e)
             {
-                Console.WriteLine($"Exception in expression {OriginalExpression}:\n\nParameter Not Defined: {e.ParameterName}\n\n{e}");
-                ExpressionError?.Invoke(this, $"Exception in expression {OriginalExpression}:\n\nParameter Not Defined: {e.ParameterName}\n\n{e}");
-                return 0.0;
+                return ReportError($"Exception in expression {OriginalExpression}:\n\nParameter Not Defined: {e.ParameterName}\n\n{e}");
             }
             catch (NCalcParserException e)
             {
-                Console.WriteLine($"Exception in expression {OriginalExpression}:\n\n{e}");
-                ExpressionError?.Invoke(this, $"Exception in expression {OriginalExpression}:\n\n{e}");
-                return 0.0;
+                return ReportError($"Exception in expression {OriginalExpression}:\n\n{e}");
             }
             catch (NCalcEvaluationException e)
             {
-                Console.WriteLine($"Exception in expression {OriginalExpression}:\n\n{e}");
-                ExpressionError?.Invoke(this, $"Exception in expression {OriginalExpression}:\n\n{e}");
-                return 0.0;
+                return ReportError($"Exception in expression {OriginalExpression}:\n\n{e}");
             }
             catch (Exception e) when (e is ArgumentException or OverflowException or InvalidOperationException)
             {
-                Console.WriteLine($"Exception in expression {OriginalExpression}:\n\n{e}");
-                ExpressionError?.Invoke(this, $"Exception in expression {OriginalExpression}:\n\n{e}");
-                return 0.0;
+                return ReportError($"Exception in expression {OriginalExpression}:\n\n{e}");
             }
         }
 
@@ -83,57 +107,14 @@ namespace ExpressionEngine
             return Convert.ToDouble(Evaluate());
         }
 
+        public double EvaluateDoubleWith(IReadOnlyDictionary<string, object> values)
+        {
+            return Convert.ToDouble(EvaluateWith(values));
+        }
+
         public decimal EvaluateDecimal()
         {
             return Convert.ToDecimal(Evaluate());
-        }
-
-        public object EvaluateWith(params (string Name, object Value)[] values)
-        {
-            foreach (KeyValuePair<string, object> parameter in Parameters)
-            {
-                _expression.Parameters[parameter.Key] = parameter.Value;
-            }
-
-            foreach ((string Name, object Value) parameter in values)
-            {
-                _expression.Parameters[parameter.Name] = parameter.Value;
-            }
-
-            try
-            {
-                return _expression.Evaluate();
-            }
-            catch (NCalcFunctionNotFoundException e)
-            {
-                Console.WriteLine($"Exception in expression {OriginalExpression}:\n\nFunction Not Found: {e.FunctionName}\n\n{e}");
-                ExpressionError?.Invoke(this, $"Exception in expression {OriginalExpression}:\n\nFunction Not Found: {e.FunctionName}\n\n{e}");
-                return 0.0;
-            }
-            catch (NCalcParameterNotDefinedException e)
-            {
-                Console.WriteLine($"Exception in expression {OriginalExpression}:\n\nParameter Not Defined: {e.ParameterName}\n\n{e}");
-                ExpressionError?.Invoke(this, $"Exception in expression {OriginalExpression}:\n\nParameter Not Defined: {e.ParameterName}\n\n{e}");
-                return 0.0;
-            }
-            catch (NCalcParserException e)
-            {
-                Console.WriteLine($"Exception in expression {OriginalExpression}:\n\n{e}");
-                ExpressionError?.Invoke(this, $"Exception in expression {OriginalExpression}:\n\n{e}");
-                return 0.0;
-            }
-            catch (NCalcEvaluationException e)
-            {
-                Console.WriteLine($"Exception in expression {OriginalExpression}:\n\n{e}");
-                ExpressionError?.Invoke(this, $"Exception in expression {OriginalExpression}:\n\n{e}");
-                return 0.0;
-            }
-            catch (Exception e) when (e is ArgumentException or OverflowException or InvalidOperationException)
-            {
-                Console.WriteLine($"Exception in expression {OriginalExpression}:\n\n{e}");
-                ExpressionError?.Invoke(this, $"Exception in expression {OriginalExpression}:\n\n{e}");
-                return 0.0;
-            }
         }
 
         public double EvaluateDoubleWith(params (string Name, object Value)[] values)
@@ -146,14 +127,19 @@ namespace ExpressionEngine
             return Convert.ToDecimal(EvaluateWith(values));
         }
 
-        public bool HasErrors()
+        public decimal EvaluateDecimalWith(IReadOnlyDictionary<string, object> values)
         {
-            return _expression.HasErrors();
+            return Convert.ToDecimal(EvaluateWith(values));
         }
 
-        public string Error => _expression.Error?.Message ?? string.Empty;
+        public bool HasErrors()
+        {
+            return _hasErrors;
+        }
 
-        public IEnumerable<string> ParameterNames => _expression.GetParameterNames();
+        public string Error => _parsedExpression.Error?.Message ?? string.Empty;
+
+        public IEnumerable<string> ParameterNames => _parameterNames;
 
         #region Constructors
         public Expression(string expression) : this(expression, ExpressionOptions.CaseInsensitiveStringComparer | ExpressionOptions.IgnoreCaseAtBuiltInFunctions | ExpressionOptions.AllowBooleanCalculation)
@@ -163,25 +149,51 @@ namespace ExpressionEngine
         protected Expression(string expression, ExpressionOptions options)
         {
             OriginalExpression = expression;
+            _options = options;
             string parsed = _regex.Replace(expression, m =>
             {
                 return $"dice({m.Groups["numdice"].Value},{m.Groups["sides"].Value})";
             });
-            _expression = new NCalc.Expression(parsed, options);
-            _expression.EvaluateFunction += DRandFunction;
-            _expression.EvaluateFunction += RandFunction;
-            _expression.EvaluateFunction += DiceFunction;
-            _expression.EvaluateFunction += NotFunction;
-
-            if (!_expression.HasErrors())
-            {
-                foreach (string parameter in _expression.GetParameterNames())
-                {
-                    _expression.Parameters[parameter] = 0.0;
-                }
-            }
+            _parsedExpression = new NCalc.Expression(parsed, options);
+            _hasErrors = _parsedExpression.HasErrors();
+            _parameterNames = _hasErrors
+                ? Array.Empty<string>()
+                : _parsedExpression.GetParameterNames();
         }
         #endregion
+
+        private NCalc.Expression CreateEvaluationExpression(IEnumerable<(string Name, object Value)> values)
+        {
+            var expression = new NCalc.Expression(_parsedExpression.LogicalExpression!, _options);
+            expression.EvaluateFunction += DRandFunction;
+            expression.EvaluateFunction += RandFunction;
+            expression.EvaluateFunction += DiceFunction;
+            expression.EvaluateFunction += NotFunction;
+
+            foreach (var parameter in _parameterNames)
+            {
+                expression.Parameters[parameter] = 0.0;
+            }
+
+            foreach (var (name, value) in values)
+            {
+                expression.Parameters[name] = value is Enum ? Convert.ToInt64(value) : value;
+            }
+
+            return expression;
+        }
+
+        private object ReportError(Exception exception)
+        {
+            return ReportError($"Exception in expression {OriginalExpression}:\n\n{exception}");
+        }
+
+        private object ReportError(string message)
+        {
+            Console.WriteLine(message);
+            ExpressionError?.Invoke(this, message);
+            return 0.0;
+        }
 
         #region In-built functions
 

--- a/ExpressionEngine/IExpression.cs
+++ b/ExpressionEngine/IExpression.cs
@@ -3,12 +3,14 @@ namespace ExpressionEngine
     public interface IExpression
     {
         string OriginalExpression { get; }
-        System.Collections.Generic.Dictionary<string, object> Parameters { get; set; }
         object Evaluate();
+        object EvaluateWith(System.Collections.Generic.IReadOnlyDictionary<string, object> values);
         object EvaluateWith(params (string Name, object Value)[] values);
         double EvaluateDouble();
+        double EvaluateDoubleWith(System.Collections.Generic.IReadOnlyDictionary<string, object> values);
         double EvaluateDoubleWith(params (string Name, object Value)[] values);
         decimal EvaluateDecimal();
+        decimal EvaluateDecimalWith(System.Collections.Generic.IReadOnlyDictionary<string, object> values);
         decimal EvaluateDecimalWith(params (string Name, object Value)[] values);
         bool HasErrors();
         string Error { get; }

--- a/FutureMUDLibrary/Combat/Simulation/ICombatSimulation.cs
+++ b/FutureMUDLibrary/Combat/Simulation/ICombatSimulation.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using MudSharp.Character;
+using MudSharp.Character.Name;
+using MudSharp.Construction;
+using MudSharp.Framework;
+using MudSharp.NPC.Templates;
+
+#nullable enable
+
+namespace MudSharp.Combat.Simulation;
+
+public enum CombatSimulationSourceType
+{
+	Character,
+	NpcTemplate
+}
+
+public enum CombatSimulationRunStatus
+{
+	Completed,
+	Stalemate,
+	VirtualTimeLimit,
+	EventLimit,
+	WallClockLimit,
+	ValidationFailed,
+	Error
+}
+
+public enum CombatSimulationOutcome
+{
+	SurvivingWinner,
+	Dead,
+	Incapacitated,
+	FullGrappleControl,
+	Surrendered,
+	Fled,
+	Withdrew,
+	Stalemate,
+	Unknown
+}
+
+public sealed record CombatSimulationParticipantRequest(
+	int Slot,
+	string Team,
+	CombatSimulationSourceType SourceType,
+	ICharacter? Character,
+	INPCTemplate? NpcTemplate,
+	int Ordinal = 1)
+{
+	public string SourceDescription => SourceType switch
+	{
+		CombatSimulationSourceType.Character =>
+			$"character #{Character?.Id:N0} ({Character?.PersonalName.GetName(NameStyle.SimpleFull) ?? "unknown"})",
+		_ => $"NPC template #{NpcTemplate?.Id:N0} ({NpcTemplate?.Name ?? "unknown"})"
+	};
+}
+
+public sealed record CombatSimulationRequest(
+	Guid RunId,
+	ICharacter RequestedBy,
+	ICell Scene,
+	IReadOnlyList<CombatSimulationParticipantRequest> Participants,
+	int Seed,
+	TimeSpan MaximumVirtualTime,
+	int MaximumEvents,
+	int MaximumTranscriptEntries,
+	TimeSpan MaximumWallClockTime,
+	bool Force);
+
+public sealed record CombatSimulationBatchRequest(
+	Guid BatchId,
+	ICharacter RequestedBy,
+	ICell Scene,
+	IReadOnlyList<CombatSimulationParticipantRequest> Participants,
+	int FirstSeed,
+	int SeedIncrement,
+	int RunCount,
+	TimeSpan MaximumVirtualTime,
+	int MaximumEvents,
+	TimeSpan MaximumWallClockTime,
+	TimeSpan MaximumBatchWallClockTime,
+	bool Force);
+
+public sealed record CombatSimulationValidationMessage(bool IsError, string Message);
+
+public sealed record CombatSimulationParticipantResult(
+	int Slot,
+	string Team,
+	string Name,
+	CombatSimulationOutcome Outcome,
+	CharacterState FinalState,
+	double BloodRatio,
+	double StaminaRatio,
+	int WoundCount,
+	bool UnderFullGrappleControl);
+
+/// <summary>
+/// Component digests for diagnosing which part of two otherwise-identical simulation runs first diverged.
+/// </summary>
+public sealed record CombatSimulationExecutionTraceCheckpoint(
+	int EventCount,
+	int RandomOperations,
+	string RandomFingerprint,
+	int SchedulerTicks,
+	string SchedulerFingerprint,
+	int TranscriptEntries,
+	string TranscriptFingerprint);
+
+/// <summary>
+/// A bounded, tail-only record of seeded random operations. It is retained so an operator can identify the
+/// first random call that differs after a checkpoint reports a replay mismatch.
+/// </summary>
+public sealed record CombatSimulationRandomTraceEntry(int OperationIndex, string Description);
+
+/// <summary>
+/// A bounded record of the stable runtime state captured immediately after a combatant is materialised.
+/// It is retained for repeated-seed diagnostics so that a replay can distinguish materialisation drift
+/// from a later combat-ordering difference.
+/// </summary>
+public sealed record CombatSimulationMaterialisationTraceEntry(int OperationIndex, string Description);
+
+/// <summary>
+/// A bounded diagnostic record of deterministic simulation state transitions. It is populated only for
+/// repeated-seed batches so an operator can identify a branch that diverges before it consumes a different
+/// random value.
+/// </summary>
+public sealed record CombatSimulationStateTraceEntry(int OperationIndex, string Description);
+
+public sealed record CombatSimulationExecutionTraceSummary(
+	int MaterialisationOperations,
+	string MaterialisationFingerprint,
+	IReadOnlyList<CombatSimulationMaterialisationTraceEntry> MaterialisationEntries,
+	int RandomOperations,
+	string RandomFingerprint,
+	int SchedulerTicks,
+	string SchedulerFingerprint,
+	int TranscriptEntries,
+	string TranscriptFingerprint,
+	string TerminalFingerprint,
+	IReadOnlyList<CombatSimulationRandomTraceEntry> RecentRandomOperations,
+	IReadOnlyList<CombatSimulationStateTraceEntry> RecentStateOperations,
+	IReadOnlyList<CombatSimulationExecutionTraceCheckpoint> Checkpoints,
+	bool CheckpointsTruncated);
+
+public sealed record CombatSimulationResult(
+	Guid RunId,
+	CombatSimulationRunStatus Status,
+	string? WinningTeam,
+	int Seed,
+	TimeSpan VirtualDuration,
+	TimeSpan WallClockDuration,
+	int EventCount,
+	IReadOnlyList<CombatSimulationParticipantResult> Participants,
+	IReadOnlyList<CombatSimulationValidationMessage> Validation,
+	IReadOnlyList<string> Transcript,
+	bool TranscriptTruncated,
+	string ExecutionFingerprint,
+	CombatSimulationExecutionTraceSummary ExecutionTrace,
+	string? ErrorMessage = null);
+
+public sealed record CombatSimulationBatchTeamResult(
+	string Team,
+	int Wins,
+	double WinRate);
+
+public sealed record CombatSimulationBatchStatusResult(
+	CombatSimulationRunStatus Status,
+	int Count);
+
+public sealed record CombatSimulationBatchOutcomeResult(
+	CombatSimulationOutcome Outcome,
+	int Count);
+
+public sealed record CombatSimulationBatchResult(
+	Guid BatchId,
+	int FirstSeed,
+	int SeedIncrement,
+	int RequestedRunCount,
+	IReadOnlyList<CombatSimulationResult> Runs,
+	IReadOnlyList<CombatSimulationBatchTeamResult> Teams,
+	IReadOnlyList<CombatSimulationBatchStatusResult> Statuses,
+	IReadOnlyList<CombatSimulationBatchOutcomeResult> Outcomes,
+	TimeSpan TotalVirtualDuration,
+	TimeSpan AverageVirtualDuration,
+	TimeSpan FastestVirtualDuration,
+	TimeSpan SlowestVirtualDuration,
+	TimeSpan TotalWallClockDuration,
+	TimeSpan AverageWallClockDuration,
+	TimeSpan BatchWallClockDuration,
+	IReadOnlyList<CombatSimulationValidationMessage> Validation,
+	string? ErrorMessage = null);
+
+public interface ICombatSimulationService
+{
+	IReadOnlyList<CombatSimulationValidationMessage> Validate(CombatSimulationRequest request);
+	IReadOnlyList<CombatSimulationValidationMessage> ValidateBatch(CombatSimulationBatchRequest request);
+	CombatSimulationResult Run(CombatSimulationRequest request);
+	CombatSimulationBatchResult RunBatch(CombatSimulationBatchRequest request);
+}
+
+/// <summary>
+/// Removes a transient simulation actor from registries without placing it in the ordinary
+/// offline-character cache.
+/// </summary>
+public interface ICombatSimulationRuntimeRegistry
+{
+	void ForgetCombatSimulationActor(ICharacter actor);
+}
+
+/// <summary>
+/// Optional combat contract used by team-aware combat implementations to supply a replacement target.
+/// </summary>
+public interface ICombatTargetingPolicy
+{
+	IPerceiver? AcquireTargetFor(IPerceiver combatant);
+}

--- a/FutureMUDLibrary/Framework/Constants.cs
+++ b/FutureMUDLibrary/Framework/Constants.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
+using System.Threading;
 
 namespace MudSharp.Framework
 {
@@ -31,8 +32,34 @@ namespace MudSharp.Framework
         public static readonly char[] CommandSeparators = { ' ' };
         public static readonly char[] WordSeparators = { ' ' };
 
-        public static readonly Random Random = new();
+		private static readonly Random _systemRandom = new();
+		private static readonly AsyncLocal<Random> _ambientRandom = new();
+		public static Random Random => _ambientRandom.Value ?? _systemRandom;
         public static readonly RandomNumberGenerator CryptoRandom = RandomNumberGenerator.Create();
+
+		public static IDisposable PushRandom(Random random)
+		{
+			ArgumentNullException.ThrowIfNull(random);
+			var previous = _ambientRandom.Value;
+			_ambientRandom.Value = random;
+			return new AmbientRandomScope(previous);
+		}
+
+		private sealed class AmbientRandomScope(Random previous) : IDisposable
+		{
+			private bool _disposed;
+
+			public void Dispose()
+			{
+				if (_disposed)
+				{
+					return;
+				}
+
+				_ambientRandom.Value = previous;
+				_disposed = true;
+			}
+		}
 
         public static readonly string[] CardinalDirectionStrings = {
             "n", "e", "s", "w", "u", "d",

--- a/FutureMUDLibrary/Framework/RandomUtilities.cs
+++ b/FutureMUDLibrary/Framework/RandomUtilities.cs
@@ -224,7 +224,7 @@ namespace MudSharp.Framework
                 return list;
             }
 
-            return list.Shuffle().Take(picks);
+            return list.OldShuffle().Take(picks);
         }
 
         public static IEnumerable<T> TakeRandom<T>(this IEnumerable<T> input, int picks, Func<T, double> weightSelector)
@@ -282,7 +282,7 @@ namespace MudSharp.Framework
             {
                 bools[i] = true;
             }
-            bools.Shuffle();
+            bools.OldShuffle();
 
             return new Queue<bool>(bools);
         }

--- a/FutureMUDLibrary/Framework/Scheduling/IScheduler.cs
+++ b/FutureMUDLibrary/Framework/Scheduling/IScheduler.cs
@@ -5,6 +5,8 @@ namespace MudSharp.Framework.Scheduling
 {
     public interface IScheduler
     {
+		DateTime? NextTriggerUtc { get; }
+		int LastCheckFiredCount { get; }
         void AddSchedule(ISchedule schedule);
         void AddOrDelaySchedule(ISchedule schedule, IFrameworkItem item);
         void CheckSchedules();

--- a/MudSharpCore Unit Tests/CombatSimulationTests.cs
+++ b/MudSharpCore Unit Tests/CombatSimulationTests.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Character;
+using MudSharp.Combat;
+using MudSharp.Combat.Simulation;
+using MudSharp.Construction;
+using MudSharp.Framework;
+using MudSharp.Framework.Scheduling;
+using MudSharp.NPC.Templates;
+using MudSharp.RPG.Law;
+
+#nullable enable
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class CombatSimulationTests
+{
+	[TestMethod]
+	[DataRow(null, true)]
+	[DataRow("", true)]
+	[DataRow("Production", true)]
+	[DataRow("staging", true)]
+	[DataRow("Development", false)]
+	[DataRow("dev", false)]
+	[DataRow("Test", false)]
+	[DataRow("local", false)]
+	public void IsProductionEnvironment_KnownAndUnknownValues_UsesFailClosedPolicy(
+		string? environment,
+		bool expected)
+	{
+		Assert.AreEqual(expected, CombatSimulationCommand.IsProductionEnvironment(environment));
+	}
+
+	[TestMethod]
+	public void Validate_TwoTeamsAndValidLimits_HasNoStructuralErrors()
+	{
+		var request = CreateRequest("red", "blue");
+
+		var messages = new CombatSimulationService().Validate(request);
+
+		Assert.IsFalse(messages.Any(x => x.IsError));
+	}
+
+	[TestMethod]
+	public void Validate_OnlyOneTeam_ReturnsStructuralError()
+	{
+		var request = CreateRequest("red", "RED");
+
+		var messages = new CombatSimulationService().Validate(request);
+
+		Assert.IsTrue(messages.Any(x => x.IsError && x.Message.Contains("opposing teams")));
+	}
+
+	[TestMethod]
+	public void ConstantsPushRandom_SameSeed_ReplaysSequenceAndRestoresAmbientValue()
+	{
+		int[] first;
+		int[] second;
+		using (MudSharp.Framework.Constants.PushRandom(new Random(8675309)))
+		{
+			first = Enumerable.Range(0, 5)
+				.Select(_ => MudSharp.Framework.Constants.Random.Next())
+				.ToArray();
+		}
+
+		using (MudSharp.Framework.Constants.PushRandom(new Random(8675309)))
+		{
+			second = Enumerable.Range(0, 5)
+				.Select(_ => MudSharp.Framework.Constants.Random.Next())
+				.ToArray();
+		}
+
+		CollectionAssert.AreEqual(first, second);
+	}
+
+	[TestMethod]
+	public void RuntimeSideEffectContext_NestedScopes_RestorePreviousPolicy()
+	{
+		Assert.IsFalse(RuntimeSideEffectContext.IsCrimeCreationSuppressed);
+
+		using (RuntimeSideEffectContext.SuppressCrimeCreation())
+		{
+			Assert.IsTrue(RuntimeSideEffectContext.IsCrimeCreationSuppressed);
+			using (RuntimeSideEffectContext.SuppressCrimeCreation())
+			{
+				Assert.IsTrue(RuntimeSideEffectContext.IsCrimeCreationSuppressed);
+			}
+
+			Assert.IsTrue(RuntimeSideEffectContext.IsCrimeCreationSuppressed);
+		}
+
+		Assert.IsFalse(RuntimeSideEffectContext.IsCrimeCreationSuppressed);
+	}
+
+	[TestMethod]
+	public void LegalAuthorityCheckPossibleCrime_Suppressed_CreatesNoCrime()
+	{
+		var authority = (LegalAuthority)RuntimeHelpers.GetUninitializedObject(typeof(LegalAuthority));
+		var criminal = new Mock<ICharacter>();
+
+		using var scope = RuntimeSideEffectContext.SuppressCrimeCreation();
+		var crimes = authority.CheckPossibleCrime(criminal.Object, CrimeTypes.Murder, null!, null!, string.Empty,
+			null!, true, null!).ToList();
+
+		Assert.AreEqual(0, crimes.Count);
+	}
+
+	[TestMethod]
+	public void CombatSimulationRuntimeScope_SameSeedAndEpoch_ReplaysAmbientStateAndRestoresPolicy()
+	{
+		var epoch = new DateTimeOffset(2030, 4, 5, 6, 7, 8, TimeSpan.Zero);
+		var gameworld = new Mock<IFuturemud>();
+		int[] first;
+		int[] second;
+		double[] firstExpressions;
+		double[] secondExpressions;
+		var expression = new ExpressionEngine.Expression("rand(1,1000000) + dice(2,1000000)");
+		var firstFingerprint = new CombatSimulationExecutionFingerprint(8675309);
+
+		using (new CombatSimulationRuntimeScope(gameworld.Object, new AdvancingTimeProvider(epoch), 8675309,
+				firstFingerprint))
+		{
+			Assert.AreEqual(epoch.UtcDateTime, RuntimeClock.UtcNow);
+			Assert.IsTrue(RuntimeSideEffectContext.IsCrimeCreationSuppressed);
+			first = Enumerable.Range(0, 5)
+				.Select(_ => Constants.Random.Next())
+				.ToArray();
+			firstExpressions = Enumerable.Range(0, 5)
+				.Select(_ => expression.EvaluateDouble())
+				.ToArray();
+		}
+
+		Assert.IsFalse(RuntimeSideEffectContext.IsCrimeCreationSuppressed);
+		var secondFingerprint = new CombatSimulationExecutionFingerprint(8675309);
+		using (new CombatSimulationRuntimeScope(gameworld.Object, new AdvancingTimeProvider(epoch), 8675309,
+				secondFingerprint))
+		{
+			second = Enumerable.Range(0, 5)
+				.Select(_ => Constants.Random.Next())
+				.ToArray();
+			secondExpressions = Enumerable.Range(0, 5)
+				.Select(_ => expression.EvaluateDouble())
+				.ToArray();
+		}
+
+		CollectionAssert.AreEqual(first, second);
+		CollectionAssert.AreEqual(firstExpressions, secondExpressions);
+		Assert.AreEqual(
+			firstFingerprint.Complete(CombatSimulationRunStatus.Completed, "red", TimeSpan.FromSeconds(1), 10, []),
+			secondFingerprint.Complete(CombatSimulationRunStatus.Completed, "red", TimeSpan.FromSeconds(1), 10, []));
+		Assert.IsFalse(RuntimeSideEffectContext.IsCrimeCreationSuppressed);
+	}
+
+	[TestMethod]
+	public void CombatSimulationRuntimeScope_DoesNotFlowSandboxServicesToChildWork()
+	{
+		var epoch = new DateTimeOffset(2030, 4, 5, 6, 7, 8, TimeSpan.Zero);
+		var gameworld = new Mock<IFuturemud>();
+
+		using var scope = new CombatSimulationRuntimeScope(gameworld.Object, new AdvancingTimeProvider(epoch),
+			8675309, new CombatSimulationExecutionFingerprint(8675309));
+		var childState = Task.Run(() =>
+			(RuntimeClock.UtcNow, RuntimeSideEffectContext.IsCrimeCreationSuppressed))
+			.GetAwaiter()
+			.GetResult();
+
+		Assert.AreNotEqual(epoch.UtcDateTime, childState.Item1);
+		Assert.IsFalse(childState.Item2);
+	}
+
+	[TestMethod]
+	public void CombatSimulationExecutionFingerprint_DifferentTrace_ProducesDifferentDigest()
+	{
+		var first = new CombatSimulationExecutionFingerprint(1234);
+		first.RecordRandom("next", 5);
+		var second = new CombatSimulationExecutionFingerprint(1234);
+		second.RecordRandom("next", 6);
+
+		Assert.AreNotEqual(
+			first.Complete(CombatSimulationRunStatus.Completed, "red", TimeSpan.Zero, 1, []),
+			second.Complete(CombatSimulationRunStatus.Completed, "red", TimeSpan.Zero, 1, []));
+	}
+
+	[TestMethod]
+	public void Validate_ManualCombatSettings_ReportsNoInputRisks()
+	{
+		var settings = new Mock<ICharacterCombatSettings>();
+		settings.SetupGet(x => x.InventoryManagement).Returns(AutomaticInventorySettings.FullyManual);
+		settings.SetupGet(x => x.MovementManagement).Returns(AutomaticMovementSettings.FullyManual);
+		settings.SetupGet(x => x.ManualPositionManagement).Returns(true);
+		settings.SetupGet(x => x.RangedManagement).Returns(AutomaticRangedSettings.FullyManual);
+		var request = CreateRequest("red", "blue", settings.Object);
+
+		var messages = new CombatSimulationService().Validate(request);
+
+		Assert.IsTrue(messages.Any(x => x.Message.Contains("manual inventory")));
+		Assert.IsTrue(messages.Any(x => x.Message.Contains("manual movement")));
+		Assert.IsTrue(messages.Any(x => x.Message.Contains("manual ranged")));
+		Assert.IsTrue(messages.Any(x => x.Message.Contains("no weighted automatic attack")));
+	}
+
+	[TestMethod]
+	public void CombatSimulationCell_DatabaseLocationId_UsesPersistentSourceCell()
+	{
+		var source = new Mock<ICell>();
+		source.SetupGet(x => x.Id).Returns(42L);
+		source.SetupGet(x => x.Gameworld).Returns(new Mock<MudSharp.Framework.IFuturemud>().Object);
+		source.SetupGet(x => x.Overlays).Returns(Array.Empty<ICellOverlay>());
+
+		var simulationCell = new Cell(source.Object, -1L);
+
+		Assert.AreEqual(-1L, simulationCell.Id);
+		Assert.AreEqual(42L, simulationCell.DatabaseLocationId);
+	}
+
+	[TestMethod]
+	public void CombatSimulationRunStatus_DescribeEnum_ProducesReadableStatus()
+	{
+		Assert.AreEqual("Event Limit", CombatSimulationRunStatus.EventLimit.DescribeEnum(true));
+	}
+
+	[TestMethod]
+	public void ValidateBatch_ValidSeedSequence_HasNoStructuralErrors()
+	{
+		var messages = new CombatSimulationService().ValidateBatch(CreateBatchRequest(1_000, 25, 5));
+
+		Assert.IsFalse(messages.Any(x => x.IsError));
+	}
+
+	[TestMethod]
+	public void ValidateBatch_OverflowingSeedSequence_ReportsError()
+	{
+		var messages = new CombatSimulationService().ValidateBatch(CreateBatchRequest(int.MaxValue, 1, 2));
+
+		Assert.IsTrue(messages.Any(x => x.IsError && x.Message.Contains("32-bit seed")));
+	}
+
+	private static CombatSimulationBatchRequest CreateBatchRequest(int firstSeed, int seedIncrement, int runCount)
+	{
+		var request = CreateRequest("red", "blue");
+		return new CombatSimulationBatchRequest(
+			Guid.NewGuid(),
+			request.RequestedBy,
+			request.Scene,
+			request.Participants,
+			firstSeed,
+			seedIncrement,
+			runCount,
+			request.MaximumVirtualTime,
+			request.MaximumEvents,
+			request.MaximumWallClockTime,
+			TimeSpan.FromMinutes(10),
+			true);
+	}
+
+	private static CombatSimulationRequest CreateRequest(
+		string firstTeam,
+		string secondTeam,
+		ICharacterCombatSettings? firstSettings = null)
+	{
+		var first = new Mock<INPCTemplate>();
+		first.SetupGet(x => x.Id).Returns(1);
+		first.SetupGet(x => x.Name).Returns("First");
+		first.SetupGet(x => x.DefaultCombatSetting).Returns(firstSettings);
+		var second = new Mock<INPCTemplate>();
+		second.SetupGet(x => x.Id).Returns(2);
+		second.SetupGet(x => x.Name).Returns("Second");
+		return new CombatSimulationRequest(
+			Guid.NewGuid(),
+			new Mock<ICharacter>().Object,
+			new Mock<ICell>().Object,
+			[
+				new CombatSimulationParticipantRequest(1, firstTeam,
+					CombatSimulationSourceType.NpcTemplate, null, first.Object),
+				new CombatSimulationParticipantRequest(2, secondTeam,
+					CombatSimulationSourceType.NpcTemplate, null, second.Object)
+			],
+			12345,
+			TimeSpan.FromMinutes(30),
+			100_000,
+			10_000,
+			TimeSpan.FromSeconds(60),
+			false);
+	}
+}

--- a/MudSharpCore Unit Tests/RuntimeSchedulerTests.cs
+++ b/MudSharpCore Unit Tests/RuntimeSchedulerTests.cs
@@ -29,6 +29,38 @@ public class RuntimeSchedulerTests
 	}
 
 	[TestMethod]
+	public void SchedulerDiagnostics_QueuedAndFiredSchedules_ReportNextTriggerAndCount()
+	{
+		var now = DateTimeOffset.UtcNow;
+		var time = new ManualTimeProvider(now);
+		var scheduler = new Scheduler(time);
+		var fired = new List<string>();
+		var trigger = now.UtcDateTime.AddSeconds(2);
+		scheduler.AddSchedule(CreateSchedule("first", trigger, fired));
+		scheduler.AddSchedule(CreateSchedule("second", trigger, fired));
+
+		Assert.AreEqual(trigger, scheduler.NextTriggerUtc);
+		time.Advance(TimeSpan.FromSeconds(2));
+		scheduler.CheckSchedules();
+
+		Assert.AreEqual(2, scheduler.LastCheckFiredCount);
+		Assert.IsNull(scheduler.NextTriggerUtc);
+	}
+
+	[TestMethod]
+	public void ScheduleBase_AmbientRuntimeClock_UsesVirtualCreationTime()
+	{
+		var virtualNow = new DateTimeOffset(2042, 3, 4, 5, 6, 7, TimeSpan.Zero);
+		var time = new ManualTimeProvider(virtualNow);
+		using var scope = RuntimeClock.Push(time);
+
+		var schedule = new Schedule(() => { }, ScheduleType.System, TimeSpan.FromSeconds(3), "virtual");
+
+		Assert.AreEqual(virtualNow.UtcDateTime, schedule.CreatedAt);
+		Assert.AreEqual(virtualNow.UtcDateTime.AddSeconds(3), schedule.TriggerETA);
+	}
+
+	[TestMethod]
 	public void CheckSchedules_CallbackAddsDueSchedule_FiresAddedScheduleInSameCheck()
 	{
 		var time = new ManualTimeProvider(DateTimeOffset.UtcNow);

--- a/MudSharpCore/Body/Implementations/BodyBiology.cs
+++ b/MudSharpCore/Body/Implementations/BodyBiology.cs
@@ -4,6 +4,7 @@ using MudSharp.Body.Position;
 using MudSharp.Body.Position.PositionStates;
 using MudSharp.Character.Heritage;
 using MudSharp.Combat;
+using MudSharp.Combat.Simulation;
 using MudSharp.Construction;
 using MudSharp.Effects.Concrete;
 using MudSharp.Events;
@@ -19,6 +20,7 @@ using MudSharp.RPG.AIStorytellers;
 using MudSharp.RPG.Merits.Interfaces;
 using MudSharp.Work.Projects.Impacts;
 using ExpressionEngine;
+using MoreLinq;
 
 namespace MudSharp.Body.Implementations;
 
@@ -1043,6 +1045,7 @@ public partial class Body
             x => x.GetSubtype<IEffectRemoveOnDamage>()?.RemovesWith(damage1) ?? false);
         if (isplainbodypart)
         {
+			RecordSimulationDamageState(damage, internalDamage);
             if (!CheckBoneDamage(ref damage, ref wounds, ref internalDamage, true, sb))
             {
                 CheckOrganDamage(ref damage, wounds, ref internalDamage, true, sb);
@@ -1082,6 +1085,33 @@ public partial class Body
         wounds.AddRange(newWounds);
         return wounds;
     }
+
+	private void RecordSimulationDamageState(IDamage damage, IDamage internalDamage)
+	{
+		var scope = CombatSimulationRuntimeScope.Current;
+		if (scope?.ExecutionFingerprint.CaptureRandomCallSites != true)
+		{
+			return;
+		}
+
+		var bodypart = damage.Bodypart;
+		var breakability = CanBreakBones(damage);
+		var bones = bodypart?.BoneInfo
+			.Where(x => Bones.Contains(x.Key))
+			.OrderBy(x => x.Key.Id)
+			.Select(x => x.Key.Id.ToString(System.Globalization.CultureInfo.InvariantCulture))
+			.ListToString(separator: ",", conjunction: string.Empty, twoItemJoiner: ",") ?? string.Empty;
+		var organs = bodypart?.OrganInfo
+			.Where(x => Organs.Contains(x.Key))
+			.OrderBy(x => x.Key.Id)
+			.Select(x => x.Key.Id.ToString(System.Globalization.CultureInfo.InvariantCulture))
+			.ListToString(separator: ",", conjunction: string.Empty, twoItemJoiner: ",") ?? string.Empty;
+		var internalDamageDescription = internalDamage is null
+			? "none"
+			: $"{(int)internalDamage.DamageType}:{internalDamage.DamageAmount.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}:{internalDamage.PainAmount.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}:{internalDamage.StunAmount.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}";
+		scope.ExecutionFingerprint.RecordState(
+			$"damage actor:{Actor.Id} part:{bodypart?.Id ?? 0} type:{(int)damage.DamageType} amount:{damage.DamageAmount.ToString("R", System.Globalization.CultureInfo.InvariantCulture)} pain:{damage.PainAmount.ToString("R", System.Globalization.CultureInfo.InvariantCulture)} stun:{damage.StunAmount.ToString("R", System.Globalization.CultureInfo.InvariantCulture)} break:{breakability.Truth}/{breakability.All}/{breakability.Group} bones:{bones} organs:{organs} internal:{internalDamageDescription}");
+	}
 
     private bool ShouldSever(IDamage damage)
     {
@@ -1143,7 +1173,11 @@ public partial class Body
         (bool damageOrgans, bool damageAllOrgans, bool highChance) = CanDamageOrgans(internalDamage);
         if (damage.Bodypart.Organs.Any() && internalDamage != null && damageOrgans)
         {
-            foreach (KeyValuePair<IOrganProto, BodypartInternalInfo> organInfo in damage.Bodypart.OrganInfo.Where(x => Organs.Contains(x.Key)).Shuffle().ToList())
+			foreach (KeyValuePair<IOrganProto, BodypartInternalInfo> organInfo in damage.Bodypart.OrganInfo
+						 .Where(x => Organs.Contains(x.Key))
+						 .OrderBy(x => x.Key.Id)
+						 .Shuffle(Constants.Random)
+						 .ToList())
             {
                 if (CheckOrganDamageSpecific(organInfo, internalDamage, damageAllOrgans, wounds, passive, highChance, sb))
                 {
@@ -1169,7 +1203,11 @@ public partial class Body
         if (damageBones && damage.Bodypart.Bones.Any())
         {
             bool boneWasHit = false;
-            foreach (KeyValuePair<IBone, BodypartInternalInfo> boneInfo in damage.Bodypart.BoneInfo.Where(x => Bones.Contains(x.Key)).Shuffle().ToList())
+			foreach (KeyValuePair<IBone, BodypartInternalInfo> boneInfo in damage.Bodypart.BoneInfo
+						 .Where(x => Bones.Contains(x.Key))
+						 .OrderBy(x => x.Key.Id)
+						 .Shuffle(Constants.Random)
+						 .ToList())
             {
                 IBone bone = boneInfo.Key;
                 double roll = Constants.Random.NextDouble();
@@ -1236,7 +1274,9 @@ public partial class Body
 
                 if (organDamage != null && organDamage.DamageAmount > 0)
                 {
-                    foreach ((IOrganProto Organ, BodypartInternalInfo Info) organ in bone.CoveredOrgans.Where(x => Organs.Contains(x.Organ)))
+                    foreach ((IOrganProto Organ, BodypartInternalInfo Info) organ in bone.CoveredOrgans
+                                 .Where(x => Organs.Contains(x.Organ))
+                                 .OrderBy(x => x.Organ.Id))
                     {
                         if (CheckOrganDamageSpecific(
                                 new KeyValuePair<IOrganProto, BodypartInternalInfo>(organ.Organ, organ.Info),

--- a/MudSharpCore/Body/Implementations/BodyCombatSimulation.cs
+++ b/MudSharpCore/Body/Implementations/BodyCombatSimulation.cs
@@ -1,0 +1,99 @@
+using MudSharp.Health;
+using MudSharp.Health.Infections;
+
+#nullable enable
+
+namespace MudSharp.Body.Implementations;
+
+public partial class Body
+{
+	internal void RestoreCombatSimulationEffects(XElement effects)
+	{
+		LoadEffects(effects);
+		ScheduleCachedEffects();
+	}
+
+	internal void CopyCombatSimulationBiologyFrom(IBody source)
+	{
+		_currentBloodVolumeLitres = Math.Clamp(source.CurrentBloodVolumeLitres, 0.0, TotalBloodVolumeLitres);
+		Changed = true;
+		CurrentStamina = source.CurrentStamina;
+		CurrentExertion = source.CurrentExertion;
+		LongtermExertion = source.LongtermExertion;
+		HeldBreathTime = source.HeldBreathTime;
+
+		foreach (var dosage in source.ActiveDrugDosages)
+		{
+			DoseImmediate(dosage.Drug, dosage.OriginalVector, dosage.Grams, dosage.Originator);
+		}
+
+		foreach (var dosage in source.LatentDrugDosages)
+		{
+			Dose(dosage.Drug, dosage.OriginalVector, dosage.Grams, dosage.Originator);
+		}
+
+		var woundMap = new Dictionary<IWound, IWound>(ReferenceEqualityComparer.Instance);
+		foreach (var sourceWound in source.Wounds)
+		{
+			var targetPart = sourceWound.Bodypart is null
+				? null
+				: Bodyparts.FirstOrDefault(x => x.Id == sourceWound.Bodypart.Id);
+			var wounds = SufferDamage(new Damage
+			{
+				DamageType = sourceWound.DamageType,
+				DamageAmount = sourceWound.OriginalDamage,
+				PainAmount = sourceWound.CurrentPain,
+				ShockAmount = sourceWound.CurrentShock,
+				StunAmount = sourceWound.CurrentStun,
+				Bodypart = targetPart
+			}).ToList();
+			var wound = wounds.FirstOrDefault(x => x.DamageType == sourceWound.DamageType) ?? wounds.FirstOrDefault();
+			if (wound is null)
+			{
+				continue;
+			}
+
+			wound.OriginalDamage = sourceWound.OriginalDamage;
+			wound.CurrentDamage = sourceWound.CurrentDamage;
+			wound.CurrentPain = sourceWound.CurrentPain;
+			wound.CurrentShock = sourceWound.CurrentShock;
+			wound.CurrentStun = sourceWound.CurrentStun;
+			wound.BleedStatus = sourceWound.BleedStatus;
+			woundMap[sourceWound] = wound;
+		}
+
+		foreach (var sourceInfection in source.PartInfections)
+		{
+			var targetWound = sourceInfection.Wound is not null && woundMap.TryGetValue(sourceInfection.Wound, out var wound)
+				? wound
+				: null;
+			var targetPart = sourceInfection.Bodypart is null
+				? null
+				: Bodyparts.Concat(Organs).FirstOrDefault(x => x.Id == sourceInfection.Bodypart.Id);
+			var infection = Infection.LoadNewInfection(
+				sourceInfection.InfectionType,
+				sourceInfection.VirulenceDifficulty,
+				sourceInfection.Intensity,
+				this,
+				targetWound,
+				targetPart,
+				sourceInfection.Virulence);
+			if (infection is Infection concreteInfection)
+			{
+				concreteInfection.Immunity = sourceInfection.Immunity;
+				if (sourceInfection is Infection concreteSource)
+				{
+					concreteInfection.InfectionStage = concreteSource.InfectionStage;
+				}
+			}
+
+			AddInfection(infection);
+			if (targetWound is not null)
+			{
+				targetWound.Infection = infection;
+			}
+		}
+
+		EvaluateWounds();
+	}
+}

--- a/MudSharpCore/Body/Implementations/BodyDrugs.cs
+++ b/MudSharpCore/Body/Implementations/BodyDrugs.cs
@@ -288,7 +288,7 @@ public partial class Body
         record = new DrugExposureRecord
         {
             Drug = drug,
-            LastUpdatedAtUtc = DateTime.UtcNow
+            LastUpdatedAtUtc = RuntimeClock.UtcNow
         };
         _drugExposureRecords.Add(record);
         DrugsChanged = true;
@@ -304,7 +304,7 @@ public partial class Body
             return;
         }
 
-        var now = DateTime.UtcNow;
+        var now = RuntimeClock.UtcNow;
         var activeDependentDrugs = ActiveDrugDosages
                                    .Select(x => x.Drug)
                                    .Where(x => DependenceInfoFor(x) is not null)

--- a/MudSharpCore/Body/Implementations/BodyParts.cs
+++ b/MudSharpCore/Body/Implementations/BodyParts.cs
@@ -1,6 +1,7 @@
 ﻿using MudSharp.Body.Disfigurements;
 using MudSharp.Database;
 using MudSharp.Construction;
+using MudSharp.Combat.Simulation;
 using MudSharp.Effects.Concrete;
 using MudSharp.Form.Material;
 using MudSharp.GameItems;
@@ -721,9 +722,27 @@ public partial class Body
         return result;
     }
 
-    public IBodypart RandomBodypart => Bodyparts.GetWeightedRandom(x => x.RelativeHitChance);
+    public IBodypart RandomBodypart
+    {
+        get
+        {
+            List<IBodypart> candidates = Bodyparts.OrderBy(x => x.Id).ToList();
+            IBodypart selected = candidates.GetWeightedRandom(x => x.RelativeHitChance);
+            RecordSimulationBodypartSelection("random", candidates, selected, string.Empty);
+            return selected;
+        }
+    }
 
-    public IBodypart RandomBodypartOrOrgan => Bodyparts.Concat(Organs).GetWeightedRandom(x => x.RelativeHitChance);
+    public IBodypart RandomBodypartOrOrgan
+    {
+        get
+        {
+            List<IBodypart> candidates = Bodyparts.Concat(Organs).OrderBy(x => x.Id).ToList();
+            IBodypart selected = candidates.GetWeightedRandom(x => x.RelativeHitChance);
+            RecordSimulationBodypartSelection("random-or-organ", candidates, selected, string.Empty);
+            return selected;
+        }
+    }
 
     public IBodypart RandomBodyPartGeometry(Orientation orientation, Alignment alignment, Facing facing,
         bool appendagesActive = false)
@@ -791,19 +810,28 @@ public partial class Body
             }
         }
 
-        return eligableBodyparts.GetWeightedRandom(x => x.RelativeHitChance) ??
-               RandomBodypart;
+        List<IBodypart> candidates = eligableBodyparts.OrderBy(x => x.Id).ToList();
+        IBodypart selected = candidates.GetWeightedRandom(x => x.RelativeHitChance) ?? RandomBodypart;
+        RecordSimulationBodypartSelection("geometry", candidates, selected,
+            $"orientation:{orientation} alignment:{alignment} facing:{facing} roll:{roll.Item1}/{roll.Item2}");
+        return selected;
     }
 
     public IBodypart RandomVitalBodypart(Facing facing)
     {
-        List<IBodypart> vitals = Bodyparts.Where(x => x.RelativeHitChance > 0 && x.IsVital).ToList();
+        List<IBodypart> vitals = Bodyparts
+            .Where(x => x.RelativeHitChance > 0 && x.IsVital)
+            .OrderBy(x => x.Id)
+            .ToList();
         if (!vitals.Any())
         {
-            vitals = Bodyparts.Where(x => x.Organs.Any()).ToList();
+            vitals = Bodyparts
+                .Where(x => x.Organs.Any())
+                .OrderBy(x => x.Id)
+                .ToList();
             if (!vitals.Any())
             {
-                vitals = Bodyparts.ToList();
+                vitals = Bodyparts.OrderBy(x => x.Id).ToList();
             }
         }
 
@@ -827,6 +855,32 @@ public partial class Body
 
         return vitals.GetRandomElement();
     }
+
+	private void RecordSimulationBodypartSelection(
+		string selector,
+		IEnumerable<IBodypart> candidates,
+		IBodypart selected,
+		string context)
+	{
+		var scope = CombatSimulationRuntimeScope.Current;
+		if (scope?.ExecutionFingerprint.CaptureRandomCallSites != true)
+		{
+			return;
+		}
+
+		var candidateIds = candidates
+			.Select(x => x.Id.ToString(System.Globalization.CultureInfo.InvariantCulture))
+			.ListToString(separator: ",", conjunction: string.Empty, twoItemJoiner: ",");
+		var callSite = string.Join(" <- ", new System.Diagnostics.StackTrace(1, false)
+			.GetFrames()?
+			.Select(x => x.GetMethod())
+			.Where(x => x?.DeclaringType?.Namespace?.StartsWith("MudSharp", StringComparison.Ordinal) == true)
+			.Select(x => x!)
+			.Take(5)
+			.Select(x => $"{x.DeclaringType!.Name}.{x.Name}") ?? []);
+		scope.ExecutionFingerprint.RecordState(
+			$"bodypart-selector:{selector} {context} candidates:{candidateIds} selected:{selected?.Id ?? 0} from:{callSite}");
+	}
 
     public ILimb GetLimbFor(IBodypart bodypart)
     {

--- a/MudSharpCore/Body/Traits/Subtypes/TheoreticalSkill.cs
+++ b/MudSharpCore/Body/Traits/Subtypes/TheoreticalSkill.cs
@@ -34,9 +34,8 @@ public class TheoreticalSkill : Trait
     {
         get
         {
-            _definition.ValueExpression.Parameters["theory"] = TheoreticalValue;
-            _definition.ValueExpression.Parameters["practical"] = PracticalValue;
-            return Convert.ToDouble(_definition.ValueExpression.Evaluate());
+            return _definition.ValueExpression.EvaluateDoubleWith(("theory", TheoreticalValue),
+                ("practical", PracticalValue));
         }
         set
         {

--- a/MudSharpCore/Body/Traits/TraitExpression.cs
+++ b/MudSharpCore/Body/Traits/TraitExpression.cs
@@ -305,108 +305,51 @@ public partial class TraitExpression : SaveableItem, ITraitExpression
     public double Evaluate(IHaveTraits owner, ITraitDefinition variable = null,
         TraitBonusContext context = TraitBonusContext.None)
     {
-        ProcessLazyLoading();
-
-        foreach (KeyValuePair<string, TraitExpressionParameter> param in Parameters)
-        {
-            Formula.Parameters[param.Key] = owner.TraitValue(param.Value.Trait, context);
-        }
-
-        if (variable != null)
-        {
-            Formula.Parameters["variable"] = owner.TraitValue(variable, context);
-        }
-        else
-        {
-            Formula.Parameters["variable"] = 0;
-        }
-
-        foreach (KeyValuePair<string, TraitExpressionExtendedOption> option in _options)
-        {
-            Formula.Parameters[option.Key] = option.Value.Evaluate(owner);
-        }
-
-#if DEBUG
-#else
-	try {
-#endif
-        return Convert.ToDouble(Formula.Evaluate());
-#if DEBUG
-#else
-	}
-	catch (Exception e)
-	{
-		Console.WriteLine($"Exception in TraitExpression #{Id.ToString("N0")} ({Formula.OriginalExpression}):\n\n{e.Message}");
-		return 0.0;
-	}
-#endif
+        return EvaluateInternal(owner, variable, context, false, Array.Empty<(string Name, object Value)>());
     }
 
     public double EvaluateWith(IHaveTraits owner, ITraitDefinition variable = null,
         TraitBonusContext context = TraitBonusContext.None, params (string Name, object Value)[] values)
     {
-        ProcessLazyLoading();
-        foreach ((string Name, object Value) value in values)
-        {
-            Formula.Parameters[value.Name] = value.Value;
-        }
-
-        foreach (KeyValuePair<string, TraitExpressionParameter> param in Parameters)
-        {
-            Formula.Parameters[param.Key] = owner.TraitValue(param.Value.Trait, context);
-        }
-
-        if (variable != null)
-        {
-            Formula.Parameters["variable"] = owner.TraitValue(variable, context);
-        }
-        else
-        {
-            Formula.Parameters["variable"] = 0;
-        }
-
-        foreach (KeyValuePair<string, TraitExpressionExtendedOption> option in _options)
-        {
-            Formula.Parameters[option.Key] = option.Value.Evaluate(owner);
-        }
-
-#if DEBUG
-#else
-	try {
-#endif
-        return Formula.EvaluateDouble();
-#if DEBUG
-#else
-	}
-	catch (Exception e)
-	{
-		Console.WriteLine($"Exception in TraitExpression #{Id.ToString("N0")} ({Formula.OriginalExpression}):\n\n{e.Message}");
-		return 0.0;
-	}
-#endif
-
+        return EvaluateInternal(owner, variable, context, false, values);
     }
 
     public double EvaluateMax(IHaveTraits owner)
     {
+        return EvaluateInternal(owner, null, TraitBonusContext.None, true, Array.Empty<(string Name, object Value)>());
+    }
+
+    private double EvaluateInternal(IHaveTraits owner, ITraitDefinition variable, TraitBonusContext context,
+        bool maximum, IEnumerable<(string Name, object Value)> values)
+    {
         ProcessLazyLoading();
+        Dictionary<string, object> evaluationValues = new(StringComparer.OrdinalIgnoreCase);
+        foreach ((string Name, object Value) value in values)
+        {
+            evaluationValues[value.Name] = value.Value;
+        }
 
         foreach (KeyValuePair<string, TraitExpressionParameter> param in Parameters)
         {
-            Formula.Parameters[param.Key] = owner.TraitMaxValue(param.Value.Trait);
+            evaluationValues[param.Key] = maximum
+                ? owner.TraitMaxValue(param.Value.Trait)
+                : owner.TraitValue(param.Value.Trait, context);
         }
+
+        evaluationValues["variable"] = variable is null || maximum
+            ? 0.0
+            : owner.TraitValue(variable, context);
 
         foreach (KeyValuePair<string, TraitExpressionExtendedOption> option in _options)
         {
-            Formula.Parameters[option.Key] = option.Value.Evaluate(owner);
+            evaluationValues[option.Key] = option.Value.Evaluate(owner);
         }
 
 #if DEBUG
 #else
 	try {
 #endif
-
-        return Convert.ToDouble(Formula.Evaluate());
+        return Formula.EvaluateDoubleWith(evaluationValues);
 #if DEBUG
 #else
 	}

--- a/MudSharpCore/Character/Character.cs
+++ b/MudSharpCore/Character/Character.cs
@@ -34,6 +34,7 @@ using MudSharp.Form.Characteristics;
 using MudSharp.Form.Material;
 using MudSharp.Framework.Revision;
 using MudSharp.Framework.Save;
+using MudSharp.Framework.Scheduling;
 using MudSharp.Framework.Units;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Inventory;
@@ -140,7 +141,7 @@ public partial class Character : PerceiverItem, ICharacter, ICharacterIdentity, 
 
 
         CommandTree = Gameworld.RetrieveAppropriateCommandTree(this);
-        LoginDateTime = DateTime.UtcNow;
+        LoginDateTime = RuntimeClock.UtcNow;
         LastMinutesUpdate = LoginDateTime;
         _dbTotalMinutesPlayed = 0;
         PositionState = PositionStanding.Instance;
@@ -1417,10 +1418,10 @@ public partial class Character : PerceiverItem, ICharacter, ICharacterIdentity, 
 
         Models.Character dbitem = new()
         {
-            Location = base.Location?.Id ?? 1L,
+			Location = DatabaseLocationId ?? 1L,
             Gender = (short)Gender.Enum,
             CultureId = Culture.Id,
-            CreationTime = DateTime.UtcNow,
+            CreationTime = RuntimeClock.UtcNow,
             CurrencyId = Currency?.Id,
             Body = (MudSharp.Models.Body)Body.DatabaseInsert(),
             DominantHandAlignment = (int)Handedness,
@@ -1501,7 +1502,7 @@ public partial class Character : PerceiverItem, ICharacter, ICharacterIdentity, 
             {
                 Character = dbitem,
                 KnowledgeId = knowledge.Knowledge.Id,
-                WhenAcquired = DateTime.UtcNow,
+                WhenAcquired = RuntimeClock.UtcNow,
                 TimesTaught = 0,
                 HowAcquired = "Chargen"
             };
@@ -2097,7 +2098,7 @@ public partial class Character : PerceiverItem, ICharacter, ICharacterIdentity, 
     public ICharacterCommandTree CommandTree { get; protected set; }
 
     private int _dbTotalMinutesPlayed;
-    public int TotalMinutesPlayed => _dbTotalMinutesPlayed + (int)(DateTime.UtcNow - LastMinutesUpdate).TotalMinutes;
+    public int TotalMinutesPlayed => _dbTotalMinutesPlayed + (int)(RuntimeClock.UtcNow - LastMinutesUpdate).TotalMinutes;
 
     public ILanguageScrambler LanguageScrambler { get; protected set; }
 
@@ -2428,7 +2429,7 @@ public partial class Character : PerceiverItem, ICharacter, ICharacterIdentity, 
             using (new FMDB())
             {
                 Models.Character dbchar = FMDB.Context.Characters.Find(Id);
-                dbchar.LastLogoutTime = DateTime.UtcNow;
+                dbchar.LastLogoutTime = RuntimeClock.UtcNow;
                 var logoutState = State | CharacterState.Stasis;
                 SaveCompatibilityWorldPresence(dbchar, logoutState);
                 SavePrimaryInstance(dbchar, logoutState);
@@ -2436,7 +2437,7 @@ public partial class Character : PerceiverItem, ICharacter, ICharacterIdentity, 
                 FMDB.Context.SaveChanges();
             }
 
-            LastLogoutDateTime = DateTime.UtcNow;
+            LastLogoutDateTime = RuntimeClock.UtcNow;
         }
 
         InvalidatePositionTargets();
@@ -2484,7 +2485,7 @@ public partial class Character : PerceiverItem, ICharacter, ICharacterIdentity, 
         }
 
         ScheduleCachedEffects();
-        LoginDateTime = DateTime.UtcNow;
+        LoginDateTime = RuntimeClock.UtcNow;
         OutputHandler.Handle(new EmoteOutput(new Emote("@ has entered the area.", this),
             flags: OutputFlags.SuppressObscured | OutputFlags.SuppressSource));
         HandleEvent(EventType.CharacterEntersGame, this);
@@ -2613,7 +2614,7 @@ public partial class Character : PerceiverItem, ICharacter, ICharacterIdentity, 
             return;
         }
 
-        DateTime now = DateTime.UtcNow;
+        DateTime now = RuntimeClock.UtcNow;
         if (dbchar == null)
         {
             dbchar = FMDB.Context.Characters.Find(Id);
@@ -3328,7 +3329,7 @@ public partial class Character : PerceiverItem, ICharacter, ICharacterIdentity, 
             return false;
         }
 
-        dub.LastUsage = DateTime.UtcNow;
+        dub.LastUsage = RuntimeClock.UtcNow;
         dub.LastDescription = perceivable.HowSeen(this, colour: false, flags: PerceiveIgnoreFlags.IgnoreNamesSetting);
         dub.Changed = true;
         return true;
@@ -3352,7 +3353,7 @@ public partial class Character : PerceiverItem, ICharacter, ICharacterIdentity, 
             return false;
         }
 
-        dub.LastUsage = DateTime.UtcNow;
+        dub.LastUsage = RuntimeClock.UtcNow;
         dub.LastDescription = perceivable.HowSeen(this, colour: false, flags: PerceiveIgnoreFlags.IgnoreNamesSetting);
         dub.Changed = true;
         return true;

--- a/MudSharpCore/Character/CharacterCombat.cs
+++ b/MudSharpCore/Character/CharacterCombat.cs
@@ -1,5 +1,6 @@
 ﻿using MudSharp.Body;
 using MudSharp.Combat;
+using MudSharp.Combat.Simulation;
 using MudSharp.Combat.Moves;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
@@ -170,6 +171,25 @@ public partial class Character
         {
             return;
         }
+
+		if (Combat is ICombatTargetingPolicy targetingPolicy)
+		{
+			var policyTarget = targetingPolicy.AcquireTargetFor(this);
+			if (policyTarget is not null)
+			{
+				CombatTarget = policyTarget;
+				if (policyTarget.CombatTarget == this)
+				{
+					EngageMutually();
+				}
+				else
+				{
+					EngageAlreadyEngaged();
+				}
+
+				return;
+			}
+		}
 
         if (CombatTarget != null)
         {

--- a/MudSharpCore/Character/CharacterCombatSimulation.cs
+++ b/MudSharpCore/Character/CharacterCombatSimulation.cs
@@ -1,0 +1,44 @@
+using MudSharp.Body.Needs;
+using MudSharp.Framework.Save;
+
+#nullable enable
+
+namespace MudSharp.Character;
+
+public partial class Character
+{
+	internal void DetachCombatSimulationLocation()
+	{
+		Location = null;
+	}
+
+	internal void RestoreCombatSimulationEffects(XElement effects)
+	{
+		LoadEffects(effects);
+		ScheduleCachedEffects();
+	}
+
+	internal void CopyCombatSimulationStateFrom(ICharacter source)
+	{
+		NeedsModel = NeedsModelFactory.ConvertNeedsModel(source.NeedsModel.ModelName, this, source.NeedsModel);
+		State = source.State;
+		CombatSettings = source.CombatSettings;
+		CombatStrategyMode = source.CombatStrategyMode;
+		PositionState = source.PositionState;
+		PositionModifier = source.PositionModifier;
+	}
+
+	internal void InitialiseCombatSimulationIdentity(long characterId, long bodyId, long instanceId)
+	{
+		InitialiseWithoutPersistence(characterId);
+		if (Body is LateKeywordedInitialisingItem body)
+		{
+			body.InitialiseWithoutPersistence(bodyId);
+		}
+
+		_handedness = Body.Handedness;
+		_instanceId = instanceId;
+		Body.BaseLiverAlcoholRemovalKilogramsPerHour = LiverFunction(this);
+		RevalidateCombatSettingsAfterInitialisation();
+	}
+}

--- a/MudSharpCore/Character/CharacterHealth.cs
+++ b/MudSharpCore/Character/CharacterHealth.cs
@@ -14,6 +14,7 @@ using MudSharp.GameItems;
 using MudSharp.GameItems.Prototypes;
 using MudSharp.Health;
 using MudSharp.Health.Breathing;
+using MudSharp.Framework.Scheduling;
 using MudSharp.Menus;
 using MudSharp.Models;
 using MudSharp.PerceptionEngine.Handlers;
@@ -163,7 +164,7 @@ public partial class Character
             SaveMinutes(null);
             dbchar.State = (int)CharacterState.Dead;
             dbchar.Status = (int)CharacterStatus.Deceased;
-            dbchar.DeathTime = DateTime.UtcNow;
+            dbchar.DeathTime = RuntimeClock.UtcNow;
             dbchar.NeedsModel = "NoNeeds";
             SaveCompatibilityWorldPresence(dbchar);
             SavePrimaryInstance(dbchar);
@@ -203,7 +204,7 @@ public partial class Character
             FMDB.Context.SaveChanges();
         }
 
-        LoginDateTime = DateTime.UtcNow;
+        LoginDateTime = RuntimeClock.UtcNow;
         LastMinutesUpdate = LoginDateTime;
         StartNeedsHeartbeat();
         ResumeMagicResourceGeneratorHeartbeats();

--- a/MudSharpCore/Character/CharacterInstanceService.cs
+++ b/MudSharpCore/Character/CharacterInstanceService.cs
@@ -8,6 +8,7 @@ using MudSharp.Construction;
 using MudSharp.Database;
 using MudSharp.Form.Shape;
 using MudSharp.Framework;
+using MudSharp.Framework.Scheduling;
 using MudSharp.GameItems;
 using MudSharp.Models;
 using MudSharp.NPC;
@@ -567,7 +568,7 @@ public static class CharacterInstanceService
 				IsPrimary = false,
 				IsEmbodied = true,
 				IsControllable = true,
-				CreatedDateTime = DateTime.UtcNow,
+				CreatedDateTime = RuntimeClock.UtcNow,
 				EffectData = CharacterInstanceMetadata.CreatePossessedCorpseEffectData(
 					anchorCharacterId,
 					anchorInstanceId,
@@ -697,7 +698,7 @@ public static class CharacterInstanceService
 				IsPrimary = false,
 				IsEmbodied = true,
 				IsControllable = true,
-				CreatedDateTime = DateTime.UtcNow,
+				CreatedDateTime = RuntimeClock.UtcNow,
 				EffectData = CharacterInstanceMetadata.CreateAnimatedCorpseEffectData(
 					anchorCharacterId,
 					anchorInstanceId,
@@ -978,7 +979,7 @@ public static class CharacterInstanceService
 				IsPrimary = false,
 				IsEmbodied = true,
 				IsControllable = options.ControlPolicy != CharacterInstanceControlPolicy.NotControllable,
-				CreatedDateTime = DateTime.UtcNow,
+				CreatedDateTime = RuntimeClock.UtcNow,
 				EffectData = options.EffectData.IfNullOrWhiteSpace("<Effects/>")
 			};
 			FMDB.Context.CharacterInstances.Add(dbinstance);

--- a/MudSharpCore/Character/CharacterInstances.cs
+++ b/MudSharpCore/Character/CharacterInstances.cs
@@ -7,6 +7,7 @@ using MudSharp.Body.Position.PositionStates;
 using MudSharp.Combat;
 using MudSharp.Construction;
 using MudSharp.Database;
+using MudSharp.Framework.Scheduling;
 using MudSharp.Models;
 using MudSharp.NPC;
 using MudSharp.PerceptionEngine.Handlers;
@@ -136,7 +137,7 @@ public partial class Character
 		_currentAccent = identity._currentAccent;
 		_dbTotalMinutesPlayed = identity._dbTotalMinutesPlayed;
 		LoginDateTime = identity.LoginDateTime;
-		LastMinutesUpdate = identity.LastMinutesUpdate == default ? DateTime.UtcNow : identity.LastMinutesUpdate;
+		LastMinutesUpdate = identity.LastMinutesUpdate == default ? RuntimeClock.UtcNow : identity.LastMinutesUpdate;
 		SetCombatSettingsProvisional(identity.CombatSettings ?? CharacterCombatSettingsResolver.ResolveFallback(this));
 		Register(new NonPlayerOutputHandler());
 		if (instance.PositionId != 0)
@@ -445,7 +446,7 @@ public partial class Character
 		primary = new MudSharp.Models.CharacterInstance
 		{
 			Character = dbchar,
-			CreatedDateTime = DateTime.UtcNow,
+			CreatedDateTime = RuntimeClock.UtcNow,
 			EffectData = "<Effects/>"
 		};
 		dbchar.CharacterInstances.Add(primary);
@@ -465,7 +466,7 @@ public partial class Character
 		primary.DeathPolicy = (int)_deathPolicy;
 		primary.PerceptionPolicy = (int)_perceptionPolicy;
 		primary.PersistencePolicy = (int)_persistencePolicy;
-		primary.LocationId = Location?.Id;
+		primary.LocationId = DatabaseLocationId;
 		primary.RoomLayer = (int)RoomLayer;
 		primary.RoutePosition = RoutePositionMetres.HasValue ? (decimal)RoutePositionMetres.Value : null;
 		primary.PositionId = (int)(PositionState?.Id ?? PositionStanding.Instance.Id);
@@ -482,7 +483,7 @@ public partial class Character
 		SaveInstanceProject(primary);
 		if (primary.CreatedDateTime == default)
 		{
-			primary.CreatedDateTime = DateTime.UtcNow;
+			primary.CreatedDateTime = RuntimeClock.UtcNow;
 		}
 
 		if (primary.Id != 0)
@@ -507,10 +508,14 @@ public partial class Character
 		}
 	}
 
+	private long? DatabaseLocationId => Location is Construction.Cell cell
+		? cell.DatabaseLocationId
+		: Location?.Id;
+
 	private void SaveCompatibilityWorldPresence(MudSharp.Models.Character dbchar, CharacterState? stateOverride = null)
 	{
 		// Legacy Characters world-presence columns mirror only the primary instance during the transition.
-		dbchar.Location = Location?.Id ?? 1L;
+		dbchar.Location = DatabaseLocationId ?? 1L;
 		dbchar.RoomLayer = (int)RoomLayer;
 		dbchar.RoutePosition = RoutePositionMetres.HasValue ? (decimal)RoutePositionMetres.Value : null;
 		dbchar.State = (int)(stateOverride ?? State);
@@ -538,7 +543,7 @@ public partial class Character
 		instance.DeathPolicy = (int)_deathPolicy;
 		instance.PerceptionPolicy = (int)_perceptionPolicy;
 		instance.PersistencePolicy = (int)_persistencePolicy;
-		instance.LocationId = Location?.Id;
+		instance.LocationId = DatabaseLocationId;
 		instance.RoomLayer = (int)RoomLayer;
 		instance.RoutePosition = RoutePositionMetres.HasValue ? (decimal)RoutePositionMetres.Value : null;
 		instance.PositionId = (int)(PositionState?.Id ?? PositionStanding.Instance.Id);
@@ -555,7 +560,7 @@ public partial class Character
 		SaveInstanceProject(instance);
 		if (instance.CreatedDateTime == default)
 		{
-			instance.CreatedDateTime = DateTime.UtcNow;
+			instance.CreatedDateTime = RuntimeClock.UtcNow;
 		}
 	}
 
@@ -589,7 +594,7 @@ public partial class Character
 			CurrentProjectLabourId = CurrentProject.Labour?.Id,
 			CurrentProjectHours = CurrentProjectHours,
 			CurrentProjectProjectHours = CurrentProjectProjectHours,
-			CreatedDateTime = DateTime.UtcNow,
+			CreatedDateTime = RuntimeClock.UtcNow,
 			EffectData = "<Effects/>"
 		};
 		dbitem.CharacterInstances.Add(primary);

--- a/MudSharpCore/Character/CharacterMovement.cs
+++ b/MudSharpCore/Character/CharacterMovement.cs
@@ -382,12 +382,10 @@ public partial class Character
 
         ICheck check = Gameworld.GetCheck(CheckType.FallingImpactCheck);
         CheckOutcome result = check.Check(this, Difficulty.Normal.StageUp((int)effectiveFallDistance));
-        FallDamageExpression.Formula.Parameters["rooms"] = effectiveFallDistance;
-        FallDamageExpression.Formula.Parameters["weight"] = Weight;
-        FallDamageExpression.Formula.Parameters["check"] = result.CheckDegrees();
-        FallDamageExpression.Formula.Parameters["success"] = result.SuccessDegrees();
-        FallDamageExpression.Formula.Parameters["failure"] = result.FailureDegrees();
-        double damageAmount = FallDamageExpression.Evaluate(this) * damageMultiplier;
+        double damageAmount = FallDamageExpression.EvaluateWith(this,
+                                  values: [("rooms", effectiveFallDistance), ("weight", Weight),
+                                      ("check", result.CheckDegrees()), ("success", result.SuccessDegrees()),
+                                      ("failure", result.FailureDegrees())]) * damageMultiplier;
         if (damageAmount <= 0.0)
         {
             return;
@@ -1288,9 +1286,8 @@ public partial class Character
                 break;
         }
 
-        BaseSpeedExpression.Formula.Parameters["encumbrance"] = (int)Encumbrance;
-        BaseSpeedExpression.Formula.Parameters["encpercent"] = EncumbrancePercentage;
-        double baseSpeed = BaseSpeedExpression.Evaluate(this);
+        double baseSpeed = BaseSpeedExpression.EvaluateWith(this,
+            values: [("encumbrance", (int)Encumbrance), ("encpercent", EncumbrancePercentage)]);
         double woundPenalty = WoundPenaltyToMoveSpeedPenalty * Body.HealthStrategy.WoundPenaltyFor(this);
 
         double aidePenalty = 1.0;

--- a/MudSharpCore/Character/Dub.cs
+++ b/MudSharpCore/Character/Dub.cs
@@ -1,5 +1,6 @@
 ﻿using MudSharp.Database;
 using MudSharp.Framework.Save;
+using MudSharp.Framework.Scheduling;
 using MudSharp.Models;
 
 namespace MudSharp.Character;
@@ -58,7 +59,7 @@ public class Dub : SaveableItem, IDub
 
     public string HowSeen(ICharacter actor)
     {
-        LastUsage = DateTime.UtcNow;
+        LastUsage = RuntimeClock.UtcNow;
         Changed = true;
         if (!string.IsNullOrEmpty(IntroducedName))
         {

--- a/MudSharpCore/Character/Heritage/Race.cs
+++ b/MudSharpCore/Character/Heritage/Race.cs
@@ -1863,8 +1863,8 @@ public partial class Race : SaveableItem, IRace
     public double BreathingRate(IBody character, IFluid fluid)
     {
         (bool _, double rate) = CanBreatheFluid(fluid);
-        BreathingVolumeExpression.Formula.Parameters["exertion"] = (int)character.CurrentExertion;
-        return BreathingVolumeExpression.Evaluate(character, context: TraitBonusContext.BreathingRate) *
+        return BreathingVolumeExpression.EvaluateWith(character, null, TraitBonusContext.BreathingRate,
+                   ("exertion", (int)character.CurrentExertion)) *
                rate;
     }
 

--- a/MudSharpCore/CharacterCreation/Resources/ChargenResourceBase.cs
+++ b/MudSharpCore/CharacterCreation/Resources/ChargenResourceBase.cs
@@ -176,7 +176,8 @@ public abstract class ChargenResourceBase : SaveableItem, IChargenResource
     {
         if (MaximumResourceReference != null)
         {
-            MaximumResourceExpression.Parameters["variable"] = account.AccountResources[MaximumResourceReference];
+            return Convert.ToInt32(MaximumResourceExpression.EvaluateDoubleWith(("variable",
+                account.AccountResources[MaximumResourceReference])));
         }
 
         return Convert.ToInt32(MaximumResourceExpression.Evaluate());

--- a/MudSharpCore/CharacterCreation/Screens/AttributePointBuyScreen.cs
+++ b/MudSharpCore/CharacterCreation/Screens/AttributePointBuyScreen.cs
@@ -146,8 +146,7 @@ public class AttributePointBuyScreenStoryboard : ChargenScreenStoryboard
             return Enumerable.Empty<(IChargenResource, int)>();
         }
 
-        BoostCostExpression.Parameters["boosts"] = nonFreeBoosts;
-        double boostExpr = BoostCostExpression.EvaluateDouble();
+        double boostExpr = BoostCostExpression.EvaluateDoubleWith(("boosts", nonFreeBoosts));
         if (boostExpr > int.MaxValue)
         {
             boostExpr = int.MaxValue;

--- a/MudSharpCore/CharacterCreation/Screens/SkillBoostSkipperScreen.cs
+++ b/MudSharpCore/CharacterCreation/Screens/SkillBoostSkipperScreen.cs
@@ -153,10 +153,9 @@ internal class SkillBoostSkipperScreenStoryboard : ChargenScreenStoryboard
 
     private int BoostCostForSkill(ITraitDefinition skill, IChargen chargen, int boosts)
     {
-        BoostCostExpression.Parameters["base"] =
-            (double)((decimal?)BaseBoostCostProg.Execute(skill, chargen) ?? 1.0M);
-        BoostCostExpression.Parameters["boosts"] = boosts;
-        return Convert.ToInt32(BoostCostExpression.Evaluate());
+        return Convert.ToInt32(BoostCostExpression.EvaluateWith(
+            ("base", (double)((decimal?)BaseBoostCostProg.Execute(skill, chargen) ?? 1.0M)),
+            ("boosts", boosts)));
     }
 
     public class SkillBoostSkipperScreen : ChargenScreen
@@ -181,10 +180,9 @@ internal class SkillBoostSkipperScreenStoryboard : ChargenScreenStoryboard
 
         private int BoostCostForSkill(ITraitDefinition skill)
         {
-            Storyboard.BoostCostExpression.Parameters["base"] =
-                (double)((decimal?)Storyboard.BaseBoostCostProg.Execute(skill, Chargen) ?? 1.0M);
-            Storyboard.BoostCostExpression.Parameters["boosts"] = SelectedBoosts[skill];
-            return Convert.ToInt32(Storyboard.BoostCostExpression.Evaluate());
+            return Convert.ToInt32(Storyboard.BoostCostExpression.EvaluateWith(
+                ("base", (double)((decimal?)Storyboard.BaseBoostCostProg.Execute(skill, Chargen) ?? 1.0M)),
+                ("boosts", SelectedBoosts[skill])));
         }
 
         #region Overrides of ChargenScreen

--- a/MudSharpCore/CharacterCreation/Screens/SkillCostPickerScreen.cs
+++ b/MudSharpCore/CharacterCreation/Screens/SkillCostPickerScreen.cs
@@ -211,8 +211,8 @@ public class SkillCostPickerScreenStoryboard : ChargenScreenStoryboard
                 int freePicks = (int)Convert.ToDouble(NumberOfFreeSkillPicksProg.Execute(chargen));
                 if (nonFreeSkills.Count > freePicks)
                 {
-                    AdditionalSkillsCostExpression.Parameters["picks"] = nonFreeSkills.Count - freePicks;
-                    sum += Convert.ToInt32(AdditionalSkillsCostExpression.Evaluate());
+                    sum += Convert.ToInt32(AdditionalSkillsCostExpression.EvaluateWith(
+                        ("picks", nonFreeSkills.Count - freePicks)));
                 }
 
                 sum += chargen.SelectedSkillBoosts.Sum(x => BoostCostForSkill(x.Key, chargen, x.Value));
@@ -224,10 +224,9 @@ public class SkillCostPickerScreenStoryboard : ChargenScreenStoryboard
 
     private int BoostCostForSkill(ITraitDefinition skill, IChargen chargen, int boosts)
     {
-        BoostCostExpression.Parameters["base"] =
-            (double)((decimal?)BaseBoostCostProg.Execute(skill, chargen) ?? 1.0M);
-        BoostCostExpression.Parameters["boosts"] = boosts;
-        return Convert.ToInt32(BoostCostExpression.Evaluate());
+        return Convert.ToInt32(BoostCostExpression.EvaluateWith(
+            ("base", (double)((decimal?)BaseBoostCostProg.Execute(skill, chargen) ?? 1.0M)),
+            ("boosts", boosts)));
     }
 
     internal class SkillCostPickerScreen : ChargenScreen
@@ -267,10 +266,9 @@ public class SkillCostPickerScreenStoryboard : ChargenScreenStoryboard
 
         private int BoostCostForSkill(ITraitDefinition skill)
         {
-            Storyboard.BoostCostExpression.Parameters["base"] =
-                (double)((decimal?)Storyboard.BaseBoostCostProg.Execute(skill, Chargen) ?? 1.0M);
-            Storyboard.BoostCostExpression.Parameters["boosts"] = SelectedBoosts[skill];
-            return Convert.ToInt32(Storyboard.BoostCostExpression.Evaluate());
+            return Convert.ToInt32(Storyboard.BoostCostExpression.EvaluateWith(
+                ("base", (double)((decimal?)Storyboard.BaseBoostCostProg.Execute(skill, Chargen) ?? 1.0M)),
+                ("boosts", SelectedBoosts[skill])));
         }
 
         protected string DisplaySkillBoostStage()

--- a/MudSharpCore/Combat/ArmourType.cs
+++ b/MudSharpCore/Combat/ArmourType.cs
@@ -229,6 +229,54 @@ public class ArmourType : SaveableItem, IArmourType
         return new ArmourType(this, newName);
     }
 
+    private enum ArmourFormulaChannel
+    {
+        Damage,
+        Stun,
+        Pain
+    }
+
+    private readonly record struct ArmourFormulaInputs(
+        int Quality,
+        double Angle,
+        double Density,
+        double Electrical,
+        double Thermal,
+        double Organic,
+        double Strength);
+
+    private static ArmourFormulaInputs FormulaInputs(ItemQuality quality, IMaterial material, double angle,
+        double strength)
+    {
+        return new ArmourFormulaInputs(
+            (int)quality,
+            angle,
+            material?.Density ?? 1.0,
+            material?.ElectricalConductivity ?? 1.0,
+            material?.ThermalConductivity ?? 1.0,
+            material?.Organic == true ? 1.0 : 0.0,
+            strength);
+    }
+
+    private static double EvaluateArmourFormula(Expression expression, ArmourFormulaInputs inputs,
+        ArmourFormulaChannel channel, double value, double originalValue)
+    {
+        return expression.EvaluateDoubleWith(
+            ("quality", inputs.Quality),
+            ("damage", value),
+            ("stun", channel == ArmourFormulaChannel.Stun ? value : 0.0),
+            ("pain", channel == ArmourFormulaChannel.Pain ? value : 0.0),
+            ("originaldamage", originalValue),
+            ("originalstun", channel == ArmourFormulaChannel.Stun ? originalValue : 0.0),
+            ("originalpain", channel == ArmourFormulaChannel.Pain ? originalValue : 0.0),
+            ("angle", inputs.Angle),
+            ("density", inputs.Density),
+            ("electrical", inputs.Electrical),
+            ("thermal", inputs.Thermal),
+            ("organic", inputs.Organic),
+            ("strength", inputs.Strength));
+    }
+
     /// <inheritdoc />
     public override void Save()
     {
@@ -362,41 +410,15 @@ public class ArmourType : SaveableItem, IArmourType
 
         (double DamageAmount, double PainAmount, double StunAmount) originalValues = (damage.DamageAmount, damage.PainAmount, damage.StunAmount);
 
+        var formulaInputs = FormulaInputs(quality, material, damage.AngleOfIncidentRadians.RadiansToDegrees(), strength);
+
         // Dissipate - dissipation is basically damage that is ignored or written off by the armour
-        Expression dissipateExpression = DissipateExpressions[damage.DamageType];
-        dissipateExpression.Parameters["quality"] = (int)quality;
-        dissipateExpression.Parameters["damage"] = damage.DamageAmount;
-        dissipateExpression.Parameters["angle"] = damage.AngleOfIncidentRadians.RadiansToDegrees();
-        dissipateExpression.Parameters["density"] = material?.Density ?? 1.0;
-        dissipateExpression.Parameters["electrical"] = material?.ElectricalConductivity ?? 1.0;
-        dissipateExpression.Parameters["thermal"] = material?.ThermalConductivity ?? 1.0;
-        dissipateExpression.Parameters["organic"] = material?.Organic == true ? 1.0 : 0.0;
-        dissipateExpression.Parameters["strength"] = strength;
-        double newDamage = Convert.ToDouble(dissipateExpression.Evaluate());
-
-        dissipateExpression = DissipateExpressionsStun[damage.DamageType];
-        dissipateExpression.Parameters["quality"] = (int)quality;
-        dissipateExpression.Parameters["stun"] = damage.StunAmount;
-        dissipateExpression.Parameters["damage"] = damage.StunAmount;
-        dissipateExpression.Parameters["angle"] = damage.AngleOfIncidentRadians.RadiansToDegrees();
-        dissipateExpression.Parameters["density"] = material?.Density ?? 1.0;
-        dissipateExpression.Parameters["electrical"] = material?.ElectricalConductivity ?? 1.0;
-        dissipateExpression.Parameters["thermal"] = material?.ThermalConductivity ?? 1.0;
-        dissipateExpression.Parameters["organic"] = material?.Organic == true ? 1.0 : 0.0;
-        dissipateExpression.Parameters["strength"] = strength;
-        double newStun = Convert.ToDouble(dissipateExpression.Evaluate());
-
-        dissipateExpression = DissipateExpressionsPain[damage.DamageType];
-        dissipateExpression.Parameters["quality"] = (int)quality;
-        dissipateExpression.Parameters["pain"] = damage.PainAmount;
-        dissipateExpression.Parameters["damage"] = damage.PainAmount;
-        dissipateExpression.Parameters["angle"] = damage.AngleOfIncidentRadians.RadiansToDegrees();
-        dissipateExpression.Parameters["density"] = material?.Density ?? 1.0;
-        dissipateExpression.Parameters["electrical"] = material?.ElectricalConductivity ?? 1.0;
-        dissipateExpression.Parameters["thermal"] = material?.ThermalConductivity ?? 1.0;
-        dissipateExpression.Parameters["organic"] = material?.Organic == true ? 1.0 : 0.0;
-        dissipateExpression.Parameters["strength"] = strength;
-        double newPain = Convert.ToDouble(dissipateExpression.Evaluate());
+        double newDamage = EvaluateArmourFormula(DissipateExpressions[damage.DamageType], formulaInputs,
+            ArmourFormulaChannel.Damage, damage.DamageAmount, originalValues.DamageAmount);
+        double newStun = EvaluateArmourFormula(DissipateExpressionsStun[damage.DamageType], formulaInputs,
+            ArmourFormulaChannel.Stun, damage.StunAmount, originalValues.StunAmount);
+        double newPain = EvaluateArmourFormula(DissipateExpressionsPain[damage.DamageType], formulaInputs,
+            ArmourFormulaChannel.Pain, damage.PainAmount, originalValues.PainAmount);
 
         if (newDamage <= 0 && newStun <= 0 && newPain <= 0)
         {
@@ -418,43 +440,12 @@ public class ArmourType : SaveableItem, IArmourType
         };
 
         // Absorb - Absorb is damage less that the armour passes on to layers below it
-        Expression absorbExpression = AbsorbExpressions[damage.DamageType];
-        absorbExpression.Parameters["quality"] = (int)quality;
-        absorbExpression.Parameters["damage"] = partDamage.DamageAmount;
-        absorbExpression.Parameters["angle"] = partDamage.AngleOfIncidentRadians.RadiansToDegrees();
-        absorbExpression.Parameters["density"] = material?.Density ?? 1.0;
-        absorbExpression.Parameters["electrical"] = material?.ElectricalConductivity ?? 1.0;
-        absorbExpression.Parameters["thermal"] = material?.ThermalConductivity ?? 1.0;
-        absorbExpression.Parameters["organic"] = material?.Organic == true ? 1.0 : 0.0;
-        absorbExpression.Parameters["strength"] = strength;
-        absorbExpression.Parameters["originaldamage"] = originalValues.DamageAmount;
-        newDamage = Convert.ToDouble(absorbExpression.Evaluate());
-
-        absorbExpression = AbsorbExpressionsStun[damage.DamageType];
-        absorbExpression.Parameters["quality"] = (int)quality;
-        absorbExpression.Parameters["stun"] = partDamage.StunAmount;
-        absorbExpression.Parameters["angle"] = partDamage.AngleOfIncidentRadians.RadiansToDegrees();
-        absorbExpression.Parameters["density"] = material?.Density ?? 1.0;
-        absorbExpression.Parameters["electrical"] = material?.ElectricalConductivity ?? 1.0;
-        absorbExpression.Parameters["thermal"] = material?.ThermalConductivity ?? 1.0;
-        absorbExpression.Parameters["organic"] = material?.Organic == true ? 1.0 : 0.0;
-        absorbExpression.Parameters["strength"] = strength;
-        absorbExpression.Parameters["originaldamage"] = originalValues.StunAmount;
-        absorbExpression.Parameters["originalstun"] = originalValues.StunAmount;
-        newStun = Convert.ToDouble(absorbExpression.Evaluate());
-
-        absorbExpression = AbsorbExpressionsPain[damage.DamageType];
-        absorbExpression.Parameters["quality"] = (int)quality;
-        absorbExpression.Parameters["pain"] = partDamage.PainAmount;
-        absorbExpression.Parameters["angle"] = partDamage.AngleOfIncidentRadians.RadiansToDegrees();
-        absorbExpression.Parameters["density"] = material?.Density ?? 1.0;
-        absorbExpression.Parameters["electrical"] = material?.ElectricalConductivity ?? 1.0;
-        absorbExpression.Parameters["thermal"] = material?.ThermalConductivity ?? 1.0;
-        absorbExpression.Parameters["organic"] = material?.Organic == true ? 1.0 : 0.0;
-        absorbExpression.Parameters["strength"] = strength;
-        absorbExpression.Parameters["originaldamage"] = originalValues.PainAmount;
-        absorbExpression.Parameters["originalpain"] = originalValues.PainAmount;
-        newPain = Convert.ToDouble(absorbExpression.Evaluate());
+        newDamage = EvaluateArmourFormula(AbsorbExpressions[damage.DamageType], formulaInputs,
+            ArmourFormulaChannel.Damage, partDamage.DamageAmount, originalValues.DamageAmount);
+        newStun = EvaluateArmourFormula(AbsorbExpressionsStun[damage.DamageType], formulaInputs,
+            ArmourFormulaChannel.Stun, partDamage.StunAmount, originalValues.StunAmount);
+        newPain = EvaluateArmourFormula(AbsorbExpressionsPain[damage.DamageType], formulaInputs,
+            ArmourFormulaChannel.Pain, partDamage.PainAmount, originalValues.PainAmount);
 
         if (newDamage <= 0 && newStun <= 0 && newPain <= 0)
         {
@@ -527,41 +518,16 @@ public class ArmourType : SaveableItem, IArmourType
 
         (double DamageAmount, double PainAmount, double StunAmount) originalValues = (damage.DamageAmount, damage.PainAmount, damage.StunAmount);
 
+        var formulaInputs = FormulaInputs(armour.Parent.Quality, armour.Parent.Material,
+            damage.AngleOfIncidentRadians.RadiansToDegrees(), strength);
+
         // Dissipate - dissipation is basically damage that is ignored or written off by the armour
-        Expression dissipateExpression = DissipateExpressions[damage.DamageType];
-        dissipateExpression.Parameters["quality"] = (int)armour.Parent.Quality;
-        dissipateExpression.Parameters["damage"] = damage.DamageAmount;
-        dissipateExpression.Parameters["angle"] = damage.AngleOfIncidentRadians.RadiansToDegrees();
-        dissipateExpression.Parameters["density"] = armour.Parent.Material?.Density ?? 1.0;
-        dissipateExpression.Parameters["electrical"] = armour.Parent.Material?.ElectricalConductivity ?? 1.0;
-        dissipateExpression.Parameters["thermal"] = armour.Parent.Material?.ThermalConductivity ?? 1.0;
-        dissipateExpression.Parameters["organic"] = armour.Parent.Material?.Organic == true ? 1.0 : 0.0;
-        dissipateExpression.Parameters["strength"] = strength;
-        double newDamage = Convert.ToDouble(dissipateExpression.Evaluate());
-
-        dissipateExpression = DissipateExpressionsStun[damage.DamageType];
-        dissipateExpression.Parameters["quality"] = (int)armour.Parent.Quality;
-        dissipateExpression.Parameters["stun"] = damage.StunAmount;
-        dissipateExpression.Parameters["damage"] = damage.StunAmount;
-        dissipateExpression.Parameters["angle"] = damage.AngleOfIncidentRadians.RadiansToDegrees();
-        dissipateExpression.Parameters["density"] = armour.Parent.Material?.Density ?? 1.0;
-        dissipateExpression.Parameters["electrical"] = armour.Parent.Material?.ElectricalConductivity ?? 1.0;
-        dissipateExpression.Parameters["thermal"] = armour.Parent.Material?.ThermalConductivity ?? 1.0;
-        dissipateExpression.Parameters["organic"] = armour.Parent.Material?.Organic == true ? 1.0 : 0.0;
-        dissipateExpression.Parameters["strength"] = strength;
-        double newStun = Convert.ToDouble(dissipateExpression.Evaluate());
-
-        dissipateExpression = DissipateExpressionsPain[damage.DamageType];
-        dissipateExpression.Parameters["quality"] = (int)armour.Parent.Quality;
-        dissipateExpression.Parameters["pain"] = damage.PainAmount;
-        dissipateExpression.Parameters["damage"] = damage.PainAmount;
-        dissipateExpression.Parameters["angle"] = damage.AngleOfIncidentRadians.RadiansToDegrees();
-        dissipateExpression.Parameters["density"] = armour.Parent.Material?.Density ?? 1.0;
-        dissipateExpression.Parameters["electrical"] = armour.Parent.Material?.ElectricalConductivity ?? 1.0;
-        dissipateExpression.Parameters["thermal"] = armour.Parent.Material?.ThermalConductivity ?? 1.0;
-        dissipateExpression.Parameters["organic"] = armour.Parent.Material?.Organic == true ? 1.0 : 0.0;
-        dissipateExpression.Parameters["strength"] = strength;
-        double newPain = Convert.ToDouble(dissipateExpression.Evaluate());
+        double newDamage = EvaluateArmourFormula(DissipateExpressions[damage.DamageType], formulaInputs,
+            ArmourFormulaChannel.Damage, damage.DamageAmount, originalValues.DamageAmount);
+        double newStun = EvaluateArmourFormula(DissipateExpressionsStun[damage.DamageType], formulaInputs,
+            ArmourFormulaChannel.Stun, damage.StunAmount, originalValues.StunAmount);
+        double newPain = EvaluateArmourFormula(DissipateExpressionsPain[damage.DamageType], formulaInputs,
+            ArmourFormulaChannel.Pain, damage.PainAmount, originalValues.PainAmount);
 
         if (newDamage <= 0 && newStun <= 0 && newPain <= 0)
         {
@@ -591,45 +557,12 @@ public class ArmourType : SaveableItem, IArmourType
             wounds.AddRange(armourWounds);
         }
 
-        Expression absorbExpression = AbsorbExpressions[damage.DamageType];
-        absorbExpression.Parameters["quality"] = (int)armour.Parent.Quality;
-        absorbExpression.Parameters["damage"] = damage.DamageAmount;
-        absorbExpression.Parameters["angle"] = damage.AngleOfIncidentRadians.RadiansToDegrees();
-        absorbExpression.Parameters["density"] = armour.Parent.Material?.Density ?? 1.0;
-        absorbExpression.Parameters["electrical"] = armour.Parent.Material?.ElectricalConductivity ?? 1.0;
-        absorbExpression.Parameters["thermal"] = armour.Parent.Material?.ThermalConductivity ?? 1.0;
-        absorbExpression.Parameters["organic"] = armour.Parent.Material?.Organic == true ? 1.0 : 0.0;
-        absorbExpression.Parameters["strength"] = strength;
-        absorbExpression.Parameters["originaldamage"] = originalValues.DamageAmount;
-        newDamage = Convert.ToDouble(absorbExpression.Evaluate());
-
-        absorbExpression = AbsorbExpressionsStun[damage.DamageType];
-        absorbExpression.Parameters["quality"] = (int)armour.Parent.Quality;
-        absorbExpression.Parameters["stun"] = damage.StunAmount;
-        absorbExpression.Parameters["damage"] = damage.StunAmount;
-        absorbExpression.Parameters["angle"] = damage.AngleOfIncidentRadians.RadiansToDegrees();
-        absorbExpression.Parameters["density"] = armour.Parent.Material?.Density ?? 1.0;
-        absorbExpression.Parameters["electrical"] = armour.Parent.Material?.ElectricalConductivity ?? 1.0;
-        absorbExpression.Parameters["thermal"] = armour.Parent.Material?.ThermalConductivity ?? 1.0;
-        absorbExpression.Parameters["organic"] = armour.Parent.Material?.Organic == true ? 1.0 : 0.0;
-        absorbExpression.Parameters["strength"] = strength;
-        absorbExpression.Parameters["originaldamage"] = originalValues.StunAmount;
-        absorbExpression.Parameters["originalstun"] = originalValues.StunAmount;
-        newStun = Convert.ToDouble(absorbExpression.Evaluate());
-
-        absorbExpression = AbsorbExpressionsPain[damage.DamageType];
-        absorbExpression.Parameters["quality"] = (int)armour.Parent.Quality;
-        absorbExpression.Parameters["pain"] = damage.PainAmount;
-        absorbExpression.Parameters["damage"] = damage.PainAmount;
-        absorbExpression.Parameters["angle"] = damage.AngleOfIncidentRadians.RadiansToDegrees();
-        absorbExpression.Parameters["density"] = armour.Parent.Material?.Density ?? 1.0;
-        absorbExpression.Parameters["electrical"] = armour.Parent.Material?.ElectricalConductivity ?? 1.0;
-        absorbExpression.Parameters["thermal"] = armour.Parent.Material?.ThermalConductivity ?? 1.0;
-        absorbExpression.Parameters["organic"] = armour.Parent.Material?.Organic == true ? 1.0 : 0.0;
-        absorbExpression.Parameters["strength"] = strength;
-        absorbExpression.Parameters["originaldamage"] = originalValues.PainAmount;
-        absorbExpression.Parameters["originalpain"] = originalValues.PainAmount;
-        newPain = Convert.ToDouble(absorbExpression.Evaluate());
+        newDamage = EvaluateArmourFormula(AbsorbExpressions[damage.DamageType], formulaInputs,
+            ArmourFormulaChannel.Damage, damage.DamageAmount, originalValues.DamageAmount);
+        newStun = EvaluateArmourFormula(AbsorbExpressionsStun[damage.DamageType], formulaInputs,
+            ArmourFormulaChannel.Stun, damage.StunAmount, originalValues.StunAmount);
+        newPain = EvaluateArmourFormula(AbsorbExpressionsPain[damage.DamageType], formulaInputs,
+            ArmourFormulaChannel.Pain, damage.PainAmount, originalValues.PainAmount);
 
         if (newDamage <= 0 && newStun <= 0 && newPain <= 0)
         {
@@ -701,39 +634,15 @@ public class ArmourType : SaveableItem, IArmourType
                 break;
         }
 
+        var formulaInputs = FormulaInputs(quality, solid, damage.AngleOfIncidentRadians.RadiansToDegrees(), strength);
+
         // Dissipate - dissipation is basically damage that is ignored or written off by the armour
-        Expression dissipateExpression = DissipateExpressions[damage.DamageType];
-        dissipateExpression.Parameters["quality"] = (int)quality;
-        dissipateExpression.Parameters["damage"] = damage.DamageAmount;
-        dissipateExpression.Parameters["angle"] = damage.AngleOfIncidentRadians.RadiansToDegrees();
-        dissipateExpression.Parameters["density"] = solid?.Density ?? 1.0;
-        dissipateExpression.Parameters["electrical"] = solid?.ElectricalConductivity ?? 1.0;
-        dissipateExpression.Parameters["thermal"] = solid?.ThermalConductivity ?? 1.0;
-        dissipateExpression.Parameters["organic"] = solid?.Organic == true ? 1.0 : 0.0;
-        dissipateExpression.Parameters["strength"] = strength;
-        double newDamage = Convert.ToDouble(dissipateExpression.Evaluate());
-
-        dissipateExpression = DissipateExpressionsStun[damage.DamageType];
-        dissipateExpression.Parameters["quality"] = (int)quality;
-        dissipateExpression.Parameters["stun"] = damage.StunAmount;
-        dissipateExpression.Parameters["angle"] = damage.AngleOfIncidentRadians.RadiansToDegrees();
-        dissipateExpression.Parameters["density"] = solid?.Density ?? 1.0;
-        dissipateExpression.Parameters["electrical"] = solid?.ElectricalConductivity ?? 1.0;
-        dissipateExpression.Parameters["thermal"] = solid?.ThermalConductivity ?? 1.0;
-        dissipateExpression.Parameters["organic"] = solid?.Organic == true ? 1.0 : 0.0;
-        dissipateExpression.Parameters["strength"] = strength;
-        double newStun = Convert.ToDouble(dissipateExpression.Evaluate());
-
-        dissipateExpression = DissipateExpressionsPain[damage.DamageType];
-        dissipateExpression.Parameters["quality"] = (int)quality;
-        dissipateExpression.Parameters["pain"] = damage.PainAmount;
-        dissipateExpression.Parameters["angle"] = damage.AngleOfIncidentRadians.RadiansToDegrees();
-        dissipateExpression.Parameters["density"] = solid?.Density ?? 1.0;
-        dissipateExpression.Parameters["electrical"] = solid?.ElectricalConductivity ?? 1.0;
-        dissipateExpression.Parameters["thermal"] = solid?.ThermalConductivity ?? 1.0;
-        dissipateExpression.Parameters["organic"] = solid?.Organic == true ? 1.0 : 0.0;
-        dissipateExpression.Parameters["strength"] = strength;
-        double newPain = Convert.ToDouble(dissipateExpression.Evaluate());
+        double newDamage = EvaluateArmourFormula(DissipateExpressions[damage.DamageType], formulaInputs,
+            ArmourFormulaChannel.Damage, damage.DamageAmount, damage.DamageAmount);
+        double newStun = EvaluateArmourFormula(DissipateExpressionsStun[damage.DamageType], formulaInputs,
+            ArmourFormulaChannel.Stun, damage.StunAmount, damage.StunAmount);
+        double newPain = EvaluateArmourFormula(DissipateExpressionsPain[damage.DamageType], formulaInputs,
+            ArmourFormulaChannel.Pain, damage.PainAmount, damage.PainAmount);
 
         if (newDamage <= 0 && newStun <= 0 && newPain <= 0)
         {
@@ -755,38 +664,12 @@ public class ArmourType : SaveableItem, IArmourType
             StunAmount = newStun
         };
 
-        Expression absorbExpression = AbsorbExpressions[damage.DamageType];
-        absorbExpression.Parameters["quality"] = (int)quality;
-        absorbExpression.Parameters["damage"] = damage.DamageAmount;
-        absorbExpression.Parameters["angle"] = damage.AngleOfIncidentRadians.RadiansToDegrees();
-        absorbExpression.Parameters["density"] = solid?.Density ?? 1.0;
-        absorbExpression.Parameters["electrical"] = solid?.ElectricalConductivity ?? 1.0;
-        absorbExpression.Parameters["thermal"] = solid?.ThermalConductivity ?? 1.0;
-        dissipateExpression.Parameters["organic"] = solid?.Organic == true ? 1.0 : 0.0;
-        dissipateExpression.Parameters["strength"] = strength;
-        newDamage = Convert.ToDouble(absorbExpression.Evaluate());
-
-        absorbExpression = AbsorbExpressionsStun[damage.DamageType];
-        absorbExpression.Parameters["quality"] = (int)quality;
-        absorbExpression.Parameters["stun"] = damage.StunAmount;
-        absorbExpression.Parameters["angle"] = damage.AngleOfIncidentRadians.RadiansToDegrees();
-        absorbExpression.Parameters["density"] = solid?.Density ?? 1.0;
-        absorbExpression.Parameters["electrical"] = solid?.ElectricalConductivity ?? 1.0;
-        absorbExpression.Parameters["thermal"] = solid?.ThermalConductivity ?? 1.0;
-        dissipateExpression.Parameters["organic"] = solid?.Organic == true ? 1.0 : 0.0;
-        dissipateExpression.Parameters["strength"] = strength;
-        newStun = Convert.ToDouble(absorbExpression.Evaluate());
-
-        absorbExpression = AbsorbExpressionsPain[damage.DamageType];
-        absorbExpression.Parameters["quality"] = (int)quality;
-        absorbExpression.Parameters["pain"] = damage.PainAmount;
-        absorbExpression.Parameters["angle"] = damage.AngleOfIncidentRadians.RadiansToDegrees();
-        absorbExpression.Parameters["density"] = solid?.Density ?? 1.0;
-        absorbExpression.Parameters["electrical"] = solid?.ElectricalConductivity ?? 1.0;
-        absorbExpression.Parameters["thermal"] = solid?.ThermalConductivity ?? 1.0;
-        dissipateExpression.Parameters["organic"] = solid?.Organic == true ? 1.0 : 0.0;
-        dissipateExpression.Parameters["strength"] = strength;
-        newPain = Convert.ToDouble(absorbExpression.Evaluate());
+        newDamage = EvaluateArmourFormula(AbsorbExpressions[damage.DamageType], formulaInputs,
+            ArmourFormulaChannel.Damage, damage.DamageAmount, damage.DamageAmount);
+        newStun = EvaluateArmourFormula(AbsorbExpressionsStun[damage.DamageType], formulaInputs,
+            ArmourFormulaChannel.Stun, damage.StunAmount, damage.StunAmount);
+        newPain = EvaluateArmourFormula(AbsorbExpressionsPain[damage.DamageType], formulaInputs,
+            ArmourFormulaChannel.Pain, damage.PainAmount, damage.PainAmount);
 
         if (newDamage <= 0 && newStun <= 0 && newPain <= 0)
         {
@@ -1121,9 +1004,9 @@ You can use the following parameters in this formula:
         sb.Append(Telnet.RESET);
         sb.AppendLine(".");
 
-        foreach (KeyValuePair<string, object> parameter in expression.Parameters)
+        foreach (string parameter in expression.ParameterNames)
         {
-            switch (parameter.Key.ToLowerInvariant())
+            switch (parameter.ToLowerInvariant())
             {
                 case "damage":
                 case "density":
@@ -1168,7 +1051,7 @@ You can use the following parameters in this formula:
 
                     continue;
                 default:
-                    sb.AppendLine($"Warning: The parameter \"{parameter.Key.ToLowerInvariant()}\" is not valid and will always be zero.".ColourError());
+                    sb.AppendLine($"Warning: The parameter \"{parameter.ToLowerInvariant()}\" is not valid and will always be zero.".ColourError());
                     continue;
             }
         }

--- a/MudSharpCore/Combat/CombatBase.cs
+++ b/MudSharpCore/Combat/CombatBase.cs
@@ -25,16 +25,16 @@ public abstract class CombatBase : ICombat
 
     public static double PowerMoveStaminaMultiplier(ICharacter assailant)
     {
-        PowerMoveStaminaCost.Formula.Parameters["encumbrance"] = (int)assailant.Encumbrance;
-        PowerMoveStaminaCost.Formula.Parameters["encpercent"] = assailant.EncumbrancePercentage;
-        return PowerMoveStaminaCost.Evaluate(assailant, null, TraitBonusContext.CombatPowerMoveStamina);
+        return PowerMoveStaminaCost.EvaluateWith(assailant, null, TraitBonusContext.CombatPowerMoveStamina,
+            ("encumbrance", (int)assailant.Encumbrance),
+            ("encpercent", assailant.EncumbrancePercentage));
     }
 
     public static double GraceMoveStaminaMultiplier(ICharacter assailant)
     {
-        GraceMoveStaminaCost.Formula.Parameters["encumbrance"] = (int)assailant.Encumbrance;
-        GraceMoveStaminaCost.Formula.Parameters["encpercent"] = assailant.EncumbrancePercentage;
-        return GraceMoveStaminaCost.Evaluate(assailant, null, TraitBonusContext.CombatGraceMoveStamina);
+        return GraceMoveStaminaCost.EvaluateWith(assailant, null, TraitBonusContext.CombatGraceMoveStamina,
+            ("encumbrance", (int)assailant.Encumbrance),
+            ("encpercent", assailant.EncumbrancePercentage));
     }
 
     public static double RelativeStrengthDefenseStaminaMultiplier(IPerceiver attacker, ICharacter defender)
@@ -44,13 +44,11 @@ public abstract class CombatBase : ICombat
             return 1.0;
         }
 
-        RelativeStrengthDefenseStaminaCost.Parameters["attacker"] =
-            StrengthForRelativeStrengthCheck.Evaluate(ach, null,
-                TraitBonusContext.CombatRelativeStrengthDefenseStamina);
-        RelativeStrengthDefenseStaminaCost.Parameters["defender"] =
-            StrengthForRelativeStrengthCheck.Evaluate(defender, null,
-                TraitBonusContext.CombatRelativeStrengthDefenseStamina);
-        return Convert.ToDouble(RelativeStrengthDefenseStaminaCost.Evaluate());
+        return RelativeStrengthDefenseStaminaCost.EvaluateDoubleWith(
+            ("attacker", StrengthForRelativeStrengthCheck.Evaluate(ach, null,
+                TraitBonusContext.CombatRelativeStrengthDefenseStamina)),
+            ("defender", StrengthForRelativeStrengthCheck.Evaluate(defender, null,
+                TraitBonusContext.CombatRelativeStrengthDefenseStamina)));
     }
 
     public static double CombatSpeedMultiplier { get; set; } = 1.0;
@@ -337,14 +335,15 @@ public abstract class CombatBase : ICombat
         }
 
         CheckOutcome result = Gameworld.GetCheck(CheckType.CombatRecoveryCheck).Check(haveTraits, recoverDifficulty);
-        RecoveryTimeExpression.Formula.Parameters["recovery"] = result.CheckDegrees();
 #if DEBUG
-        TimeSpan time = TimeSpan.FromSeconds(baseTime * RecoveryTimeExpression.Evaluate(haveTraits) * CombatSpeedMultiplier);
+        TimeSpan time = TimeSpan.FromSeconds(baseTime * RecoveryTimeExpression.EvaluateWith(haveTraits,
+            values: [("recovery", result.CheckDegrees())]) * CombatSpeedMultiplier);
         Console.WriteLine(
             $"Combat Delay {perceiver.HowSeen(perceiver, colour: false, flags: PerceiveIgnoreFlags.IgnoreSelf)}: {time}");
         return time;
 #else
-			return TimeSpan.FromSeconds(baseTime*RecoveryTimeExpression.Evaluate(haveTraits)*CombatSpeedMultiplier);
+			return TimeSpan.FromSeconds(baseTime * RecoveryTimeExpression.EvaluateWith(haveTraits,
+				values: [("recovery", result.CheckDegrees())]) * CombatSpeedMultiplier);
 #endif
     }
 

--- a/MudSharpCore/Combat/CombatExtensions.cs
+++ b/MudSharpCore/Combat/CombatExtensions.cs
@@ -51,13 +51,11 @@ public static class CombatExtensions
 
         string expressionText = character.Gameworld.GetStaticConfiguration(MovementSpeedExpressionConfig);
         Expression expression = new(expressionText);
-        expression.Parameters["baseSpeed"] = baseSpeed;
-        expression.Parameters["degree"] = degrees;
 
         double modifiedSpeed;
         try
         {
-            modifiedSpeed = Convert.ToDouble(expression.Evaluate());
+            modifiedSpeed = expression.EvaluateDoubleWith(("baseSpeed", baseSpeed), ("degree", degrees));
         }
         catch
         {

--- a/MudSharpCore/Combat/Moves/BreakoutMove.cs
+++ b/MudSharpCore/Combat/Moves/BreakoutMove.cs
@@ -30,23 +30,18 @@ public class BreakoutMove : CombatMoveBase
 
     private (Difficulty Breakout, Difficulty Oppose) GetBreakoutDifficulty(ICharacter grappler)
     {
-        AttackerStrengthExpression.Formula.Parameters["weight"] = Assailant.Weight;
-        AttackerStrengthExpression.Formula.Parameters["height"] = Assailant.Height;
-        AttackerStrengthExpression.Formula.Parameters["limbs"] = Assailant
-                                                                 .CombinedEffectsOfType<ILimbIneffectiveEffect>()
-                                                                 .Count(
-                                                                     x => x.Reason == LimbIneffectiveReason.Grappling);
-        DefenderStrengthExpression.Formula.Parameters["weight"] = grappler.Weight;
-        DefenderStrengthExpression.Formula.Parameters["height"] = grappler.Height;
-        DefenderStrengthExpression.Formula.Parameters["limbs"] = Assailant
-                                                                 .CombinedEffectsOfType<ILimbIneffectiveEffect>()
-                                                                 .Count(
-                                                                     x => x.Reason == LimbIneffectiveReason.Grappling);
-
         double attackerStrength =
-            AttackerStrengthExpression.Evaluate(Assailant, context: TraitBonusContext.BreakoutFromGrapple);
+            AttackerStrengthExpression.EvaluateWith(Assailant, null, TraitBonusContext.BreakoutFromGrapple,
+                ("weight", Assailant.Weight),
+                ("height", Assailant.Height),
+                ("limbs", Assailant.CombinedEffectsOfType<ILimbIneffectiveEffect>()
+                    .Count(x => x.Reason == LimbIneffectiveReason.Grappling)));
         double defenderStrength =
-            DefenderStrengthExpression.Evaluate(grappler, context: TraitBonusContext.OpposeBreakoutFromGrapple);
+            DefenderStrengthExpression.EvaluateWith(grappler, null, TraitBonusContext.OpposeBreakoutFromGrapple,
+                ("weight", grappler.Weight),
+                ("height", grappler.Height),
+                ("limbs", Assailant.CombinedEffectsOfType<ILimbIneffectiveEffect>()
+                    .Count(x => x.Reason == LimbIneffectiveReason.Grappling)));
 
         SizeCategory attackerSize = Assailant.CurrentContextualSize(SizeContext.GrappleAttack);
         SizeCategory defenderSize = Assailant.CurrentContextualSize(SizeContext.GrappleDefense);

--- a/MudSharpCore/Combat/Moves/ChangePositionMove.cs
+++ b/MudSharpCore/Combat/Moves/ChangePositionMove.cs
@@ -1,5 +1,6 @@
 ﻿using MudSharp.Body.Position;
 using MudSharp.RPG.Checks;
+using MoreLinq;
 
 namespace MudSharp.Combat.Moves;
 
@@ -26,7 +27,7 @@ public class ChangePositionMove : CombatMoveBase
         ICombatMove opponent =
             Assailant.Combat.Combatants.Where(x => x.CombatTarget == Assailant)
                      .SelectNotNull(x => x.ResponseToMove(this, Assailant))
-                     .Shuffle()
+                     .Shuffle(Constants.Random)
                      .FirstOrDefault();
         if (opponent == null || opponent is HelplessDefenseMove)
         {

--- a/MudSharpCore/Combat/Moves/ClinchAttackMove.cs
+++ b/MudSharpCore/Combat/Moves/ClinchAttackMove.cs
@@ -140,12 +140,7 @@ public class ClinchAttackMove : WeaponAttackMove
         }
 
         double finalAngle = Attack.Profile.BaseAngleOfIncidence * angleMultiplier;
-        Attack.Profile.DamageExpression.Formula.Parameters["degree"] = finalDegree;
-        Attack.Profile.DamageExpression.Formula.Parameters["quality"] = (int)Weapon.Parent.Quality;
-        Attack.Profile.StunExpression.Formula.Parameters["degree"] = finalDegree;
-        Attack.Profile.StunExpression.Formula.Parameters["quality"] = (int)Weapon.Parent.Quality;
-        Attack.Profile.PainExpression.Formula.Parameters["degree"] = finalDegree;
-        Attack.Profile.PainExpression.Formula.Parameters["quality"] = (int)Weapon.Parent.Quality;
+        int quality = (int)Weapon.Parent.Quality;
 
         Damage finalDamage = new()
         {
@@ -154,15 +149,18 @@ public class ClinchAttackMove : WeaponAttackMove
             ToolOrigin = Weapon.Parent,
             AngleOfIncidentRadians = finalAngle,
             Bodypart = TargetBodypart,
-            DamageAmount = Attack.Profile.DamageExpression.Evaluate(Assailant) * 2 * finalAngle / Math.PI,
+            DamageAmount = EvaluateAttackFormula(Attack.Profile.DamageExpression, Assailant,
+                MudSharp.Body.Traits.TraitBonusContext.None, finalDegree, quality) * 2 * finalAngle / Math.PI,
             DamageType = Attack.Profile.DamageType,
-            PainAmount = Attack.Profile.PainExpression.Evaluate(Assailant) * 2 * finalAngle / Math.PI,
+            PainAmount = EvaluateAttackFormula(Attack.Profile.PainExpression, Assailant,
+                MudSharp.Body.Traits.TraitBonusContext.None, finalDegree, quality) * 2 * finalAngle / Math.PI,
             PenetrationOutcome =
                 Gameworld.GetCheck(CheckType.MeleeWeaponPenetrateCheck)
                          .Check(Assailant, GetPenetrationDifficulty(Attack.Profile.DamageType),
                              Weapon.WeaponType.AttackTrait, CharacterTarget),
             ShockAmount = 0,
-            StunAmount = Attack.Profile.DamageExpression.Evaluate(Assailant) * 2 * finalAngle / Math.PI
+            StunAmount = EvaluateAttackFormula(Attack.Profile.DamageExpression, Assailant,
+                MudSharp.Body.Traits.TraitBonusContext.None, finalDegree, quality) * 2 * finalAngle / Math.PI
         };
 
         string dodgeEmote = Gameworld.CombatMessageManager.GetMessageFor(CharacterTarget, Assailant, Weapon.Parent,
@@ -199,12 +197,8 @@ public class ClinchAttackMove : WeaponAttackMove
             $"MeleeWeaponAttack HelplessDefenseMove Outcome: {result.Degree.Describe()} to {result.Outcome.Describe()}");
 #endif
         double finalAngle = Attack.Profile.BaseAngleOfIncidence;
-        Attack.Profile.DamageExpression.Formula.Parameters["degree"] = (int)result.Degree;
-        Attack.Profile.DamageExpression.Formula.Parameters["quality"] = (int)Weapon.Parent.Quality;
-        Attack.Profile.StunExpression.Formula.Parameters["degree"] = (int)result.Degree;
-        Attack.Profile.StunExpression.Formula.Parameters["quality"] = (int)Weapon.Parent.Quality;
-        Attack.Profile.PainExpression.Formula.Parameters["degree"] = (int)result.Degree;
-        Attack.Profile.PainExpression.Formula.Parameters["quality"] = (int)Weapon.Parent.Quality;
+        int degree = (int)result.Degree;
+        int quality = (int)Weapon.Parent.Quality;
 
         Damage finalDamage = new()
         {
@@ -213,15 +207,18 @@ public class ClinchAttackMove : WeaponAttackMove
             ToolOrigin = Weapon.Parent,
             AngleOfIncidentRadians = finalAngle,
             Bodypart = TargetBodypart,
-            DamageAmount = Attack.Profile.DamageExpression.Evaluate(Assailant) * 2 * finalAngle / Math.PI,
+            DamageAmount = EvaluateAttackFormula(Attack.Profile.DamageExpression, Assailant,
+                MudSharp.Body.Traits.TraitBonusContext.None, degree, quality) * 2 * finalAngle / Math.PI,
             DamageType = Attack.Profile.DamageType,
-            PainAmount = Attack.Profile.PainExpression.Evaluate(Assailant) * 2 * finalAngle / Math.PI,
+            PainAmount = EvaluateAttackFormula(Attack.Profile.PainExpression, Assailant,
+                MudSharp.Body.Traits.TraitBonusContext.None, degree, quality) * 2 * finalAngle / Math.PI,
             PenetrationOutcome =
                 Gameworld.GetCheck(CheckType.MeleeWeaponPenetrateCheck)
                          .Check(Assailant, GetPenetrationDifficulty(Attack.Profile.DamageType),
                              Weapon.WeaponType.AttackTrait, defenderMove.Assailant),
             ShockAmount = 0,
-            StunAmount = Attack.Profile.DamageExpression.Evaluate(Assailant) * 2 * finalAngle / Math.PI
+            StunAmount = EvaluateAttackFormula(Attack.Profile.DamageExpression, Assailant,
+                MudSharp.Body.Traits.TraitBonusContext.None, degree, quality) * 2 * finalAngle / Math.PI
         };
 
         Assailant.OutputHandler.Handle(

--- a/MudSharpCore/Combat/Moves/CoupDeGrace.cs
+++ b/MudSharpCore/Combat/Moves/CoupDeGrace.cs
@@ -34,12 +34,8 @@ public class CoupDeGrace : WeaponAttackMove
                     BuiltInCombatMoveType.CoupDeGrace, attackRoll.Outcome, null), TargetBodypart.FullDescription());
         OpposedOutcome result = new(attackRoll, Outcome.NotTested);
         double finalAngle = Attack.Profile.BaseAngleOfIncidence;
-        Attack.Profile.DamageExpression.Formula.Parameters["degree"] = (int)result.Degree;
-        Attack.Profile.DamageExpression.Formula.Parameters["quality"] = (int)Weapon.Parent.Quality;
-        Attack.Profile.StunExpression.Formula.Parameters["degree"] = (int)result.Degree;
-        Attack.Profile.StunExpression.Formula.Parameters["quality"] = (int)Weapon.Parent.Quality;
-        Attack.Profile.PainExpression.Formula.Parameters["degree"] = (int)result.Degree;
-        Attack.Profile.PainExpression.Formula.Parameters["quality"] = (int)Weapon.Parent.Quality;
+        int degree = (int)result.Degree;
+        int quality = (int)Weapon.Parent.Quality;
 
         Damage finalDamage = new()
         {
@@ -48,12 +44,15 @@ public class CoupDeGrace : WeaponAttackMove
             ToolOrigin = Weapon.Parent,
             AngleOfIncidentRadians = finalAngle,
             Bodypart = TargetBodypart,
-            DamageAmount = Attack.Profile.DamageExpression.Evaluate(Assailant) * 2 * finalAngle / Math.PI,
+            DamageAmount = Attack.Profile.DamageExpression.EvaluateWith(Assailant,
+                values: [("degree", degree), ("quality", quality)]) * 2 * finalAngle / Math.PI,
             DamageType = Attack.Profile.DamageType,
-            PainAmount = Attack.Profile.PainExpression.Evaluate(Assailant) * 2 * finalAngle / Math.PI,
+            PainAmount = Attack.Profile.PainExpression.EvaluateWith(Assailant,
+                values: [("degree", degree), ("quality", quality)]) * 2 * finalAngle / Math.PI,
             PenetrationOutcome = Outcome.MajorPass,
             ShockAmount = 0,
-            StunAmount = Attack.Profile.DamageExpression.Evaluate(Assailant) * 2 * finalAngle / Math.PI
+            StunAmount = Attack.Profile.DamageExpression.EvaluateWith(Assailant,
+                values: [("degree", degree), ("quality", quality)]) * 2 * finalAngle / Math.PI
         };
 
         Assailant.OutputHandler.Handle(

--- a/MudSharpCore/Combat/Moves/DownedMeleeAttack.cs
+++ b/MudSharpCore/Combat/Moves/DownedMeleeAttack.cs
@@ -46,13 +46,13 @@ public class DownedMeleeAttack : MeleeWeaponAttack
         }
 
         ICheck check = Gameworld.GetCheck(CheckType.StaggeringBlowDefense);
-        DownedMeleeExpressionAttacker.Formula.Parameters["damage"] = result.WoundsCaused.Sum(x => x.OriginalDamage);
-        DownedMeleeExpressionAttacker.Formula.Parameters["stun"] = result.WoundsCaused.Sum(x => x.CurrentStun);
-        double attackerStrength = DownedMeleeExpressionAttacker.Evaluate(Assailant);
+        double attackerStrength = DownedMeleeExpressionAttacker.EvaluateWith(Assailant,
+            values: [("damage", result.WoundsCaused.Sum(x => x.OriginalDamage)),
+                ("stun", result.WoundsCaused.Sum(x => x.CurrentStun))]);
 
-        DownedMeleeExpressionDefender.Formula.Parameters["damage"] = result.WoundsCaused.Sum(x => x.OriginalDamage);
-        DownedMeleeExpressionDefender.Formula.Parameters["stun"] = result.WoundsCaused.Sum(x => x.CurrentStun);
-        double defenderStrength = DownedMeleeExpressionDefender.Evaluate(Target);
+        double defenderStrength = DownedMeleeExpressionDefender.EvaluateWith(Target,
+            values: [("damage", result.WoundsCaused.Sum(x => x.OriginalDamage)),
+                ("stun", result.WoundsCaused.Sum(x => x.CurrentStun))]);
         CheckOutcome cr = check.Check(Target, ((ISecondaryDifficultyAttack)Attack).SecondaryDifficulty, Assailant,
             externalBonus: (defenderStrength - attackerStrength) *
                            Gameworld.GetStaticDouble("StaggeringBlowPenaltyMultiplier"));

--- a/MudSharpCore/Combat/Moves/MagicPowerAttackMove.cs
+++ b/MudSharpCore/Combat/Moves/MagicPowerAttackMove.cs
@@ -157,10 +157,6 @@ public class MagicPowerAttackMove : WeaponAttackMove, IMagicPowerAttackMove
             $"MeleeWeaponAttack Block Outcome: {result.Degree.Describe()} to {result.Outcome.Describe()}");
 #endif
 
-        Attack.Profile.DamageExpression.Formula.Parameters["degree"] = (int)result.Degree;
-        Attack.Profile.StunExpression.Formula.Parameters["degree"] = (int)result.Degree;
-        Attack.Profile.PainExpression.Formula.Parameters["degree"] = (int)result.Degree;
-
         List<IWound> wounds = new();
         List<IWound> wardWounds = new();
 
@@ -174,13 +170,15 @@ public class MagicPowerAttackMove : WeaponAttackMove, IMagicPowerAttackMove
                 AngleOfIncidentRadians = Attack.Profile.BaseAngleOfIncidence,
                 Bodypart = TargetBodypart,
                 DamageAmount =
-                    Attack.Profile.DamageExpression.Evaluate(Assailant,
-                        context: TraitBonusContext.ArmedDamageCalculation) * 2 * Attack.Profile.BaseAngleOfIncidence /
+                    EvaluateAttackFormula(Attack.Profile.DamageExpression, Assailant,
+                        TraitBonusContext.ArmedDamageCalculation, (int)result.Degree, 0) * 2 *
+                    Attack.Profile.BaseAngleOfIncidence /
                     Math.PI,
                 DamageType = Attack.Profile.DamageType,
                 PainAmount =
-                    Attack.Profile.PainExpression.Evaluate(Assailant,
-                        context: TraitBonusContext.ArmedDamageCalculation) * 2 * Attack.Profile.BaseAngleOfIncidence /
+                    EvaluateAttackFormula(Attack.Profile.PainExpression, Assailant,
+                        TraitBonusContext.ArmedDamageCalculation, (int)result.Degree, 0) * 2 *
+                    Attack.Profile.BaseAngleOfIncidence /
                     Math.PI,
                 PenetrationOutcome =
                     Gameworld.GetCheck(CheckType.MeleeWeaponPenetrateCheck)
@@ -189,8 +187,9 @@ public class MagicPowerAttackMove : WeaponAttackMove, IMagicPowerAttackMove
                                  Weapon),
                 ShockAmount = 0,
                 StunAmount =
-                    Attack.Profile.StunExpression.Evaluate(Assailant,
-                        context: TraitBonusContext.ArmedDamageCalculation) * 2 * Attack.Profile.BaseAngleOfIncidence /
+                    EvaluateAttackFormula(Attack.Profile.StunExpression, Assailant,
+                        TraitBonusContext.ArmedDamageCalculation, (int)result.Degree, 0) * 2 *
+                    Attack.Profile.BaseAngleOfIncidence /
                     Math.PI
             };
 
@@ -256,8 +255,8 @@ public class MagicPowerAttackMove : WeaponAttackMove, IMagicPowerAttackMove
                 AngleOfIncidentRadians = finalAngle,
                 Bodypart = null,
                 DamageAmount =
-                    Attack.Profile.DamageExpression.Evaluate(Assailant,
-                        context: TraitBonusContext.ArmedDamageCalculation) * 2 * finalAngle / Math.PI,
+                    EvaluateAttackFormula(Attack.Profile.DamageExpression, Assailant,
+                        TraitBonusContext.ArmedDamageCalculation, (int)result.Degree, 0) * 2 * finalAngle / Math.PI,
                 DamageType = Attack.Profile.DamageType,
                 PainAmount = 0,
                 PenetrationOutcome = Outcome.MajorFail,
@@ -322,10 +321,6 @@ public class MagicPowerAttackMove : WeaponAttackMove, IMagicPowerAttackMove
             $"MeleeWeaponAttack Parry Outcome: {result.Degree.Describe()} to {result.Outcome.Describe()}");
 #endif
 
-        Attack.Profile.DamageExpression.Formula.Parameters["degree"] = (int)result.Degree;
-        Attack.Profile.StunExpression.Formula.Parameters["degree"] = (int)result.Degree;
-        Attack.Profile.PainExpression.Formula.Parameters["degree"] = (int)result.Degree;
-
         List<IWound> wounds = new();
         List<IWound> wardWounds = new();
 
@@ -364,12 +359,12 @@ public class MagicPowerAttackMove : WeaponAttackMove, IMagicPowerAttackMove
                 AngleOfIncidentRadians = finalAngle,
                 Bodypart = TargetBodypart,
                 DamageAmount =
-                    Attack.Profile.DamageExpression.Evaluate(Assailant,
-                        context: TraitBonusContext.ArmedDamageCalculation) * 2 * finalAngle / Math.PI,
+                    EvaluateAttackFormula(Attack.Profile.DamageExpression, Assailant,
+                        TraitBonusContext.ArmedDamageCalculation, (int)result.Degree, 0) * 2 * finalAngle / Math.PI,
                 DamageType = Attack.Profile.DamageType,
                 PainAmount =
-                    Attack.Profile.PainExpression.Evaluate(Assailant,
-                        context: TraitBonusContext.ArmedDamageCalculation) * 2 * finalAngle / Math.PI,
+                    EvaluateAttackFormula(Attack.Profile.PainExpression, Assailant,
+                        TraitBonusContext.ArmedDamageCalculation, (int)result.Degree, 0) * 2 * finalAngle / Math.PI,
                 PenetrationOutcome =
                     Gameworld.GetCheck(CheckType.MeleeWeaponPenetrateCheck)
                              .Check(Assailant, GetPenetrationDifficulty(Attack.Profile.DamageType),
@@ -377,8 +372,8 @@ public class MagicPowerAttackMove : WeaponAttackMove, IMagicPowerAttackMove
                                  Weapon),
                 ShockAmount = 0,
                 StunAmount =
-                    Attack.Profile.StunExpression.Evaluate(Assailant,
-                        context: TraitBonusContext.ArmedDamageCalculation) * 2 * finalAngle / Math.PI
+                    EvaluateAttackFormula(Attack.Profile.StunExpression, Assailant,
+                        TraitBonusContext.ArmedDamageCalculation, (int)result.Degree, 0) * 2 * finalAngle / Math.PI
             };
 
             string parryEmote = Gameworld.CombatMessageManager.GetFailMessageFor(defenderMove.Assailant, Assailant,
@@ -439,7 +434,8 @@ public class MagicPowerAttackMove : WeaponAttackMove, IMagicPowerAttackMove
                 ToolOrigin = null,
                 AngleOfIncidentRadians = finalAngle,
                 Bodypart = null,
-                DamageAmount = Attack.Profile.DamageExpression.Evaluate(Assailant) * 2 * finalAngle / Math.PI,
+                DamageAmount = EvaluateAttackFormula(Attack.Profile.DamageExpression, Assailant,
+                    TraitBonusContext.None, (int)result.Degree, 0) * 2 * finalAngle / Math.PI,
                 DamageType = Attack.Profile.DamageType,
                 PainAmount = 0,
                 PenetrationOutcome = Outcome.MajorFail,
@@ -562,19 +558,15 @@ public class MagicPowerAttackMove : WeaponAttackMove, IMagicPowerAttackMove
 
             double finalAngle = Attack.Profile.BaseAngleOfIncidence * angleMultiplier;
 
-            Attack.Profile.DamageExpression.Formula.Parameters["degree"] = (int)result.Degree;
-            Attack.Profile.StunExpression.Formula.Parameters["degree"] = (int)result.Degree;
-            Attack.Profile.PainExpression.Formula.Parameters["degree"] = (int)result.Degree;
-            Attack.Profile.DamageExpression.Formula.Parameters["quality"] = 0;
-            Attack.Profile.StunExpression.Formula.Parameters["quality"] = 0;
-            Attack.Profile.PainExpression.Formula.Parameters["quality"] = 0;
-
             double damageResult =
-                Attack.Profile.DamageExpression.Evaluate(Assailant, context: TraitBonusContext.ArmedDamageCalculation);
+                EvaluateAttackFormula(Attack.Profile.DamageExpression, Assailant,
+                    TraitBonusContext.ArmedDamageCalculation, (int)result.Degree, 0);
             double stunResult =
-                Attack.Profile.DamageExpression.Evaluate(Assailant, context: TraitBonusContext.ArmedDamageCalculation);
+                EvaluateAttackFormula(Attack.Profile.DamageExpression, Assailant,
+                    TraitBonusContext.ArmedDamageCalculation, (int)result.Degree, 0);
             double painResult =
-                Attack.Profile.DamageExpression.Evaluate(Assailant, context: TraitBonusContext.ArmedDamageCalculation);
+                EvaluateAttackFormula(Attack.Profile.DamageExpression, Assailant,
+                    TraitBonusContext.ArmedDamageCalculation, (int)result.Degree, 0);
 
             Damage damage = new()
             {

--- a/MudSharpCore/Combat/Moves/MeleeWeaponAttack.cs
+++ b/MudSharpCore/Combat/Moves/MeleeWeaponAttack.cs
@@ -203,13 +203,6 @@ public class MeleeWeaponAttack : WeaponAttackMove
             $"MeleeWeaponAttack Block Outcome: {result.Degree.Describe()} to {result.Outcome.Describe()}");
 #endif
 
-        Attack.Profile.DamageExpression.Formula.Parameters["degree"] = (int)result.Degree;
-        Attack.Profile.DamageExpression.Formula.Parameters["quality"] = (int)Weapon.Parent.Quality;
-        Attack.Profile.StunExpression.Formula.Parameters["degree"] = (int)result.Degree;
-        Attack.Profile.StunExpression.Formula.Parameters["quality"] = (int)Weapon.Parent.Quality;
-        Attack.Profile.PainExpression.Formula.Parameters["degree"] = (int)result.Degree;
-        Attack.Profile.PainExpression.Formula.Parameters["quality"] = (int)Weapon.Parent.Quality;
-
         List<IWound> wounds = new();
         List<IWound> wardWounds = new();
 
@@ -223,13 +216,15 @@ public class MeleeWeaponAttack : WeaponAttackMove
                 AngleOfIncidentRadians = Attack.Profile.BaseAngleOfIncidence,
                 Bodypart = TargetBodypart,
                 DamageAmount =
-                    Attack.Profile.DamageExpression.Evaluate(Assailant,
-                        context: TraitBonusContext.ArmedDamageCalculation) * 2 * Attack.Profile.BaseAngleOfIncidence /
+                    EvaluateAttackFormula(Attack.Profile.DamageExpression, Assailant,
+                        TraitBonusContext.ArmedDamageCalculation, (int)result.Degree, (int)Weapon.Parent.Quality) *
+                    2 * Attack.Profile.BaseAngleOfIncidence /
                     Math.PI,
                 DamageType = Attack.Profile.DamageType,
                 PainAmount =
-                    Attack.Profile.PainExpression.Evaluate(Assailant,
-                        context: TraitBonusContext.ArmedDamageCalculation) * 2 * Attack.Profile.BaseAngleOfIncidence /
+                    EvaluateAttackFormula(Attack.Profile.PainExpression, Assailant,
+                        TraitBonusContext.ArmedDamageCalculation, (int)result.Degree, (int)Weapon.Parent.Quality) *
+                    2 * Attack.Profile.BaseAngleOfIncidence /
                     Math.PI,
                 PenetrationOutcome =
                     Gameworld.GetCheck(CheckType.MeleeWeaponPenetrateCheck)
@@ -238,8 +233,9 @@ public class MeleeWeaponAttack : WeaponAttackMove
                                  Weapon),
                 ShockAmount = 0,
                 StunAmount =
-                    Attack.Profile.StunExpression.Evaluate(Assailant,
-                        context: TraitBonusContext.ArmedDamageCalculation) * 2 * Attack.Profile.BaseAngleOfIncidence /
+                    EvaluateAttackFormula(Attack.Profile.StunExpression, Assailant,
+                        TraitBonusContext.ArmedDamageCalculation, (int)result.Degree, (int)Weapon.Parent.Quality) *
+                    2 * Attack.Profile.BaseAngleOfIncidence /
                     Math.PI
             };
 
@@ -305,8 +301,9 @@ public class MeleeWeaponAttack : WeaponAttackMove
                 AngleOfIncidentRadians = finalAngle,
                 Bodypart = null,
                 DamageAmount =
-                    Attack.Profile.DamageExpression.Evaluate(Assailant,
-                        context: TraitBonusContext.ArmedDamageCalculation) * 2 * finalAngle / Math.PI,
+                    EvaluateAttackFormula(Attack.Profile.DamageExpression, Assailant,
+                        TraitBonusContext.ArmedDamageCalculation, (int)result.Degree, (int)Weapon.Parent.Quality) *
+                    2 * finalAngle / Math.PI,
                 DamageType = Attack.Profile.DamageType,
                 PainAmount = 0,
                 PenetrationOutcome = Outcome.MajorFail,
@@ -378,13 +375,6 @@ public class MeleeWeaponAttack : WeaponAttackMove
             $"MeleeWeaponAttack Parry Outcome: {result.Degree.Describe()} to {result.Outcome.Describe()}");
 #endif
 
-        Attack.Profile.DamageExpression.Formula.Parameters["degree"] = (int)result.Degree;
-        Attack.Profile.DamageExpression.Formula.Parameters["quality"] = (int)Weapon.Parent.Quality;
-        Attack.Profile.StunExpression.Formula.Parameters["degree"] = (int)result.Degree;
-        Attack.Profile.StunExpression.Formula.Parameters["quality"] = (int)Weapon.Parent.Quality;
-        Attack.Profile.PainExpression.Formula.Parameters["degree"] = (int)result.Degree;
-        Attack.Profile.PainExpression.Formula.Parameters["quality"] = (int)Weapon.Parent.Quality;
-
         List<IWound> wounds = new();
         List<IWound> wardWounds = new();
 
@@ -423,12 +413,14 @@ public class MeleeWeaponAttack : WeaponAttackMove
                 AngleOfIncidentRadians = finalAngle,
                 Bodypart = TargetBodypart,
                 DamageAmount =
-                    Attack.Profile.DamageExpression.Evaluate(Assailant,
-                        context: TraitBonusContext.ArmedDamageCalculation) * 2 * finalAngle / Math.PI,
+                    EvaluateAttackFormula(Attack.Profile.DamageExpression, Assailant,
+                        TraitBonusContext.ArmedDamageCalculation, (int)result.Degree, (int)Weapon.Parent.Quality) *
+                    2 * finalAngle / Math.PI,
                 DamageType = Attack.Profile.DamageType,
                 PainAmount =
-                    Attack.Profile.PainExpression.Evaluate(Assailant,
-                        context: TraitBonusContext.ArmedDamageCalculation) * 2 * finalAngle / Math.PI,
+                    EvaluateAttackFormula(Attack.Profile.PainExpression, Assailant,
+                        TraitBonusContext.ArmedDamageCalculation, (int)result.Degree, (int)Weapon.Parent.Quality) *
+                    2 * finalAngle / Math.PI,
                 PenetrationOutcome =
                     Gameworld.GetCheck(CheckType.MeleeWeaponPenetrateCheck)
                              .Check(Assailant, GetPenetrationDifficulty(Attack.Profile.DamageType),
@@ -436,8 +428,9 @@ public class MeleeWeaponAttack : WeaponAttackMove
                                  Weapon),
                 ShockAmount = 0,
                 StunAmount =
-                    Attack.Profile.StunExpression.Evaluate(Assailant,
-                        context: TraitBonusContext.ArmedDamageCalculation) * 2 * finalAngle / Math.PI
+                    EvaluateAttackFormula(Attack.Profile.StunExpression, Assailant,
+                        TraitBonusContext.ArmedDamageCalculation, (int)result.Degree, (int)Weapon.Parent.Quality) *
+                    2 * finalAngle / Math.PI
             };
 
             string parryEmote = Gameworld.CombatMessageManager.GetFailMessageFor(defenderMove.Assailant, Assailant,
@@ -498,7 +491,8 @@ public class MeleeWeaponAttack : WeaponAttackMove
                 ToolOrigin = null,
                 AngleOfIncidentRadians = finalAngle,
                 Bodypart = null,
-                DamageAmount = Attack.Profile.DamageExpression.Evaluate(Assailant) * 2 * finalAngle / Math.PI,
+                DamageAmount = EvaluateAttackFormula(Attack.Profile.DamageExpression, Assailant,
+                    TraitBonusContext.None, (int)result.Degree, (int)Weapon.Parent.Quality) * 2 * finalAngle / Math.PI,
                 DamageType = Attack.Profile.DamageType,
                 PainAmount = 0,
                 PenetrationOutcome = Outcome.MajorFail,

--- a/MudSharpCore/Combat/Moves/MeleeWeaponSmashItemAttack.cs
+++ b/MudSharpCore/Combat/Moves/MeleeWeaponSmashItemAttack.cs
@@ -55,11 +55,10 @@ public class MeleeWeaponSmashItemAttack : WeaponAttackMove
         CheckOutcome check = Gameworld.GetCheck(CheckType.MeleeWeaponCheck)
                              .Check(Assailant, Difficulty.Easy, Weapon.WeaponType.AttackTrait, Target);
         OpposedOutcome result = new(check, Outcome.NotTested);
-        Attack.Profile.DamageExpression.Formula.Parameters["degree"] = (int)result.Degree;
-        Attack.Profile.DamageExpression.Formula.Parameters["quality"] = (int)Weapon.Parent.Quality;
 
-        double damage = Attack.Profile.DamageExpression.Evaluate(Assailant) * 2 * Attack.Profile.BaseAngleOfIncidence /
-                     Math.PI;
+        double damage = Attack.Profile.DamageExpression.EvaluateWith(Assailant,
+                            values: [("degree", (int)result.Degree), ("quality", (int)Weapon.Parent.Quality)]) * 2 *
+                        Attack.Profile.BaseAngleOfIncidence / Math.PI;
 
         Damage finalDamage = new()
         {

--- a/MudSharpCore/Combat/Moves/RangedWeaponAttackBase.cs
+++ b/MudSharpCore/Combat/Moves/RangedWeaponAttackBase.cs
@@ -79,14 +79,15 @@ public abstract class RangedWeaponAttackBase : CombatMoveBase, IRangedWeaponAtta
             return 0.0;
         }
 
-        TargetExpression.Parameters["range"] = range;
-        TargetExpression.Parameters["average"] = target.Bodyparts.Average(x => x.RelativeHitChance);
-        TargetExpression.Parameters["chance"] = Assailant.TargettedBodypart.RelativeHitChance;
+        double averageChance = target.Bodyparts.Average(x => x.RelativeHitChance);
+        double targetChance = Assailant.TargettedBodypart.RelativeHitChance;
+        double targetPenalty = TargetExpression.EvaluateDoubleWith(("range", range), ("average", averageChance),
+            ("chance", targetChance));
 #if DEBUG
         Console.WriteLine(
-            $"Target Range Penalty r{range} a{target.Bodyparts.Average(x => x.RelativeHitChance)} c{Assailant.TargettedBodypart.RelativeHitChance}: {Convert.ToDouble(TargetExpression.Evaluate())}");
+            $"Target Range Penalty r{range} a{averageChance} c{targetChance}: {targetPenalty}");
 #endif
-        return Convert.ToDouble(TargetExpression.Evaluate());
+        return targetPenalty;
     }
 
     private static Expression _targetExpression;
@@ -152,14 +153,10 @@ public abstract class RangedWeaponAttackBase : CombatMoveBase, IRangedWeaponAtta
 					DefenderOutcome = Outcome.NotTested
 				};
 			}
-		}
+        }
 
         IHaveABody targetHb = target as IHaveABody;
-        Weapon.WeaponType.AccuracyBonusExpression.Formula.Parameters["quality"] = (int)Weapon.Parent.Quality;
         int range = Assailant.DistanceBetween(target, 10);
-        Weapon.WeaponType.AccuracyBonusExpression.Formula.Parameters["range"] = range;
-        Weapon.WeaponType.AccuracyBonusExpression.Formula.Parameters["inmelee"] = Assailant.MeleeRange ? 1 : 0;
-        Weapon.WeaponType.AccuracyBonusExpression.Formula.Parameters["aim"] = Assailant.Aim?.AimPercentage ?? 0;
         ICheck check = Gameworld.GetCheck(Weapon.WeaponType.FireCheck);
         Difficulty difficulty = Assailant.GetDifficultyForTool(Weapon.Parent, Weapon.WeaponType.BaseAimDifficulty)
                                   .StageUp(Assailant.TargettedBodypart != null ? 1 : 0);
@@ -249,7 +246,10 @@ public abstract class RangedWeaponAttackBase : CombatMoveBase, IRangedWeaponAtta
                 results = check.MultiDifficultyCheck(Assailant, difficulty, coverDifficulty, target,
                     Weapon.WeaponType.FireTrait,
                     // Bonuses
-                    Weapon.WeaponType.AccuracyBonusExpression.Evaluate(Assailant, Weapon.WeaponType.FireTrait) +
+                    Weapon.WeaponType.AccuracyBonusExpression.EvaluateWith(Assailant, Weapon.WeaponType.FireTrait,
+                        values: [("quality", (int)Weapon.Parent.Quality), ("range", range),
+                            ("inmelee", Assailant.MeleeRange ? 1 : 0),
+                            ("aim", Assailant.Aim?.AimPercentage ?? 0)]) +
                     ((Weapon as IFirearm)?.EffectiveAccuracyBonus ?? 0.0) +
                     Weapon.Parent
                           .EffectsOfType<IMagicWeaponEnhancementEffect>(x =>

--- a/MudSharpCore/Combat/Moves/RepositionMove.cs
+++ b/MudSharpCore/Combat/Moves/RepositionMove.cs
@@ -1,5 +1,6 @@
 ﻿using MudSharp.Body.Position;
 using MudSharp.RPG.Checks;
+using MoreLinq;
 
 namespace MudSharp.Combat.Moves;
 
@@ -25,7 +26,7 @@ public class RepositionMove : CombatMoveBase
         ICombatMove opponent =
             Assailant.Combat.Combatants.Where(x => x.CombatTarget == Assailant)
                      .SelectNotNull(x => x.ResponseToMove(this, Assailant))
-                     .Shuffle()
+                     .Shuffle(Constants.Random)
                      .FirstOrDefault();
         if (opponent == null || opponent is HelplessDefenseMove)
         {

--- a/MudSharpCore/Combat/Moves/ScreechAttackMove.cs
+++ b/MudSharpCore/Combat/Moves/ScreechAttackMove.cs
@@ -43,17 +43,10 @@ public class ScreechAttackMove : NaturalAttackMove
 		                       .OfType<ICharacter>()
 		                       .Where(x => x.RoomLayer == Assailant.RoomLayer)
                                .Where(x => x.Body.Bodyparts.Any(y => y.Organs.Any(z => z is EarProto)))
-		                       .Distinct()
+			                       .Distinct()
                                .ToList();
-        Attack.Profile.DamageExpression.Formula.Parameters["degree"] = attackRoll.Outcome.CheckDegrees();
-        Attack.Profile.DamageExpression.Formula.Parameters["quality"] =
-            (int)Assailant.NaturalWeaponQuality(NaturalAttack);
-        Attack.Profile.StunExpression.Formula.Parameters["degree"] = attackRoll.Outcome.CheckDegrees();
-        Attack.Profile.StunExpression.Formula.Parameters["quality"] =
-            (int)Assailant.NaturalWeaponQuality(NaturalAttack);
-        Attack.Profile.PainExpression.Formula.Parameters["degree"] = attackRoll.Outcome.CheckDegrees();
-        Attack.Profile.PainExpression.Formula.Parameters["quality"] =
-            (int)Assailant.NaturalWeaponQuality(NaturalAttack);
+        int formulaDegree = attackRoll.Outcome.CheckDegrees();
+        int quality = (int)Assailant.NaturalWeaponQuality(NaturalAttack);
 
         Damage baseDamage = new()
         {
@@ -63,14 +56,17 @@ public class ScreechAttackMove : NaturalAttackMove
             AngleOfIncidentRadians = Attack.Profile.BaseAngleOfIncidence,
             Bodypart = null,
             DamageAmount =
-                Attack.Profile.DamageExpression.Evaluate(Assailant),
+                Attack.Profile.DamageExpression.EvaluateWith(Assailant,
+                    values: [("degree", formulaDegree), ("quality", quality)]),
             DamageType = Attack.Profile.DamageType,
             PainAmount =
-                Attack.Profile.PainExpression.Evaluate(Assailant),
+                Attack.Profile.PainExpression.EvaluateWith(Assailant,
+                    values: [("degree", formulaDegree), ("quality", quality)]),
             PenetrationOutcome = Outcome.NotTested,
             ShockAmount = 0,
             StunAmount =
-                Attack.Profile.DamageExpression.Evaluate(Assailant)
+                Attack.Profile.DamageExpression.EvaluateWith(Assailant,
+                    values: [("degree", formulaDegree), ("quality", quality)])
         };
 
         List<IWound> wounds = new();

--- a/MudSharpCore/Combat/Moves/StaggeringBlowMove.cs
+++ b/MudSharpCore/Combat/Moves/StaggeringBlowMove.cs
@@ -45,19 +45,20 @@ public class StaggeringBlowMove : MeleeWeaponAttack
         }
 
         ICheck check = Gameworld.GetCheck(CheckType.StaggeringBlowDefense);
-        StaggeringBlowExpressionAttacker.Formula.Parameters["damage"] = result.WoundsCaused.Sum(x => x.OriginalDamage);
-        StaggeringBlowExpressionAttacker.Formula.Parameters["stun"] = result.WoundsCaused.Sum(x => x.CurrentStun);
-        StaggeringBlowExpressionAttacker.Formula.Parameters["weight"] = Assailant.Weight;
-        StaggeringBlowExpressionAttacker.Formula.Parameters["height"] = Assailant.Height;
         double attackerStrength =
-            StaggeringBlowExpressionAttacker.Evaluate(Assailant, context: TraitBonusContext.StaggeringBlowCheck);
+            StaggeringBlowExpressionAttacker.EvaluateWith(Assailant, null, TraitBonusContext.StaggeringBlowCheck,
+                ("damage", result.WoundsCaused.Sum(x => x.OriginalDamage)),
+                ("stun", result.WoundsCaused.Sum(x => x.CurrentStun)),
+                ("weight", Assailant.Weight),
+                ("height", Assailant.Height));
 
-        StaggeringBlowExpressionDefender.Formula.Parameters["damage"] = result.WoundsCaused.Sum(x => x.OriginalDamage);
-        StaggeringBlowExpressionDefender.Formula.Parameters["stun"] = result.WoundsCaused.Sum(x => x.CurrentStun);
-        StaggeringBlowExpressionDefender.Formula.Parameters["weight"] = Target.Weight;
-        StaggeringBlowExpressionDefender.Formula.Parameters["height"] = Target.Height;
         double defenderStrength =
-            StaggeringBlowExpressionDefender.Evaluate(Target, context: TraitBonusContext.StaggeringBlowDefenseCheck);
+            StaggeringBlowExpressionDefender.EvaluateWith(Target, null,
+                TraitBonusContext.StaggeringBlowDefenseCheck,
+                ("damage", result.WoundsCaused.Sum(x => x.OriginalDamage)),
+                ("stun", result.WoundsCaused.Sum(x => x.CurrentStun)),
+                ("weight", Target.Weight),
+                ("height", Target.Height));
         CheckOutcome cr = check.Check(Target, ((ISecondaryDifficultyAttack)Attack).SecondaryDifficulty, Assailant,
             externalBonus: (defenderStrength - attackerStrength) *
                            Gameworld.GetStaticDouble("StaggeringBlowPenaltyMultiplier"));

--- a/MudSharpCore/Combat/Moves/StaggeringBlowUnarmedMove.cs
+++ b/MudSharpCore/Combat/Moves/StaggeringBlowUnarmedMove.cs
@@ -54,19 +54,20 @@ public class StaggeringBlowUnarmedMove : NaturalAttackMove
         }
 
         ICheck check = Gameworld.GetCheck(CheckType.StaggeringBlowDefense);
-        StaggeringBlowExpressionAttacker.Formula.Parameters["damage"] = result.WoundsCaused.Sum(x => x.OriginalDamage);
-        StaggeringBlowExpressionAttacker.Formula.Parameters["stun"] = result.WoundsCaused.Sum(x => x.CurrentStun);
-        StaggeringBlowExpressionAttacker.Formula.Parameters["weight"] = Assailant.Weight;
-        StaggeringBlowExpressionAttacker.Formula.Parameters["height"] = Assailant.Height;
         double attackerStrength =
-            StaggeringBlowExpressionAttacker.Evaluate(Assailant, context: TraitBonusContext.StaggeringBlowCheck);
+            StaggeringBlowExpressionAttacker.EvaluateWith(Assailant, null, TraitBonusContext.StaggeringBlowCheck,
+                ("damage", result.WoundsCaused.Sum(x => x.OriginalDamage)),
+                ("stun", result.WoundsCaused.Sum(x => x.CurrentStun)),
+                ("weight", Assailant.Weight),
+                ("height", Assailant.Height));
 
-        StaggeringBlowExpressionDefender.Formula.Parameters["damage"] = result.WoundsCaused.Sum(x => x.OriginalDamage);
-        StaggeringBlowExpressionDefender.Formula.Parameters["stun"] = result.WoundsCaused.Sum(x => x.CurrentStun);
-        StaggeringBlowExpressionDefender.Formula.Parameters["weight"] = Target.Weight;
-        StaggeringBlowExpressionDefender.Formula.Parameters["height"] = Target.Height;
         double defenderStrength =
-            StaggeringBlowExpressionDefender.Evaluate(Target, context: TraitBonusContext.StaggeringBlowDefenseCheck);
+            StaggeringBlowExpressionDefender.EvaluateWith(Target, null,
+                TraitBonusContext.StaggeringBlowDefenseCheck,
+                ("damage", result.WoundsCaused.Sum(x => x.OriginalDamage)),
+                ("stun", result.WoundsCaused.Sum(x => x.CurrentStun)),
+                ("weight", Target.Weight),
+                ("height", Target.Height));
         CheckOutcome cr = check.Check(Target, ((ISecondaryDifficultyAttack)Attack).SecondaryDifficulty, Assailant,
             externalBonus: (defenderStrength - attackerStrength) *
                            Gameworld.GetStaticDouble("StaggeringBlowPenaltyMultiplier"));

--- a/MudSharpCore/Combat/Moves/StandMove.cs
+++ b/MudSharpCore/Combat/Moves/StandMove.cs
@@ -1,6 +1,7 @@
 ﻿using MudSharp.Body.Position;
 using MudSharp.Body.Position.PositionStates;
 using MudSharp.RPG.Checks;
+using MoreLinq;
 
 namespace MudSharp.Combat.Moves;
 
@@ -25,7 +26,7 @@ public class StandMove : CombatMoveBase
         ICombatMove opponent =
             Assailant.Combat.Combatants.Where(x => x.CombatTarget == Assailant)
                      .SelectNotNull(x => x.ResponseToMove(this, Assailant))
-                     .Shuffle()
+                     .Shuffle(Constants.Random)
                      .FirstOrDefault();
         if (opponent == null || opponent is HelplessDefenseMove)
         {

--- a/MudSharpCore/Combat/Moves/StrangleAttack.cs
+++ b/MudSharpCore/Combat/Moves/StrangleAttack.cs
@@ -97,12 +97,8 @@ public class StrangleAttack : NaturalAttackMove
             style: OutputStyle.CombatMessage, flags: OutputFlags.InnerWrap));
 
         List<IWound> wounds = new();
-        Attack.Profile.DamageExpression.Formula.Parameters["degree"] = (int)degree;
-        Attack.Profile.DamageExpression.Formula.Parameters["quality"] = Assailant.NaturalWeaponQuality(NaturalAttack);
-        Attack.Profile.StunExpression.Formula.Parameters["degree"] = (int)degree;
-        Attack.Profile.StunExpression.Formula.Parameters["quality"] = Assailant.NaturalWeaponQuality(NaturalAttack);
-        Attack.Profile.PainExpression.Formula.Parameters["degree"] = (int)degree;
-        Attack.Profile.PainExpression.Formula.Parameters["quality"] = Assailant.NaturalWeaponQuality(NaturalAttack);
+        int formulaDegree = (int)degree;
+        var quality = Assailant.NaturalWeaponQuality(NaturalAttack);
 
         Damage finalDamage = new()
         {
@@ -112,13 +108,16 @@ public class StrangleAttack : NaturalAttackMove
             AngleOfIncidentRadians = Attack.Profile.BaseAngleOfIncidence,
             Bodypart = targetBodypart,
             DamageAmount =
-                Attack.Profile.DamageExpression.Evaluate(Assailant),
+                Attack.Profile.DamageExpression.EvaluateWith(Assailant,
+                    values: [("degree", formulaDegree), ("quality", quality)]),
             DamageType = Attack.Profile.DamageType,
             PainAmount =
-                Attack.Profile.PainExpression.Evaluate(Assailant),
+                Attack.Profile.PainExpression.EvaluateWith(Assailant,
+                    values: [("degree", formulaDegree), ("quality", quality)]),
             PenetrationOutcome = Outcome.NotTested,
             ShockAmount = 0,
-            StunAmount = Attack.Profile.DamageExpression.Evaluate(Assailant)
+            StunAmount = Attack.Profile.DamageExpression.EvaluateWith(Assailant,
+                values: [("degree", formulaDegree), ("quality", quality)])
         };
 
         IEffect effect = Assailant.EffectsOfType<Strangling>().FirstOrDefault(x => x.Target == CharacterTarget);

--- a/MudSharpCore/Combat/Moves/TakedownMove.cs
+++ b/MudSharpCore/Combat/Moves/TakedownMove.cs
@@ -97,22 +97,18 @@ public class TakedownMove : WeaponAttackMove
         OpposedOutcome result = new(attackRoll, Outcome.NotTested);
         OpposedOutcomeDegree degree = result.Degree;
 
-        Attack.Profile.DamageExpression.Formula.Parameters["degree"] = (int)degree;
-        Attack.Profile.DamageExpression.Formula.Parameters["quality"] =
-            (int)Assailant.NaturalWeaponQuality(NaturalAttack);
-        Attack.Profile.StunExpression.Formula.Parameters["degree"] = (int)degree;
-        Attack.Profile.StunExpression.Formula.Parameters["quality"] =
-            (int)Assailant.NaturalWeaponQuality(NaturalAttack);
-        Attack.Profile.PainExpression.Formula.Parameters["degree"] = (int)degree;
-        Attack.Profile.PainExpression.Formula.Parameters["quality"] =
-            (int)Assailant.NaturalWeaponQuality(NaturalAttack);
+        int formulaDegree = (int)degree;
+        int quality = (int)Assailant.NaturalWeaponQuality(NaturalAttack);
 
         double damageResult =
-            Attack.Profile.DamageExpression.Evaluate(Assailant, context: TraitBonusContext.UnarmedDamageCalculation);
+            Attack.Profile.DamageExpression.EvaluateWith(Assailant, null, TraitBonusContext.UnarmedDamageCalculation,
+                ("degree", formulaDegree), ("quality", quality));
         double stunResult =
-            Attack.Profile.DamageExpression.Evaluate(Assailant, context: TraitBonusContext.UnarmedDamageCalculation);
+            Attack.Profile.DamageExpression.EvaluateWith(Assailant, null, TraitBonusContext.UnarmedDamageCalculation,
+                ("degree", formulaDegree), ("quality", quality));
         double painResult =
-            Attack.Profile.DamageExpression.Evaluate(Assailant, context: TraitBonusContext.UnarmedDamageCalculation);
+            Attack.Profile.DamageExpression.EvaluateWith(Assailant, null, TraitBonusContext.UnarmedDamageCalculation,
+                ("degree", formulaDegree), ("quality", quality));
 
 		CharacterTarget.DoCombatKnockdown(attackRoll.Outcome.SuccessDegrees(),
 			VehicleCombatDisplacementType.Throw);

--- a/MudSharpCore/Combat/Moves/UnarmedDownedMeleeAttack.cs
+++ b/MudSharpCore/Combat/Moves/UnarmedDownedMeleeAttack.cs
@@ -41,15 +41,15 @@ public class UnarmedDownedMeleeAttack : NaturalAttackMove
         }
 
         ICheck check = Gameworld.GetCheck(CheckType.StaggeringBlowDefense);
-        DownedMeleeExpressionAttacker.Formula.Parameters["damage"] = result.WoundsCaused.Sum(x => x.OriginalDamage);
-        DownedMeleeExpressionAttacker.Formula.Parameters["stun"] = result.WoundsCaused.Sum(x => x.CurrentStun);
         double attackerStrength =
-            DownedMeleeExpressionAttacker.Evaluate(Assailant, context: TraitBonusContext.StaggeringBlowCheck);
+            DownedMeleeExpressionAttacker.EvaluateWith(Assailant, null, TraitBonusContext.StaggeringBlowCheck,
+                ("damage", result.WoundsCaused.Sum(x => x.OriginalDamage)),
+                ("stun", result.WoundsCaused.Sum(x => x.CurrentStun)));
 
-        DownedMeleeExpressionDefender.Formula.Parameters["damage"] = result.WoundsCaused.Sum(x => x.OriginalDamage);
-        DownedMeleeExpressionDefender.Formula.Parameters["stun"] = result.WoundsCaused.Sum(x => x.CurrentStun);
         double defenderStrength =
-            DownedMeleeExpressionDefender.Evaluate(Target, context: TraitBonusContext.StaggeringBlowDefenseCheck);
+            DownedMeleeExpressionDefender.EvaluateWith(Target, null, TraitBonusContext.StaggeringBlowDefenseCheck,
+                ("damage", result.WoundsCaused.Sum(x => x.OriginalDamage)),
+                ("stun", result.WoundsCaused.Sum(x => x.CurrentStun)));
         CheckOutcome cr = check.Check(Target, ((ISecondaryDifficultyAttack)Attack).SecondaryDifficulty, Assailant,
             externalBonus: (defenderStrength - attackerStrength) *
                            Gameworld.GetStaticDouble("StaggeringBlowPenaltyMultiplier"));

--- a/MudSharpCore/Combat/Moves/UnarmedSmashItemAttack.cs
+++ b/MudSharpCore/Combat/Moves/UnarmedSmashItemAttack.cs
@@ -57,8 +57,6 @@ public class UnarmedSmashItemAttack : WeaponAttackMove
         CrimeExtensions.CheckPossibleCrimeAllAuthorities(Assailant, CrimeTypes.Vandalism, null, Target, "");
         CheckOutcome check = Gameworld.GetCheck(CheckType.NaturalWeaponAttack).Check(Assailant, Difficulty.Easy, Target, null);
         OpposedOutcome result = new(check, Outcome.NotTested);
-        Attack.Profile.DamageExpression.Formula.Parameters["degree"] = (int)result.Degree;
-        Attack.Profile.DamageExpression.Formula.Parameters["quality"] = (int)NaturalAttack.Quality;
 
         Tuple<IDamage, IDamage> damages = GetDamagePlusSelfDamage(null, Bodypart, null, Target.Material, check.Outcome,
             NaturalAttack.Attack.Profile.DamageType, NaturalAttack.Attack.Profile.BaseAngleOfIncidence, NaturalAttack,

--- a/MudSharpCore/Combat/Moves/UnbalancingBlowMove.cs
+++ b/MudSharpCore/Combat/Moves/UnbalancingBlowMove.cs
@@ -45,20 +45,21 @@ public class UnbalancingBlowMove : MeleeWeaponAttack
         }
 
         ICheck check = Gameworld.GetCheck(CheckType.StaggeringBlowDefense);
-        UnbalancingBlowExpressionAttacker.Formula.Parameters["damage"] = result.WoundsCaused.Sum(x => x.OriginalDamage);
-        UnbalancingBlowExpressionAttacker.Formula.Parameters["stun"] = result.WoundsCaused.Sum(x => x.CurrentStun);
-        UnbalancingBlowExpressionAttacker.Formula.Parameters["pain"] = result.WoundsCaused.Sum(x => x.CurrentPain);
-        UnbalancingBlowExpressionAttacker.Formula.Parameters["degree"] = result.AttackerOutcome.CheckDegrees();
         double attackerStrength =
-            UnbalancingBlowExpressionAttacker.Evaluate(Assailant, context: TraitBonusContext.UnbalancingBlowCheck);
+            UnbalancingBlowExpressionAttacker.EvaluateWith(Assailant, null, TraitBonusContext.UnbalancingBlowCheck,
+                ("damage", result.WoundsCaused.Sum(x => x.OriginalDamage)),
+                ("stun", result.WoundsCaused.Sum(x => x.CurrentStun)),
+                ("pain", result.WoundsCaused.Sum(x => x.CurrentPain)),
+                ("degree", result.AttackerOutcome.CheckDegrees()));
 
-        UnbalancingBlowExpressionDefender.Formula.Parameters["damage"] = result.WoundsCaused.Sum(x => x.OriginalDamage);
-        UnbalancingBlowExpressionDefender.Formula.Parameters["stun"] = result.WoundsCaused.Sum(x => x.CurrentStun);
-        UnbalancingBlowExpressionDefender.Formula.Parameters["pain"] = result.WoundsCaused.Sum(x => x.CurrentPain);
-        UnbalancingBlowExpressionDefender.Formula.Parameters["degree"] = result.DefenderOutcome.CheckDegrees();
-        UnbalancingBlowExpressionDefender.Formula.Parameters["limbs"] = 0;
         double defenderStrength =
-            UnbalancingBlowExpressionDefender.Evaluate(Target, context: TraitBonusContext.UnbalancingBlowDefenseCheck);
+            UnbalancingBlowExpressionDefender.EvaluateWith(Target, null,
+                TraitBonusContext.UnbalancingBlowDefenseCheck,
+                ("damage", result.WoundsCaused.Sum(x => x.OriginalDamage)),
+                ("stun", result.WoundsCaused.Sum(x => x.CurrentStun)),
+                ("pain", result.WoundsCaused.Sum(x => x.CurrentPain)),
+                ("degree", result.DefenderOutcome.CheckDegrees()),
+                ("limbs", 0));
         CheckOutcome cr = check.Check(Target, ((ISecondaryDifficultyAttack)Attack).SecondaryDifficulty, Assailant,
             externalBonus: (defenderStrength - attackerStrength) *
                            Gameworld.GetStaticDouble("UnbalancingBlowPenaltyMultiplier"));

--- a/MudSharpCore/Combat/Moves/UnbalancingBlowUnarmedMove.cs
+++ b/MudSharpCore/Combat/Moves/UnbalancingBlowUnarmedMove.cs
@@ -50,23 +50,22 @@ public class UnbalancingBlowUnarmedMove : NaturalAttackMove
         }
 
         ICheck check = Gameworld.GetCheck(CheckType.StaggeringBlowDefense);
-        UnbalancingBlowExpressionAttacker.Formula.Parameters["damage"] = result.WoundsCaused.Sum(x => x.OriginalDamage);
-        UnbalancingBlowExpressionAttacker.Formula.Parameters["stun"] = result.WoundsCaused.Sum(x => x.CurrentStun);
-        UnbalancingBlowExpressionAttacker.Formula.Parameters["pain"] = result.WoundsCaused.Sum(x => x.CurrentPain);
-        UnbalancingBlowExpressionAttacker.Formula.Parameters["degree"] = result.AttackerOutcome.CheckDegrees();
         double attackerStrength =
-            UnbalancingBlowExpressionAttacker.Evaluate(Assailant, context: TraitBonusContext.UnbalancingBlowCheck);
-
-        UnbalancingBlowExpressionDefender.Formula.Parameters["damage"] = result.WoundsCaused.Sum(x => x.OriginalDamage);
-        UnbalancingBlowExpressionDefender.Formula.Parameters["stun"] = result.WoundsCaused.Sum(x => x.CurrentStun);
-        UnbalancingBlowExpressionDefender.Formula.Parameters["pain"] = result.WoundsCaused.Sum(x => x.CurrentPain);
-        UnbalancingBlowExpressionDefender.Formula.Parameters["degree"] = result.DefenderOutcome.CheckDegrees();
-        UnbalancingBlowExpressionDefender.Formula.Parameters["limbs"] = Target.CombinedEffectsOfType<BeingGrappled>()
-                                                                              .Sum(x => x.Grappling.LimbsUnderControl
-                                                                                  .Count());
+            UnbalancingBlowExpressionAttacker.EvaluateWith(Assailant, null, TraitBonusContext.UnbalancingBlowCheck,
+                ("damage", result.WoundsCaused.Sum(x => x.OriginalDamage)),
+                ("stun", result.WoundsCaused.Sum(x => x.CurrentStun)),
+                ("pain", result.WoundsCaused.Sum(x => x.CurrentPain)),
+                ("degree", result.AttackerOutcome.CheckDegrees()));
 
         double defenderStrength =
-            UnbalancingBlowExpressionDefender.Evaluate(Target, context: TraitBonusContext.UnbalancingBlowDefenseCheck);
+            UnbalancingBlowExpressionDefender.EvaluateWith(Target, null,
+                TraitBonusContext.UnbalancingBlowDefenseCheck,
+                ("damage", result.WoundsCaused.Sum(x => x.OriginalDamage)),
+                ("stun", result.WoundsCaused.Sum(x => x.CurrentStun)),
+                ("pain", result.WoundsCaused.Sum(x => x.CurrentPain)),
+                ("degree", result.DefenderOutcome.CheckDegrees()),
+                ("limbs", Target.CombinedEffectsOfType<BeingGrappled>()
+                    .Sum(x => x.Grappling.LimbsUnderControl.Count())));
         CheckOutcome cr = check.Check(Target, ((ISecondaryDifficultyAttack)Attack).SecondaryDifficulty, Assailant,
             externalBonus: (defenderStrength - attackerStrength) *
                            Gameworld.GetStaticDouble("UnbalancingBlowPenaltyMultiplier"));

--- a/MudSharpCore/Combat/Moves/WeaponAttackMove.cs
+++ b/MudSharpCore/Combat/Moves/WeaponAttackMove.cs
@@ -21,6 +21,12 @@ public abstract class WeaponAttackMove : CombatMoveBase, IWeaponAttackMove
 
     public virtual double BloodSprayMultiplier => 0.0;
 
+    protected static double EvaluateAttackFormula(ITraitExpression formula, IHaveTraits owner,
+        TraitBonusContext context, object degree, object quality)
+    {
+        return formula.EvaluateWith(owner, null, context, ("degree", degree), ("quality", quality));
+    }
+
     protected void CheckLodged(IEnumerable<IWound> wounds)
     {
         foreach ((IGameItem Item, IBodypart Bodypart, IHaveWounds Owner) item in wounds.Where(x => x.Lodged != null)
@@ -181,21 +187,17 @@ public abstract class WeaponAttackMove : CombatMoveBase, IWeaponAttackMove
             .ToList();
         var effectiveQuality = (int)weapon.Parent.Quality + (int)Math.Round(magicEnhancements.Sum(x => x.QualityBonus));
 
-        Attack.Profile.DamageExpression.Formula.Parameters["degree"] = (int)degree;
-        Attack.Profile.DamageExpression.Formula.Parameters["quality"] = effectiveQuality;
-        Attack.Profile.StunExpression.Formula.Parameters["degree"] = (int)degree;
-        Attack.Profile.StunExpression.Formula.Parameters["quality"] = effectiveQuality;
-        Attack.Profile.PainExpression.Formula.Parameters["degree"] = (int)degree;
-        Attack.Profile.PainExpression.Formula.Parameters["quality"] = effectiveQuality;
-
         double damageResult =
-            Attack.Profile.DamageExpression.Evaluate(Assailant, context: TraitBonusContext.ArmedDamageCalculation) +
+            EvaluateAttackFormula(Attack.Profile.DamageExpression, Assailant, TraitBonusContext.ArmedDamageCalculation,
+                (int)degree, effectiveQuality) +
             magicEnhancements.Sum(x => x.DamageBonus);
         double stunResult =
-            Attack.Profile.StunExpression.Evaluate(Assailant, context: TraitBonusContext.ArmedDamageCalculation) +
+            EvaluateAttackFormula(Attack.Profile.StunExpression, Assailant, TraitBonusContext.ArmedDamageCalculation,
+                (int)degree, effectiveQuality) +
             magicEnhancements.Sum(x => x.StunBonus);
         double painResult =
-            Attack.Profile.PainExpression.Evaluate(Assailant, context: TraitBonusContext.ArmedDamageCalculation) +
+            EvaluateAttackFormula(Attack.Profile.PainExpression, Assailant, TraitBonusContext.ArmedDamageCalculation,
+                (int)degree, effectiveQuality) +
             magicEnhancements.Sum(x => x.PainBonus);
 
         if (!Gameworld.GetStaticBool("WeaponsTakeDamageFromAttacks"))
@@ -261,25 +263,17 @@ public abstract class WeaponAttackMove : CombatMoveBase, IWeaponAttackMove
         double relativeHardness = CalculateRelativeHardness(Assailant, target, attackingBodypart, targetBodypart,
             targetMaterial, attackOutcome, damageType);
 
-        attack.Attack.Profile.DamageExpression.Formula.Parameters["degree"] = (int)degree;
-        attack.Attack.Profile.DamageExpression.Formula.Parameters["quality"] =
-            (int)Assailant.NaturalWeaponQuality(attack);
-        attack.Attack.Profile.StunExpression.Formula.Parameters["degree"] = (int)degree;
-        attack.Attack.Profile.StunExpression.Formula.Parameters["quality"] =
-            (int)Assailant.NaturalWeaponQuality(attack);
-        attack.Attack.Profile.PainExpression.Formula.Parameters["degree"] = (int)degree;
-        attack.Attack.Profile.PainExpression.Formula.Parameters["quality"] =
-            (int)Assailant.NaturalWeaponQuality(attack);
+        int quality = (int)Assailant.NaturalWeaponQuality(attack);
 
         double damageResult =
-            attack.Attack.Profile.DamageExpression.Evaluate(Assailant,
-                context: TraitBonusContext.UnarmedDamageCalculation);
+            EvaluateAttackFormula(attack.Attack.Profile.DamageExpression, Assailant,
+                TraitBonusContext.UnarmedDamageCalculation, (int)degree, quality);
 		double stunResult =
-			attack.Attack.Profile.StunExpression.Evaluate(Assailant,
-				context: TraitBonusContext.UnarmedDamageCalculation);
+			EvaluateAttackFormula(attack.Attack.Profile.StunExpression, Assailant,
+				TraitBonusContext.UnarmedDamageCalculation, (int)degree, quality);
 		double painResult =
-			attack.Attack.Profile.PainExpression.Evaluate(Assailant,
-				context: TraitBonusContext.UnarmedDamageCalculation);
+			EvaluateAttackFormula(attack.Attack.Profile.PainExpression, Assailant,
+				TraitBonusContext.UnarmedDamageCalculation, (int)degree, quality);
 
         Damage finalDamage = new()
         {
@@ -460,15 +454,7 @@ public abstract class WeaponAttackMove : CombatMoveBase, IWeaponAttackMove
         }
 
         double finalAngle = weaponAttack.Profile.BaseAngleOfIncidence * angleMultiplier;
-        weaponAttack.Profile.DamageExpression.Formula.Parameters["degree"] = finalDegree;
-        weaponAttack.Profile.DamageExpression.Formula.Parameters["quality"] =
-            (int)wardResult.WardWeapon.Parent.Quality;
-        weaponAttack.Profile.StunExpression.Formula.Parameters["degree"] = finalDegree;
-        weaponAttack.Profile.StunExpression.Formula.Parameters["quality"] =
-            (int)wardResult.WardWeapon.Parent.Quality;
-        weaponAttack.Profile.PainExpression.Formula.Parameters["degree"] = finalDegree;
-        weaponAttack.Profile.PainExpression.Formula.Parameters["quality"] =
-            (int)wardResult.WardWeapon.Parent.Quality;
+        int quality = (int)wardResult.WardWeapon.Parent.Quality;
 
         Damage finalDamage = new()
         {
@@ -478,20 +464,20 @@ public abstract class WeaponAttackMove : CombatMoveBase, IWeaponAttackMove
             AngleOfIncidentRadians = finalAngle,
             Bodypart = targetBodypart,
             DamageAmount =
-                weaponAttack.Profile.DamageExpression.Evaluate(defender,
-                    context: TraitBonusContext.ArmedDamageCalculation) * 2 * finalAngle / Math.PI,
+                EvaluateAttackFormula(weaponAttack.Profile.DamageExpression, defender,
+                    TraitBonusContext.ArmedDamageCalculation, finalDegree, quality) * 2 * finalAngle / Math.PI,
             DamageType = weaponAttack.Profile.DamageType,
             PainAmount =
-                weaponAttack.Profile.PainExpression.Evaluate(defender,
-                    context: TraitBonusContext.ArmedDamageCalculation) * 2 * finalAngle / Math.PI,
+                EvaluateAttackFormula(weaponAttack.Profile.PainExpression, defender,
+                    TraitBonusContext.ArmedDamageCalculation, finalDegree, quality) * 2 * finalAngle / Math.PI,
             PenetrationOutcome =
                 Gameworld.GetCheck(CheckType.MeleeWeaponPenetrateCheck)
                          .Check(defender, GetPenetrationDifficulty(weaponAttack.Profile.DamageType),
                              wardResult.WardWeapon.WeaponType.AttackTrait, aggressor),
             ShockAmount = 0,
             StunAmount =
-                weaponAttack.Profile.StunExpression.Evaluate(defender,
-                    context: TraitBonusContext.ArmedDamageCalculation) * 2 * finalAngle / Math.PI
+                EvaluateAttackFormula(weaponAttack.Profile.StunExpression, defender,
+                    TraitBonusContext.ArmedDamageCalculation, finalDegree, quality) * 2 * finalAngle / Math.PI
         };
 
         (wardResult.WardWeapon as IConditionDegradingComponent)?.UseCondition(
@@ -585,15 +571,7 @@ public abstract class WeaponAttackMove : CombatMoveBase, IWeaponAttackMove
             }
 
             double finalAngle = naturalAttack.Attack.Profile.BaseAngleOfIncidence * angleMultiplier;
-            naturalAttack.Attack.Profile.DamageExpression.Formula.Parameters["degree"] = finalDegree;
-            naturalAttack.Attack.Profile.DamageExpression.Formula.Parameters["quality"] =
-                (int)defender.NaturalWeaponQuality(naturalAttack);
-            naturalAttack.Attack.Profile.StunExpression.Formula.Parameters["degree"] = finalDegree;
-            naturalAttack.Attack.Profile.StunExpression.Formula.Parameters["quality"] =
-                (int)defender.NaturalWeaponQuality(naturalAttack);
-            naturalAttack.Attack.Profile.PainExpression.Formula.Parameters["degree"] = finalDegree;
-            naturalAttack.Attack.Profile.PainExpression.Formula.Parameters["quality"] =
-                (int)defender.NaturalWeaponQuality(naturalAttack);
+            int quality = (int)defender.NaturalWeaponQuality(naturalAttack);
 
             double relativeHardness = CalculateRelativeHardness(defender, aggressor, naturalAttack.Bodypart,
                 targetBodypart,
@@ -607,13 +585,13 @@ public abstract class WeaponAttackMove : CombatMoveBase, IWeaponAttackMove
                 AngleOfIncidentRadians = finalAngle,
                 Bodypart = targetBodypart,
                 DamageAmount =
-                    naturalAttack.Attack.Profile.DamageExpression.Evaluate(defender,
-                        context: TraitBonusContext.UnarmedDamageCalculation) * 2 * finalAngle / Math.PI *
+                    EvaluateAttackFormula(naturalAttack.Attack.Profile.DamageExpression, defender,
+                        TraitBonusContext.UnarmedDamageCalculation, finalDegree, quality) * 2 * finalAngle / Math.PI *
                     relativeHardness,
                 DamageType = naturalAttack.Attack.Profile.DamageType,
                 PainAmount =
-                    naturalAttack.Attack.Profile.PainExpression.Evaluate(defender,
-                        context: TraitBonusContext.UnarmedDamageCalculation) * 2 * finalAngle / Math.PI *
+                    EvaluateAttackFormula(naturalAttack.Attack.Profile.PainExpression, defender,
+                        TraitBonusContext.UnarmedDamageCalculation, finalDegree, quality) * 2 * finalAngle / Math.PI *
                     relativeHardness,
                 PenetrationOutcome = Gameworld.GetCheck(CheckType.MeleeWeaponPenetrateCheck)
                                               .Check(defender,
@@ -621,8 +599,8 @@ public abstract class WeaponAttackMove : CombatMoveBase, IWeaponAttackMove
                                                   aggressor),
                 ShockAmount = 0,
                 StunAmount =
-                    naturalAttack.Attack.Profile.StunExpression.Evaluate(defender,
-                        context: TraitBonusContext.UnarmedDamageCalculation) * 2 * finalAngle / Math.PI *
+                    EvaluateAttackFormula(naturalAttack.Attack.Profile.StunExpression, defender,
+                        TraitBonusContext.UnarmedDamageCalculation, finalDegree, quality) * 2 * finalAngle / Math.PI *
                     relativeHardness
             };
 
@@ -634,19 +612,19 @@ public abstract class WeaponAttackMove : CombatMoveBase, IWeaponAttackMove
                 AngleOfIncidentRadians = finalAngle,
                 Bodypart = naturalAttack.Bodypart,
                 DamageAmount =
-                    naturalAttack.Attack.Profile.DamageExpression.Evaluate(defender,
-                        context: TraitBonusContext.UnarmedDamageCalculation) * 2 * finalAngle / Math.PI *
+                    EvaluateAttackFormula(naturalAttack.Attack.Profile.DamageExpression, defender,
+                        TraitBonusContext.UnarmedDamageCalculation, finalDegree, quality) * 2 * finalAngle / Math.PI *
                     (1.0 - relativeHardness),
                 DamageType = DamageType.Crushing,
                 PainAmount =
-                    naturalAttack.Attack.Profile.PainExpression.Evaluate(defender,
-                        context: TraitBonusContext.UnarmedDamageCalculation) * 2 * finalAngle / Math.PI *
+                    EvaluateAttackFormula(naturalAttack.Attack.Profile.PainExpression, defender,
+                        TraitBonusContext.UnarmedDamageCalculation, finalDegree, quality) * 2 * finalAngle / Math.PI *
                     (1.0 - relativeHardness),
                 PenetrationOutcome = new CheckOutcome { Outcome = Outcome.MajorFail },
                 ShockAmount = 0,
                 StunAmount =
-                    naturalAttack.Attack.Profile.StunExpression.Evaluate(defender,
-                        context: TraitBonusContext.UnarmedDamageCalculation) * 2 * finalAngle / Math.PI *
+                    EvaluateAttackFormula(naturalAttack.Attack.Profile.StunExpression, defender,
+                        TraitBonusContext.UnarmedDamageCalculation, finalDegree, quality) * 2 * finalAngle / Math.PI *
                     (1.0 - relativeHardness)
             };
 

--- a/MudSharpCore/Combat/Moves/WrenchingAttack.cs
+++ b/MudSharpCore/Combat/Moves/WrenchingAttack.cs
@@ -37,15 +37,8 @@ public class WrenchingAttack : NaturalAttackMove
             style: OutputStyle.CombatMessage, flags: OutputFlags.InnerWrap));
 
         List<IWound> wounds = new();
-        Attack.Profile.DamageExpression.Formula.Parameters["degree"] = (int)degree;
-        Attack.Profile.DamageExpression.Formula.Parameters["quality"] =
-            (int)Assailant.NaturalWeaponQuality(NaturalAttack);
-        Attack.Profile.StunExpression.Formula.Parameters["degree"] = (int)degree;
-        Attack.Profile.StunExpression.Formula.Parameters["quality"] =
-            (int)Assailant.NaturalWeaponQuality(NaturalAttack);
-        Attack.Profile.PainExpression.Formula.Parameters["degree"] = (int)degree;
-        Attack.Profile.PainExpression.Formula.Parameters["quality"] =
-            (int)Assailant.NaturalWeaponQuality(NaturalAttack);
+        int formulaDegree = (int)degree;
+        int quality = (int)Assailant.NaturalWeaponQuality(NaturalAttack);
 
         Damage finalDamage = new()
         {
@@ -55,13 +48,16 @@ public class WrenchingAttack : NaturalAttackMove
             AngleOfIncidentRadians = Attack.Profile.BaseAngleOfIncidence,
             Bodypart = TargetBodypart,
             DamageAmount =
-                Attack.Profile.DamageExpression.Evaluate(Assailant),
+                Attack.Profile.DamageExpression.EvaluateWith(Assailant,
+                    values: [("degree", formulaDegree), ("quality", quality)]),
             DamageType = DamageType.Wrenching,
             PainAmount =
-                Attack.Profile.PainExpression.Evaluate(Assailant),
+                Attack.Profile.PainExpression.EvaluateWith(Assailant,
+                    values: [("degree", formulaDegree), ("quality", quality)]),
             PenetrationOutcome = Outcome.NotTested,
             ShockAmount = 0,
-            StunAmount = Attack.Profile.DamageExpression.Evaluate(Assailant)
+            StunAmount = Attack.Profile.DamageExpression.EvaluateWith(Assailant,
+                values: [("degree", formulaDegree), ("quality", quality)])
         };
 
         wounds.AddRange(CharacterTarget.SufferDamage(finalDamage));

--- a/MudSharpCore/Combat/ScatterStrategies/ArcingScatterStrategy.cs
+++ b/MudSharpCore/Combat/ScatterStrategies/ArcingScatterStrategy.cs
@@ -17,9 +17,8 @@ public class ArcingScatterStrategy : IRangedScatterStrategy
     private static double Weight(IPerceiver candidate, IPerceiver target)
     {
         IExpression expr = WeightExpression;
-        expr.Parameters["size"] = (int)candidate.Size;
-        expr.Parameters["proximity"] = (int)candidate.GetProximity(target);
-        double weight = expr.EvaluateDouble();
+        double weight = expr.EvaluateDoubleWith(("size", (int)candidate.Size),
+            ("proximity", (int)candidate.GetProximity(target)));
         if (candidate.RoomLayer.IsHigherThan(target.RoomLayer))
         {
             weight *= 1.5;

--- a/MudSharpCore/Combat/ScatterStrategies/BallisticScatterStrategy.cs
+++ b/MudSharpCore/Combat/ScatterStrategies/BallisticScatterStrategy.cs
@@ -17,9 +17,8 @@ public class BallisticScatterStrategy : IRangedScatterStrategy
     private static double Weight(IPerceiver candidate, IPerceiver target)
     {
         IExpression expr = WeightExpression;
-        expr.Parameters["size"] = (int)candidate.Size;
-        expr.Parameters["proximity"] = (int)candidate.GetProximity(target);
-        return expr.EvaluateDouble();
+        return expr.EvaluateDoubleWith(("size", (int)candidate.Size),
+            ("proximity", (int)candidate.GetProximity(target)));
     }
 
     public RangedScatterResult? GetScatterTarget(ICharacter shooter, IPerceiver originalTarget,

--- a/MudSharpCore/Combat/ScatterStrategies/LightScatterStrategy.cs
+++ b/MudSharpCore/Combat/ScatterStrategies/LightScatterStrategy.cs
@@ -17,9 +17,8 @@ public class LightScatterStrategy : IRangedScatterStrategy
     private static double Weight(IPerceiver candidate, IPerceiver target)
     {
         IExpression expr = WeightExpression;
-        expr.Parameters["size"] = (int)candidate.Size;
-        expr.Parameters["proximity"] = (int)candidate.GetProximity(target);
-        return expr.EvaluateDouble();
+        return expr.EvaluateDoubleWith(("size", (int)candidate.Size),
+            ("proximity", (int)candidate.GetProximity(target)));
     }
 
     public RangedScatterResult? GetScatterTarget(ICharacter shooter, IPerceiver originalTarget,

--- a/MudSharpCore/Combat/ScatterStrategies/SpreadScatterStrategy.cs
+++ b/MudSharpCore/Combat/ScatterStrategies/SpreadScatterStrategy.cs
@@ -17,9 +17,8 @@ public class SpreadScatterStrategy : IRangedScatterStrategy
     private static double Weight(IPerceiver candidate, IPerceiver target)
     {
         IExpression expr = WeightExpression;
-        expr.Parameters["size"] = (int)candidate.Size;
-        expr.Parameters["proximity"] = (int)candidate.GetProximity(target);
-        return expr.EvaluateDouble();
+        return expr.EvaluateDoubleWith(("size", (int)candidate.Size),
+            ("proximity", (int)candidate.GetProximity(target)));
     }
 
     public RangedScatterResult? GetScatterTarget(ICharacter shooter, IPerceiver originalTarget,

--- a/MudSharpCore/Combat/Simulation/AdvancingTimeProvider.cs
+++ b/MudSharpCore/Combat/Simulation/AdvancingTimeProvider.cs
@@ -1,0 +1,22 @@
+#nullable enable
+
+namespace MudSharp.Combat.Simulation;
+
+internal sealed class AdvancingTimeProvider(DateTimeOffset initialUtc) : TimeProvider
+{
+	private DateTimeOffset _utcNow = initialUtc;
+
+	public override DateTimeOffset GetUtcNow()
+	{
+		return _utcNow;
+	}
+
+	public void AdvanceTo(DateTime utc)
+	{
+		var target = new DateTimeOffset(DateTime.SpecifyKind(utc, DateTimeKind.Utc));
+		if (target > _utcNow)
+		{
+			_utcNow = target;
+		}
+	}
+}

--- a/MudSharpCore/Combat/Simulation/CombatSimulationCharacter.cs
+++ b/MudSharpCore/Combat/Simulation/CombatSimulationCharacter.cs
@@ -1,0 +1,54 @@
+using MudSharp.Body.Position.PositionStates;
+using MudSharp.Character;
+using MudSharp.CharacterCreation;
+using MudSharp.GameItems;
+using MudSharp.NPC.Templates;
+using MudSharp.PerceptionEngine;
+
+#nullable enable
+
+namespace MudSharp.Combat.Simulation;
+
+internal sealed class CombatSimulationCharacter(IFuturemud gameworld, ICharacterTemplate template)
+	: Character.Character(gameworld, template)
+{
+	public override bool IsPlayerCharacter => false;
+
+	public override IGameItem? Die()
+	{
+		if (State.HasFlag(CharacterState.Dead))
+		{
+			return null;
+		}
+
+		OutputHandler.Handle(new EmoteOutput(new Emote(Gameworld.GetStaticString("RegularDeathEmote"), this, this)));
+		State = CharacterState.Dead;
+		PositionState = PositionSprawled.Instance;
+		Combat?.LeaveCombat(this);
+		Movement?.CancelForMoverOnly(this);
+		Body.Die();
+		return null;
+	}
+}
+
+internal sealed class CombatSimulationNpc(
+	IFuturemud gameworld,
+	ICharacterTemplate template,
+	INPCTemplate npcTemplate) : NPC.NPC(gameworld, template, npcTemplate)
+{
+	public override IGameItem? Die()
+	{
+		if (State.HasFlag(CharacterState.Dead))
+		{
+			return null;
+		}
+
+		OutputHandler.Handle(new EmoteOutput(new Emote(Gameworld.GetStaticString("RegularDeathEmote"), this, this)));
+		State = CharacterState.Dead;
+		PositionState = PositionSprawled.Instance;
+		Combat?.LeaveCombat(this);
+		Movement?.CancelForMoverOnly(this);
+		Body.Die();
+		return null;
+	}
+}

--- a/MudSharpCore/Combat/Simulation/CombatSimulationCombat.cs
+++ b/MudSharpCore/Combat/Simulation/CombatSimulationCombat.cs
@@ -1,0 +1,56 @@
+using MudSharp.Character;
+using MudSharp.Framework;
+using MudSharp.RPG.Checks;
+
+#nullable enable
+
+namespace MudSharp.Combat.Simulation;
+
+internal sealed class CombatSimulationCombat(IFuturemud gameworld) : SimpleMeleeCombat(gameworld), ICombatTargetingPolicy
+{
+	private readonly Dictionary<IPerceiver, string> _teams = new(ReferenceEqualityComparer.Instance);
+	private readonly Dictionary<IPerceiver, CombatStrategyMode> _departureModes = new(ReferenceEqualityComparer.Instance);
+
+	public void JoinCombat(IPerceiver character, string team)
+	{
+		_teams[character] = team;
+		base.JoinCombat(character, Difficulty.Automatic);
+	}
+
+	public string? TeamFor(IPerceiver character)
+	{
+		return _teams.GetValueOrDefault(character);
+	}
+
+	public CombatStrategyMode? DepartureModeFor(IPerceiver character)
+	{
+		return _departureModes.GetValueOrDefault(character);
+	}
+
+	public override bool LeaveCombat(IPerceiver character)
+	{
+		if (character is not null)
+		{
+			_departureModes.TryAdd(character, character.CombatStrategyMode);
+		}
+
+		return base.LeaveCombat(character);
+	}
+
+	public IPerceiver? AcquireTargetFor(IPerceiver combatant)
+	{
+		if (!_teams.TryGetValue(combatant, out var team))
+		{
+			return null;
+		}
+
+		return Combatants
+			.Where(x => !ReferenceEquals(x, combatant))
+			.Where(x => !_teams.TryGetValue(x, out var otherTeam) ||
+			            !string.Equals(team, otherTeam, StringComparison.InvariantCultureIgnoreCase))
+			.Where(x => x is not ICharacter character || character.State.IsAble())
+			.Where(combatant.CanEngage)
+			.OrderBy(x => x.Id)
+			.FirstOrDefault();
+	}
+}

--- a/MudSharpCore/Combat/Simulation/CombatSimulationCommand.cs
+++ b/MudSharpCore/Combat/Simulation/CombatSimulationCommand.cs
@@ -1,0 +1,1047 @@
+using MudSharp.Character;
+using MudSharp.Character.Name;
+using MudSharp.Construction;
+using MudSharp.Framework;
+
+#nullable enable
+
+namespace MudSharp.Combat.Simulation;
+
+internal sealed class CombatSimulationCommandSession(ICell scene)
+{
+	public ICell Scene { get; set; } = scene;
+	public List<CombatSimulationParticipantRequest> Participants { get; } = [];
+	public int Seed { get; set; } = Random.Shared.Next();
+	public TimeSpan MaximumVirtualTime { get; set; } = TimeSpan.FromMinutes(30);
+	public int MaximumEvents { get; set; } = 100_000;
+	public int MaximumTranscriptEntries { get; set; } = 10_000;
+	public TimeSpan MaximumWallClockTime { get; set; } = TimeSpan.FromSeconds(60);
+	public CombatSimulationResult? LastResult { get; set; }
+	public CombatSimulationBatchResult? LastBatch { get; set; }
+	public int NextSlot { get; set; } = 1;
+}
+
+internal static class CombatSimulationCommand
+{
+	private const string HelpText = @"The #3impdebug combatsim#0 workflow stages and runs an accelerated combat using transient copies of loaded characters or NPC templates. Combat, effects and heartbeats use a private virtual-time scheduler while the normal game loop is blocked. EF SaveChanges calls and ordinary save-queue work are suppressed; generated actors, bodies, items and the transient scene are removed afterward. Direct Dapper writes and external effects from hooks or progs cannot be unwound.
+
+Review #3validate#0 before running. Any warning requires #3force#0. An unset or unrecognised #3FUTUREMUD_ENVIRONMENT#0 is treated as production, where every run also requires the exact #3confirm-production#0 argument. Batch runs do not retain transcripts and have a ten-minute aggregate wall-clock guard.
+
+The syntax is:
+
+	#3impdebug combatsim new [<cell>]#0
+	#3impdebug combatsim add character <loaded character> team <team>#0
+	#3impdebug combatsim add template <NPC template> team <team> [count <number>]#0
+	#3impdebug combatsim remove <slot>#0
+	#3impdebug combatsim set scene <cell>#0
+	#3impdebug combatsim set seed <number>#0
+	#3impdebug combatsim set maxtime <timespan>#0
+	#3impdebug combatsim set maxevents <number>#0
+	#3impdebug combatsim set transcript <number>#0
+	#3impdebug combatsim show#0
+	#3impdebug combatsim validate#0
+	#3impdebug combatsim run [force] [confirm-production]#0
+	#3impdebug combatsim batch <runs> [seed <start>] [step <increment>] [force] [confirm-production]#0
+	#3impdebug combatsim batchreport [runs [<start>] [<count>]]#0
+	#3impdebug combatsim batchreport trace <run> <random|state|materialisation> [<start>] [<count>]#0
+	#3impdebug combatsim report#0
+	#3impdebug combatsim transcript [<start>] [<count>]#0
+	#3impdebug combatsim clear#0";
+
+	private static readonly Dictionary<long, CombatSimulationCommandSession> _sessions = [];
+
+	public static void Execute(ICharacter actor, StringStack command)
+	{
+		var action = command.PopSpeech().CollapseString().ToLowerInvariant();
+		switch (action)
+		{
+			case "new":
+				New(actor, command);
+				return;
+			case "add":
+				Add(actor, command);
+				return;
+			case "remove":
+				Remove(actor, command);
+				return;
+			case "set":
+				Set(actor, command);
+				return;
+			case "show":
+				Show(actor);
+				return;
+			case "validate":
+				Validate(actor);
+				return;
+			case "run":
+				Run(actor, command);
+				return;
+			case "batch":
+				Batch(actor, command);
+				return;
+			case "batchreport":
+				BatchReport(actor, command);
+				return;
+			case "report":
+				Report(actor);
+				return;
+			case "transcript":
+				Transcript(actor, command);
+				return;
+			case "clear":
+				_sessions.Remove(actor.Id);
+				actor.OutputHandler.Send("You clear your staged combat simulation.");
+				return;
+			default:
+				actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+				return;
+		}
+	}
+
+	internal static bool IsProductionEnvironment(string? environment)
+	{
+		return !new[] { "development", "dev", "test", "testing", "local" }
+			.Any(x => string.Equals(environment, x, StringComparison.InvariantCultureIgnoreCase));
+	}
+
+	private static CombatSimulationCommandSession? Session(ICharacter actor, bool sendError = true)
+	{
+		if (_sessions.TryGetValue(actor.Id, out var session))
+		{
+			return session;
+		}
+
+		if (sendError)
+		{
+			actor.OutputHandler.Send(
+				$"You have no staged simulation. Begin with {"impdebug combatsim new".ColourCommand()}.");
+		}
+
+		return null;
+	}
+
+	private static void New(ICharacter actor, StringStack command)
+	{
+		var scene = command.IsFinished ? actor.Location : actor.Gameworld.Cells.GetByIdOrName(command.SafeRemainingArgument);
+		if (scene is null)
+		{
+			actor.OutputHandler.Send("There is no such cell to use as the combat scene.");
+			return;
+		}
+
+		_sessions[actor.Id] = new CombatSimulationCommandSession(scene);
+		actor.OutputHandler.Send(
+			$"You begin staging an accelerated combat simulation in {scene.GetFriendlyReference(actor).ColourName()}. Add at least two opposing teams, then validate it.");
+	}
+
+	private static void Add(ICharacter actor, StringStack command)
+	{
+		var session = Session(actor);
+		if (session is null)
+		{
+			return;
+		}
+
+		var sourceType = command.PopSpeech().CollapseString().ToLowerInvariant();
+		if (sourceType is not ("character" or "char" or "template" or "npc"))
+		{
+			actor.OutputHandler.Send(
+				$"Do you want to add a {"character".ColourCommand()} or an NPC {"template".ColourCommand()}?");
+			return;
+		}
+
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which loaded character or NPC template do you want to add?");
+			return;
+		}
+
+		var selector = command.PopSpeech();
+		if (!command.PopSpeech().EqualTo("team") || command.IsFinished)
+		{
+			actor.OutputHandler.Send("You must specify the opposing team with the team keyword.");
+			return;
+		}
+
+		var team = command.PopSpeech();
+		var count = 1;
+		if (!command.IsFinished)
+		{
+			if (!command.PopSpeech().EqualTo("count") || command.IsFinished ||
+			    !int.TryParse(command.PopSpeech(), out count) || count is < 1 or > 100 || !command.IsFinished)
+			{
+				actor.OutputHandler.Send("The optional count must be a whole number from 1 to 100.");
+				return;
+			}
+		}
+
+		if (sourceType is "character" or "char")
+		{
+			if (count != 1)
+			{
+				actor.OutputHandler.Send("Loaded character sources can only be added once per command.");
+				return;
+			}
+
+			var character = actor.Gameworld.Actors.GetByIdOrName(selector);
+			if (character is null)
+			{
+				actor.OutputHandler.Send("There is no such loaded character.");
+				return;
+			}
+
+			session.Participants.Add(new CombatSimulationParticipantRequest(
+				session.NextSlot++, team, CombatSimulationSourceType.Character, character, null));
+			actor.OutputHandler.Send(
+				$"You add {character.PersonalName.GetName(NameStyle.SimpleFull).ColourName()} to team {team.ColourName()}.");
+			return;
+		}
+
+		var template = actor.Gameworld.NpcTemplates.GetByIdOrName(selector);
+		if (template is null)
+		{
+			actor.OutputHandler.Send("There is no such current NPC template.");
+			return;
+		}
+
+		for (var i = 1; i <= count; i++)
+		{
+			session.Participants.Add(new CombatSimulationParticipantRequest(
+				session.NextSlot++, team, CombatSimulationSourceType.NpcTemplate, null, template, i));
+		}
+
+		actor.OutputHandler.Send(
+			$"You add {count.ToString("N0", actor).ColourValue()} instance{(count == 1 ? string.Empty : "s")} of {template.Name.ColourName()} to team {team.ColourName()}.");
+	}
+
+	private static void Remove(ICharacter actor, StringStack command)
+	{
+		var session = Session(actor);
+		if (session is null)
+		{
+			return;
+		}
+
+		if (!int.TryParse(command.SafeRemainingArgument, out var slot))
+		{
+			actor.OutputHandler.Send("Which numeric combatant slot do you want to remove?");
+			return;
+		}
+
+		var removed = session.Participants.RemoveAll(x => x.Slot == slot);
+		actor.OutputHandler.Send(removed > 0
+			? $"You remove combatant slot {slot.ToString("N0", actor).ColourValue()}."
+			: "There is no combatant with that slot number.");
+	}
+
+	private static void Set(ICharacter actor, StringStack command)
+	{
+		var session = Session(actor);
+		if (session is null)
+		{
+			return;
+		}
+
+		var option = command.PopSpeech().CollapseString().ToLowerInvariant();
+		switch (option)
+		{
+			case "scene":
+			case "cell":
+				var scene = actor.Gameworld.Cells.GetByIdOrName(command.SafeRemainingArgument);
+				if (scene is null)
+				{
+					actor.OutputHandler.Send("There is no such cell.");
+					return;
+				}
+
+				session.Scene = scene;
+				actor.OutputHandler.Send($"The combat scene is now {scene.GetFriendlyReference(actor).ColourName()}.");
+				return;
+			case "seed":
+				if (!int.TryParse(command.SafeRemainingArgument, out var seed))
+				{
+					actor.OutputHandler.Send("The seed must be a 32-bit whole number.");
+					return;
+				}
+
+				session.Seed = seed;
+				actor.OutputHandler.Send($"The random seed is now {seed.ToString("N0", actor).ColourValue()}.");
+				return;
+			case "maxtime":
+			case "time":
+				if (!TimeSpan.TryParse(command.SafeRemainingArgument, actor, out var maximumTime) ||
+				    maximumTime <= TimeSpan.Zero || maximumTime > TimeSpan.FromDays(1))
+				{
+					actor.OutputHandler.Send("Specify a positive timespan no greater than one day.");
+					return;
+				}
+
+				session.MaximumVirtualTime = maximumTime;
+				actor.OutputHandler.Send($"The virtual-time limit is now {maximumTime.Describe(actor).ColourValue()}.");
+				return;
+			case "maxevents":
+			case "events":
+				if (!int.TryParse(command.SafeRemainingArgument, out var events) || events is < 1 or > 1_000_000)
+				{
+					actor.OutputHandler.Send("Specify an event limit from 1 to 1,000,000.");
+					return;
+				}
+
+				session.MaximumEvents = events;
+				actor.OutputHandler.Send($"The event limit is now {events.ToString("N0", actor).ColourValue()}.");
+				return;
+			case "transcript":
+				if (!int.TryParse(command.SafeRemainingArgument, out var entries) || entries is < 0 or > 100_000)
+				{
+					actor.OutputHandler.Send("Specify a transcript limit from 0 to 100,000 entries.");
+					return;
+				}
+
+				session.MaximumTranscriptEntries = entries;
+				actor.OutputHandler.Send($"The transcript limit is now {entries.ToString("N0", actor).ColourValue()} entries.");
+				return;
+			default:
+				actor.OutputHandler.Send("You can set scene, seed, maxtime, maxevents or transcript.");
+				return;
+		}
+	}
+
+	private static void Show(ICharacter actor)
+	{
+		var session = Session(actor);
+		if (session is null)
+		{
+			return;
+		}
+
+		var sb = new StringBuilder();
+		sb.AppendLine("Accelerated Combat Simulation");
+		sb.AppendLine();
+		sb.AppendLine($"Scene: {session.Scene.GetFriendlyReference(actor).ColourName()}");
+		sb.AppendLine($"Seed: {session.Seed.ToString("N0", actor).ColourValue()}");
+		sb.AppendLine($"Limits: {session.MaximumVirtualTime.Describe(actor).ColourValue()} virtual time, {session.MaximumEvents.ToString("N0", actor).ColourValue()} events, {session.MaximumWallClockTime.Describe(actor).ColourValue()} wall time");
+		sb.AppendLine($"Transcript: {session.MaximumTranscriptEntries.ToString("N0", actor).ColourValue()} entries");
+		sb.AppendLine();
+		var rows = session.Participants
+			.OrderBy(x => x.Slot)
+			.Select(x => new[]
+			{
+				x.Slot.ToString("N0", actor),
+				x.Team,
+				x.SourceType.DescribeEnum(true),
+				x.SourceDescription
+			});
+		sb.AppendLine(session.Participants.Count == 0
+			? "No combatants have been added."
+			: StringUtilities.GetTextTable(rows, ["Slot", "Team", "Type", "Source"], actor, Telnet.Green));
+		actor.OutputHandler.Send(sb.ToString());
+	}
+
+	private static CombatSimulationRequest BuildRequest(ICharacter actor, CombatSimulationCommandSession session, bool force)
+	{
+		return new CombatSimulationRequest(
+			Guid.NewGuid(), actor, session.Scene, session.Participants.ToList(), session.Seed,
+			session.MaximumVirtualTime, session.MaximumEvents, session.MaximumTranscriptEntries,
+			session.MaximumWallClockTime, force);
+	}
+
+	private static CombatSimulationBatchRequest BuildBatchRequest(
+		ICharacter actor,
+		CombatSimulationCommandSession session,
+		int firstSeed,
+		int seedIncrement,
+		int runCount,
+		bool force)
+	{
+		return new CombatSimulationBatchRequest(
+			Guid.NewGuid(),
+			actor,
+			session.Scene,
+			session.Participants.ToList(),
+			firstSeed,
+			seedIncrement,
+			runCount,
+			session.MaximumVirtualTime,
+			session.MaximumEvents,
+			session.MaximumWallClockTime,
+			TimeSpan.FromMinutes(10),
+			force);
+	}
+
+	private static void Validate(ICharacter actor)
+	{
+		var session = Session(actor);
+		if (session is null)
+		{
+			return;
+		}
+
+		var service = new CombatSimulationService();
+		ShowValidation(actor, service.Validate(BuildRequest(actor, session, false)));
+	}
+
+	private static void ShowValidation(ICharacter actor, IReadOnlyList<CombatSimulationValidationMessage> messages)
+	{
+		var sb = new StringBuilder();
+		if (messages.Count == 0)
+		{
+			sb.AppendLine("The staged simulation passed preflight without warnings.".Colour(Telnet.Green));
+		}
+		else
+		{
+			foreach (var message in messages)
+			{
+				sb.AppendLine($"{(message.IsError ? "ERROR".ColourError() : "WARNING".Colour(Telnet.Yellow))}: {message.Message}");
+			}
+		}
+
+		actor.OutputHandler.Send(sb.ToString());
+	}
+
+	private static void Run(ICharacter actor, StringStack command)
+	{
+		var session = Session(actor);
+		if (session is null)
+		{
+			return;
+		}
+
+		var arguments = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+		while (!command.IsFinished)
+		{
+			arguments.Add(command.PopSpeech());
+		}
+
+		if (arguments.Any(x => !x.In("force", "confirm-production")))
+		{
+			actor.OutputHandler.Send("The only run options are force and confirm-production.");
+			return;
+		}
+
+		var production = IsProductionEnvironment(Environment.GetEnvironmentVariable("FUTUREMUD_ENVIRONMENT"));
+		if (production && !arguments.Contains("confirm-production"))
+		{
+			actor.OutputHandler.Send(
+				"This server is treated as production. The simulation blocks the game loop and hooks, progs, direct Dapper writes or external services may have side effects. Re-run with the exact confirm-production argument if you accept that risk."
+					.ColourError());
+			return;
+		}
+
+		actor.OutputHandler.Send(
+			$"Starting combat simulation with seed {session.Seed.ToString("N0", actor).ColourValue()}. Player input and ordinary loop work will resume when it finishes.");
+		var service = new CombatSimulationService();
+		var result = service.Run(BuildRequest(actor, session, arguments.Contains("force")));
+		session.LastResult = result;
+		actor.OutputHandler.Send(RenderReport(result, actor));
+	}
+
+	private static void Batch(ICharacter actor, StringStack command)
+	{
+		var session = Session(actor);
+		if (session is null)
+		{
+			return;
+		}
+
+		if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var runCount))
+		{
+			actor.OutputHandler.Send("Specify how many simulations to run in the batch.");
+			return;
+		}
+
+		if (runCount is < 1 or > 100)
+		{
+			actor.OutputHandler.Send("The batch run count must be between 1 and 100.");
+			return;
+		}
+
+		var firstSeed = session.Seed;
+		var seedIncrement = 1;
+		var arguments = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+		while (!command.IsFinished)
+		{
+			var option = command.PopSpeech().ToLowerInvariant();
+			switch (option)
+			{
+				case "seed":
+					if (command.IsFinished || !int.TryParse(command.PopSpeech(), out firstSeed))
+					{
+						actor.OutputHandler.Send("The batch starting seed must be a 32-bit whole number.");
+						return;
+					}
+
+					break;
+				case "step":
+				case "increment":
+					if (command.IsFinished || !int.TryParse(command.PopSpeech(), out seedIncrement))
+					{
+						actor.OutputHandler.Send("The batch seed increment must be a 32-bit whole number.");
+						return;
+					}
+
+					break;
+				case "force":
+				case "confirm-production":
+					arguments.Add(option);
+					break;
+				default:
+					actor.OutputHandler.Send("The batch syntax is: impdebug combatsim batch <runs> [seed <start>] [step <increment>] [force] [confirm-production].");
+					return;
+			}
+		}
+
+		if (IsProductionEnvironment(Environment.GetEnvironmentVariable("FUTUREMUD_ENVIRONMENT")) &&
+		    !arguments.Contains("confirm-production"))
+		{
+			actor.OutputHandler.Send(
+				"This server is treated as production. A batch blocks the game loop for multiple simulations and may invoke hooks, progs, direct Dapper writes or external services. Re-run with the exact confirm-production argument if you accept that risk."
+					.ColourError());
+			return;
+		}
+
+		actor.OutputHandler.Send(
+			$"Starting {runCount.ToString("N0", actor).ColourValue()} combat simulations from seed {firstSeed.ToString("N0", actor).ColourValue()} with an increment of {seedIncrement.ToString("N0", actor).ColourValue()}. Player input and ordinary loop work will resume when the batch finishes.");
+		var result = new CombatSimulationService().RunBatch(BuildBatchRequest(
+			actor,
+			session,
+			firstSeed,
+			seedIncrement,
+			runCount,
+			arguments.Contains("force")));
+		session.LastBatch = result;
+		session.LastResult = result.Runs.LastOrDefault();
+		actor.OutputHandler.Send(RenderBatchReport(result, actor));
+	}
+
+	private static void BatchReport(ICharacter actor, StringStack command)
+	{
+		var result = Session(actor)?.LastBatch;
+		if (result is null)
+		{
+			actor.OutputHandler.Send("There is no completed combat-simulation batch report in your session.");
+			return;
+		}
+
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send(RenderBatchReport(result, actor));
+			return;
+		}
+
+		var section = command.PopSpeech().ToLowerInvariant();
+		if (section == "trace")
+		{
+			BatchTrace(actor, command, result);
+			return;
+		}
+
+		if (section != "runs")
+		{
+			actor.OutputHandler.Send("The batch report syntax is impdebug combatsim batchreport [runs [start] [count]] or impdebug combatsim batchreport trace <run> <random|state|materialisation> [start] [count].");
+			return;
+		}
+
+		var start = 1;
+		var count = 25;
+		if (!command.IsFinished && (!int.TryParse(command.PopSpeech(), out start) || start < 1))
+		{
+			actor.OutputHandler.Send("The run-report start must be a positive run number.");
+			return;
+		}
+
+		if (!command.IsFinished && (!int.TryParse(command.PopSpeech(), out count) || count is < 1 or > 100))
+		{
+			actor.OutputHandler.Send("The run-report count must be from 1 to 100.");
+			return;
+		}
+
+		if (!command.IsFinished)
+		{
+			actor.OutputHandler.Send("The batch report syntax is impdebug combatsim batchreport [runs [start] [count]] or impdebug combatsim batchreport trace <run> <random|state|materialisation> [start] [count].");
+			return;
+		}
+
+		actor.OutputHandler.Send(RenderBatchRunPage(result, actor, start, count));
+	}
+
+	private static void BatchTrace(ICharacter actor, StringStack command, CombatSimulationBatchResult result)
+	{
+		if (!int.TryParse(command.PopSpeech(), out var runNumber) || runNumber < 1 || runNumber > result.Runs.Count)
+		{
+			actor.OutputHandler.Send($"The run number must be between 1 and {result.Runs.Count:N0}.");
+			return;
+		}
+
+		var traceType = command.PopSpeech().ToLowerInvariant();
+		var start = 1;
+		var count = 100;
+		if (!command.IsFinished && (!int.TryParse(command.PopSpeech(), out start) || start < 1))
+		{
+			actor.OutputHandler.Send("The trace start must be a positive entry number.");
+			return;
+		}
+
+		if (!command.IsFinished && (!int.TryParse(command.PopSpeech(), out count) || count is < 1 or > 1_000))
+		{
+			actor.OutputHandler.Send("The trace count must be from 1 to 1,000.");
+			return;
+		}
+
+		if (!command.IsFinished)
+		{
+			actor.OutputHandler.Send("The batch trace syntax is impdebug combatsim batchreport trace <run> <random|state|materialisation> [start] [count].");
+			return;
+		}
+
+		var trace = result.Runs[runNumber - 1].ExecutionTrace;
+		IReadOnlyList<CombatSimulationRandomTraceEntry>? randomEntries = null;
+		IReadOnlyList<CombatSimulationStateTraceEntry>? stateEntries = null;
+		IReadOnlyList<CombatSimulationMaterialisationTraceEntry>? materialisationEntries = null;
+		var traceName = traceType;
+		switch (traceType)
+		{
+			case "random":
+				randomEntries = trace.RecentRandomOperations;
+				break;
+			case "state":
+				stateEntries = trace.RecentStateOperations;
+				break;
+			case "materialisation":
+			case "materialization":
+				materialisationEntries = trace.MaterialisationEntries;
+				traceName = "materialisation";
+				break;
+			default:
+				actor.OutputHandler.Send("The trace type must be random, state or materialisation.");
+				return;
+		}
+
+		var entries = randomEntries is not null
+			? randomEntries.Select(x => (x.OperationIndex, x.Description))
+			: stateEntries is not null
+				? stateEntries.Select(x => (x.OperationIndex, x.Description))
+				: materialisationEntries!.Select(x => (x.OperationIndex, x.Description));
+		var page = entries
+			.Skip(start - 1)
+			.Take(count)
+			.ToList();
+		if (page.Count == 0)
+		{
+			actor.OutputHandler.Send($"There are no {traceName} trace entries in that range. Detailed traces are retained only for repeated-seed batch diagnostics.");
+			return;
+		}
+
+		var end = start + page.Count - 1;
+		actor.OutputHandler.Send($"Combat Simulation Batch Run {runNumber:N0} {traceName} trace {start:N0} to {end:N0}:\n" +
+			page.Select(x => $"{x.OperationIndex:N0}: {x.Description}").ListToString(separator: "\n", conjunction: string.Empty, twoItemJoiner: "\n"));
+	}
+
+	private static void Report(ICharacter actor)
+	{
+		var result = Session(actor)?.LastResult;
+		if (result is null)
+		{
+			actor.OutputHandler.Send("There is no completed combat simulation report in your session.");
+			return;
+		}
+
+		actor.OutputHandler.Send(RenderReport(result, actor));
+	}
+
+	private static string RenderReport(CombatSimulationResult result, ICharacter actor)
+	{
+		var sb = new StringBuilder();
+		sb.AppendLine($"Combat Simulation {result.RunId.ToString().ColourValue()}");
+		sb.AppendLine();
+		sb.AppendLine($"Status: {result.Status.DescribeEnum(true).ColourName()}");
+		sb.AppendLine($"Winner: {(result.WinningTeam?.ColourName() ?? "none".ColourError())}");
+		sb.AppendLine($"Seed: {result.Seed.ToString("N0", actor).ColourValue()}");
+		sb.AppendLine($"Duration: {result.VirtualDuration.Describe(actor).ColourValue()} virtual, {result.WallClockDuration.Describe(actor).ColourValue()} wall-clock");
+		sb.AppendLine($"Events: {result.EventCount.ToString("N0", actor).ColourValue()}");
+		sb.AppendLine($"Execution fingerprint: {result.ExecutionFingerprint.ColourValue()}");
+		sb.AppendLine($"Trace layers: {DescribeTraceSummary(result.ExecutionTrace)}");
+		sb.AppendLine($"Transcript: {result.Transcript.Count.ToString("N0", actor).ColourValue()} entries{(result.TranscriptTruncated ? " (truncated)".Colour(Telnet.Yellow) : string.Empty)}");
+		if (!string.IsNullOrWhiteSpace(result.ErrorMessage))
+		{
+			sb.AppendLine($"Error: {result.ErrorMessage.ColourError()}");
+		}
+
+		if (result.Participants.Count > 0)
+		{
+			sb.AppendLine();
+			sb.AppendLine(StringUtilities.GetTextTable(
+				result.Participants.OrderBy(x => x.Slot).Select(x => new[]
+				{
+					x.Slot.ToString("N0", actor), x.Team, x.Name, x.Outcome.DescribeEnum(true),
+					x.FinalState.Describe(), x.BloodRatio.ToString("P1", actor),
+					x.StaminaRatio.ToString("P1", actor), x.WoundCount.ToString("N0", actor)
+				}),
+				["Slot", "Team", "Name", "Outcome", "State", "Blood", "Stamina", "Wounds"], actor,
+				Telnet.Green));
+		}
+
+		if (result.Validation.Count > 0)
+		{
+			sb.AppendLine();
+			sb.AppendLine("Preflight and runtime warnings:");
+			foreach (var warning in result.Validation)
+			{
+				sb.AppendLine($"  {(warning.IsError ? "ERROR".ColourError() : "WARNING".Colour(Telnet.Yellow))}: {warning.Message}");
+			}
+		}
+
+		return sb.ToString();
+	}
+
+	private static string RenderBatchReport(CombatSimulationBatchResult result, ICharacter actor)
+	{
+		var sb = new StringBuilder();
+		var lastSeed = result.RequestedRunCount > 0
+			? (long)result.FirstSeed + ((long)result.SeedIncrement * (result.RequestedRunCount - 1))
+			: result.FirstSeed;
+		sb.AppendLine($"Combat Simulation Batch {result.BatchId.ToString().ColourValue()}");
+		sb.AppendLine();
+		sb.AppendLine($"Runs: {result.Runs.Count.ToString("N0", actor).ColourValue()} of {result.RequestedRunCount.ToString("N0", actor).ColourValue()}");
+		sb.AppendLine($"Seeds: {result.FirstSeed.ToString("N0", actor).ColourValue()} to {lastSeed.ToString("N0", actor).ColourValue()} (increment {result.SeedIncrement.ToString("N0", actor).ColourValue()})");
+		if (result.Runs.Count > 0)
+		{
+			sb.AppendLine($"Virtual duration: {result.TotalVirtualDuration.Describe(actor).ColourValue()} total, {result.AverageVirtualDuration.Describe(actor).ColourValue()} average, {result.FastestVirtualDuration.Describe(actor).ColourValue()} to {result.SlowestVirtualDuration.Describe(actor).ColourValue()} range");
+			sb.AppendLine($"Simulation wall-clock: {result.TotalWallClockDuration.Describe(actor).ColourValue()} total, {result.AverageWallClockDuration.Describe(actor).ColourValue()} average");
+		}
+
+		sb.AppendLine($"Batch wall-clock: {result.BatchWallClockDuration.Describe(actor).ColourValue()}");
+		sb.AppendLine("Transcripts: omitted for batch runs to keep tournament memory bounded.".Colour(Telnet.Yellow));
+		if (!string.IsNullOrWhiteSpace(result.ErrorMessage))
+		{
+			sb.AppendLine($"Error: {result.ErrorMessage.ColourError()}");
+		}
+
+		if (result.Teams.Count > 0)
+		{
+			sb.AppendLine();
+			sb.AppendLine(StringUtilities.GetTextTable(
+				result.Teams.Select(x => new[]
+				{
+					x.Team,
+					x.Wins.ToString("N0", actor),
+					x.WinRate.ToString("P1", actor)
+				}),
+				["Team", "Wins", "Win Rate"], actor, Telnet.Green));
+		}
+
+		if (result.Statuses.Count > 0)
+		{
+			sb.AppendLine();
+			sb.AppendLine(StringUtilities.GetTextTable(
+				result.Statuses.Select(x => new[]
+				{
+					x.Status.DescribeEnum(true),
+					x.Count.ToString("N0", actor)
+				}),
+				["Run Status", "Count"], actor, Telnet.Green));
+		}
+
+		if (result.Outcomes.Count > 0)
+		{
+			sb.AppendLine();
+			sb.AppendLine(StringUtilities.GetTextTable(
+				result.Outcomes.Select(x => new[]
+				{
+					x.Outcome.DescribeEnum(true),
+					x.Count.ToString("N0", actor)
+				}),
+				["Combatant Outcome", "Count"], actor, Telnet.Green));
+		}
+
+		var replayGroups = result.Runs
+			.GroupBy(x => x.Seed)
+			.Where(x => x.Count() > 1)
+			.OrderBy(x => x.Key)
+			.ToList();
+		if (replayGroups.Count > 0)
+		{
+			sb.AppendLine();
+			sb.AppendLine("Repeated-seed replay diagnostics:");
+			var replayRows = replayGroups.Select(group =>
+			{
+				var fingerprints = group.Select(x => x.ExecutionFingerprint).Distinct().ToList();
+				return new[]
+				{
+					group.Key.ToString("N0", actor),
+					group.Count().ToString("N0", actor),
+					fingerprints.Count == 1 ? "Match".Colour(Telnet.Green) : "MISMATCH".ColourError(),
+					fingerprints.Count.ToString("N0", actor),
+					fingerprints.Select(ShortFingerprint).ListToString()
+				};
+			});
+			sb.AppendLine(StringUtilities.GetTextTable(replayRows,
+				["Seed", "Runs", "Replay", "Traces", "Fingerprint(s)"], actor, Telnet.Green));
+			if (replayGroups.Any(x => x.Select(y => y.ExecutionFingerprint).Distinct().Skip(1).Any()))
+			{
+				sb.AppendLine("WARNING: runs with the same seed produced different execution fingerprints. Use batchreport runs to inspect the affected runs."
+					.ColourError());
+				foreach (var group in replayGroups.Where(x => x.Select(y => y.ExecutionFingerprint).Distinct().Skip(1).Any()))
+				{
+					sb.AppendLine($"Seed {group.Key.ToString("N0", actor)} trace comparison: {DescribeTraceComparison(group)}.");
+				}
+			}
+		}
+
+		if (result.Validation.Count > 0)
+		{
+			sb.AppendLine();
+			sb.AppendLine("Batch preflight warnings:");
+			foreach (var warning in result.Validation)
+			{
+				sb.AppendLine($"  {(warning.IsError ? "ERROR".ColourError() : "WARNING".Colour(Telnet.Yellow))}: {warning.Message}");
+			}
+		}
+
+		return sb.ToString();
+	}
+
+	private static string RenderBatchRunPage(CombatSimulationBatchResult result, ICharacter actor, int start, int count)
+	{
+		var runs = result.Runs
+			.Select((run, index) => (Run: run, Number: index + 1))
+			.Skip(start - 1)
+			.Take(count)
+			.ToList();
+		if (runs.Count == 0)
+		{
+			return "There are no completed batch runs in that range.";
+		}
+
+		var end = runs[^1].Number;
+		var sb = new StringBuilder();
+		sb.AppendLine($"Combat Simulation Batch Runs {runs[0].Number.ToString("N0", actor).ColourValue()} to {end.ToString("N0", actor).ColourValue()} of {result.Runs.Count.ToString("N0", actor).ColourValue()}");
+		sb.AppendLine();
+		sb.AppendLine(StringUtilities.GetTextTable(runs.Select(x => new[]
+			{
+				x.Number.ToString("N0", actor),
+				x.Run.Seed.ToString("N0", actor),
+				x.Run.Status.DescribeEnum(true),
+				x.Run.WinningTeam ?? "none",
+				x.Run.VirtualDuration.Describe(actor),
+				x.Run.WallClockDuration.Describe(actor),
+				x.Run.EventCount.ToString("N0", actor),
+				ShortFingerprint(x.Run.ExecutionFingerprint)
+			}),
+			["Run", "Seed", "Status", "Winner", "Virtual", "Wall", "Events", "Trace"], actor, Telnet.Green));
+		return sb.ToString();
+	}
+
+	private static string ShortFingerprint(string fingerprint)
+	{
+		var separator = fingerprint.IndexOf(':');
+		var prefix = separator < 0 ? string.Empty : fingerprint[..(separator + 1)];
+		var digest = separator < 0 ? fingerprint : fingerprint[(separator + 1)..];
+		if (digest.Length <= 12)
+		{
+			return $"{prefix}{digest}";
+		}
+
+		return $"{prefix}{digest[..12]}";
+	}
+
+	private static string DescribeTraceSummary(CombatSimulationExecutionTraceSummary trace)
+	{
+		return $"materialisation {trace.MaterialisationOperations:N0}/{ShortFingerprint(trace.MaterialisationFingerprint)}, " +
+		       $"random {trace.RandomOperations:N0}/{ShortFingerprint(trace.RandomFingerprint)}, " +
+		       $"scheduler {trace.SchedulerTicks:N0}/{ShortFingerprint(trace.SchedulerFingerprint)}, " +
+		       $"output {trace.TranscriptEntries:N0}/{ShortFingerprint(trace.TranscriptFingerprint)}, " +
+		       $"terminal {ShortFingerprint(trace.TerminalFingerprint)}, " +
+		       $"checkpoints {trace.Checkpoints.Count:N0}{(trace.CheckpointsTruncated ? "+" : string.Empty)}";
+	}
+
+	private static string DescribeTraceComparison(IEnumerable<CombatSimulationResult> runs)
+	{
+		var traces = runs.Select(x => x.ExecutionTrace).ToList();
+		var layers = new[]
+			{
+				DescribeTraceLayer("materialisation", traces.Select(x => x.MaterialisationFingerprint)),
+				DescribeTraceLayer("random", traces.Select(x => x.RandomFingerprint)),
+				DescribeTraceLayer("scheduler", traces.Select(x => x.SchedulerFingerprint)),
+				DescribeTraceLayer("output", traces.Select(x => x.TranscriptFingerprint)),
+				DescribeTraceLayer("terminal", traces.Select(x => x.TerminalFingerprint))
+			}
+			.ListToString(separator: ", ", conjunction: string.Empty, twoItemJoiner: ", ");
+		return $"{layers}; {DescribeMaterialisationDivergence(traces)}; {DescribeFirstCheckpointDivergence(traces)}; {DescribeRecentStateDivergence(traces)}; {DescribeRecentRandomDivergence(traces)}";
+	}
+
+	private static string DescribeMaterialisationDivergence(
+		IReadOnlyList<CombatSimulationExecutionTraceSummary> traces)
+	{
+		if (!traces.Select(x => x.MaterialisationFingerprint).Distinct().Skip(1).Any())
+		{
+			return "materialised runtime state match";
+		}
+
+		var entriesByRun = traces
+			.Select(x => x.MaterialisationEntries.ToDictionary(y => y.OperationIndex, y => y.Description))
+			.ToList();
+		var comparableIndexes = entriesByRun
+			.Select(x => x.Keys.AsEnumerable())
+			.Aggregate((left, right) => left.Intersect(right))
+			.Order()
+			.ToList();
+		foreach (var index in comparableIndexes)
+		{
+			var entries = entriesByRun.Select(x => x[index]).ToList();
+			if (entries.Distinct().Skip(1).Any())
+			{
+				return $"materialisation state entry #{index:N0} differs";
+			}
+		}
+
+		return "materialisation details differ outside their comparable prefix";
+	}
+
+	private static string DescribeRecentStateDivergence(
+		IReadOnlyList<CombatSimulationExecutionTraceSummary> traces)
+	{
+		var operationsByRun = traces
+			.Select(x => x.RecentStateOperations.ToDictionary(y => y.OperationIndex, y => y.Description))
+			.ToList();
+		if (operationsByRun.Count == 0 || operationsByRun.Any(x => x.Count == 0))
+		{
+			return "no detailed state trace";
+		}
+
+		var comparableIndexes = operationsByRun
+			.Select(x => x.Keys.AsEnumerable())
+			.Aggregate((left, right) => left.Intersect(right))
+			.Order()
+			.ToList();
+		foreach (var index in comparableIndexes)
+		{
+			var operations = operationsByRun.Select(x => x[index]).ToList();
+			if (operations.Distinct().Skip(1).Any())
+			{
+				return $"state transition #{index:N0} differs ({operations.ListToString(conjunction: string.Empty, separator: " / ", twoItemJoiner: " / ")})";
+			}
+		}
+
+		return "detailed state trace has no comparable split";
+	}
+
+	private static string DescribeTraceLayer(string name, IEnumerable<string> fingerprints)
+	{
+		return fingerprints.Distinct().Skip(1).Any()
+			? $"{name} MISMATCH".ColourError()
+			: $"{name} match".Colour(Telnet.Green);
+	}
+
+	private static string DescribeFirstCheckpointDivergence(
+		IReadOnlyList<CombatSimulationExecutionTraceSummary> traces)
+	{
+		if (traces.Count == 0 || traces.Any(x => x.Checkpoints.Count == 0))
+		{
+			return "no comparable checkpoints";
+		}
+
+		var commonCount = traces.Min(x => x.Checkpoints.Count);
+		for (var index = 0; index < commonCount; index++)
+		{
+			var checkpoints = traces.Select(x => x.Checkpoints[index]).ToList();
+			var differences = new List<string>();
+			if (checkpoints.Select(x => x.EventCount).Distinct().Skip(1).Any())
+			{
+				differences.Add("event total");
+			}
+
+			if (checkpoints.Select(x => (x.RandomOperations, x.RandomFingerprint)).Distinct().Skip(1).Any())
+			{
+				differences.Add("random");
+			}
+
+			if (checkpoints.Select(x => (x.SchedulerTicks, x.SchedulerFingerprint)).Distinct().Skip(1).Any())
+			{
+				differences.Add("scheduler");
+			}
+
+			if (checkpoints.Select(x => (x.TranscriptEntries, x.TranscriptFingerprint)).Distinct().Skip(1).Any())
+			{
+				differences.Add("output");
+			}
+
+			if (differences.Count > 0)
+			{
+				var firstEvent = checkpoints.Min(x => x.EventCount);
+				var lastEvent = checkpoints.Max(x => x.EventCount);
+				return $"first checkpoint split near {firstEvent:N0}" +
+				       (firstEvent == lastEvent ? "" : $" to {lastEvent:N0}") +
+				       $" events ({differences.ListToString()})";
+			}
+		}
+
+		return traces.Select(x => x.Checkpoints.Count).Distinct().Skip(1).Any() ||
+		       traces.Select(x => x.CheckpointsTruncated).Distinct().Skip(1).Any()
+			? "checkpoint history length differs after the comparable prefix"
+			: "checkpoint sequence match";
+	}
+
+	private static string DescribeRecentRandomDivergence(
+		IReadOnlyList<CombatSimulationExecutionTraceSummary> traces)
+	{
+		if (!traces.Select(x => x.RandomFingerprint).Distinct().Skip(1).Any())
+		{
+			return "recent random trace match";
+		}
+
+		var operationsByRun = traces
+			.Select(x => x.RecentRandomOperations.ToDictionary(y => y.OperationIndex, y => y.Description))
+			.ToList();
+		var comparableIndexes = operationsByRun
+			.Select(x => x.Keys.AsEnumerable())
+			.Aggregate((left, right) => left.Intersect(right))
+			.Order()
+			.ToList();
+		foreach (var index in comparableIndexes)
+		{
+			var operations = operationsByRun.Select(x => x[index]).ToList();
+			if (operations.Distinct().Skip(1).Any())
+			{
+				return $"recent random call #{index:N0} differs ({operations.ListToString(conjunction: string.Empty, separator: " / ", twoItemJoiner: " / ")})";
+			}
+		}
+
+		return "recent random trace has no comparable split";
+	}
+
+	private static void Transcript(ICharacter actor, StringStack command)
+	{
+		var result = Session(actor)?.LastResult;
+		if (result is null)
+		{
+			actor.OutputHandler.Send("There is no completed combat simulation transcript in your session.");
+			return;
+		}
+
+		var start = 1;
+		var count = 100;
+		if (!command.IsFinished && (!int.TryParse(command.PopSpeech(), out start) || start < 1))
+		{
+			actor.OutputHandler.Send("The transcript start must be a positive entry number.");
+			return;
+		}
+
+		if (!command.IsFinished && (!int.TryParse(command.PopSpeech(), out count) || count is < 1 or > 1_000))
+		{
+			actor.OutputHandler.Send("The transcript count must be from 1 to 1,000.");
+			return;
+		}
+
+		if (!command.IsFinished)
+		{
+			actor.OutputHandler.Send("The syntax is impdebug combatsim transcript [start] [count].");
+			return;
+		}
+
+		var entries = result.Transcript.Skip(start - 1).Take(count).ToList();
+		actor.OutputHandler.Send(entries.Count == 0
+			? "There are no transcript entries in that range."
+			: entries.Select((x, i) => $"{(start + i).ToString("N0", actor)}: {x}").ListToString(
+				separator: "\n", conjunction: string.Empty, twoItemJoiner: "\n"));
+	}
+}

--- a/MudSharpCore/Combat/Simulation/CombatSimulationExecutionFingerprint.cs
+++ b/MudSharpCore/Combat/Simulation/CombatSimulationExecutionFingerprint.cs
@@ -1,0 +1,423 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+
+#nullable enable
+
+namespace MudSharp.Combat.Simulation;
+
+/// <summary>
+/// Produces a versioned, deterministic digest of an accelerated combat run. It deliberately excludes
+/// wall-clock timing and transient framework identifiers so that repeated seeded runs can be compared.
+/// </summary>
+internal sealed class CombatSimulationExecutionFingerprint
+{
+	public const string Version = "v1";
+	private const int TraceCheckpointInterval = 50;
+	private const int MaximumTraceCheckpoints = 200;
+	private const int MaximumRecentRandomOperations = 128;
+	private const int MaximumDetailedRandomOperations = 10_000;
+	private const int MaximumMaterialisationEntries = 256;
+	private const int MaximumDetailedStateOperations = 10_000;
+	private readonly IncrementalHash _hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+	private readonly IncrementalHash _materialisationHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+	private readonly IncrementalHash _randomHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+	private readonly IncrementalHash _schedulerHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+	private readonly IncrementalHash _transcriptHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+	private readonly IncrementalHash _terminalHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+	private readonly IncrementalHash _randomCheckpointHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+	private readonly IncrementalHash _schedulerCheckpointHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+	private readonly IncrementalHash _transcriptCheckpointHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+	private readonly List<CombatSimulationExecutionTraceCheckpoint> _checkpoints = [];
+	private readonly Queue<CombatSimulationRandomTraceEntry> _recentRandomOperations = [];
+	private readonly List<CombatSimulationMaterialisationTraceEntry> _materialisationEntries = [];
+	private readonly Queue<CombatSimulationStateTraceEntry> _recentStateOperations = [];
+	private string? _completedFingerprint;
+	private CombatSimulationExecutionTraceSummary? _traceSummary;
+	private int _materialisationOperations;
+	private int _randomOperations;
+	private int _schedulerTicks;
+	private int _transcriptEntries;
+	private int _lastCheckpointEventCount;
+	private int _nextCheckpointEvent = TraceCheckpointInterval;
+	private bool _checkpointsTruncated;
+
+	public CombatSimulationExecutionFingerprint(int seed, bool captureRandomCallSites = false)
+	{
+		CaptureRandomCallSites = captureRandomCallSites;
+		Record("futuremud-combat-simulation");
+		Record(Version);
+		Record("seed");
+		Record(seed.ToString(System.Globalization.CultureInfo.InvariantCulture));
+	}
+
+	public CombatSimulationExecutionTraceSummary TraceSummary => _traceSummary ??
+		throw new InvalidOperationException("The combat simulation fingerprint has not been completed.");
+	public bool CaptureRandomCallSites { get; }
+	public CombatSimulationRandomTraceEntry? LastRandomOperation => _recentRandomOperations.LastOrDefault();
+
+	public void RecordMaterialisation(CombatSimulationParticipantRequest participant)
+	{
+		var slot = participant.Slot.ToString(System.Globalization.CultureInfo.InvariantCulture);
+		var sourceType = ((int)participant.SourceType).ToString(System.Globalization.CultureInfo.InvariantCulture);
+		var source = participant.SourceType == CombatSimulationSourceType.Character
+			? participant.Character?.Id.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty
+			: participant.NpcTemplate?.Id.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty;
+		var ordinal = participant.Ordinal.ToString(System.Globalization.CultureInfo.InvariantCulture);
+		Record("materialise");
+		Record(slot);
+		Record(participant.Team);
+		Record(sourceType);
+		Record(source);
+		Record(ordinal);
+		RecordTrace(_materialisationHash, "materialise", slot, participant.Team, sourceType, source, ordinal);
+		_materialisationOperations++;
+	}
+
+	public void RecordMaterialisationRuntimeState(int slot, string category, IEnumerable<string> values)
+	{
+		var slotText = slot.ToString(System.Globalization.CultureInfo.InvariantCulture);
+		var value = string.Join("|", values);
+		Record("materialise-runtime");
+		Record(slotText);
+		Record(category);
+		Record(value);
+		RecordTrace(_materialisationHash, "materialise-runtime", slotText, category, value);
+		if (CaptureRandomCallSites && _materialisationEntries.Count < MaximumMaterialisationEntries)
+		{
+			_materialisationEntries.Add(new CombatSimulationMaterialisationTraceEntry(
+				_materialisationOperations + 1,
+				$"slot:{slotText} {category}:{ShortDigest(value)}"));
+		}
+
+		_materialisationOperations++;
+	}
+
+	public void RecordRandom(
+		string operation,
+		long value,
+		long firstArgument = 0,
+		long secondArgument = 0,
+		string? callSite = null)
+	{
+		var first = firstArgument.ToString(System.Globalization.CultureInfo.InvariantCulture);
+		var second = secondArgument.ToString(System.Globalization.CultureInfo.InvariantCulture);
+		var result = value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+		Record("random");
+		Record(operation);
+		Record(first);
+		Record(second);
+		Record(result);
+		RecordTrace(_randomHash, "random", operation, first, second, result);
+		RecordTrace(_randomCheckpointHash, "random", operation, first, second, result);
+		RecordRecentRandomOperation($"{operation}({first}, {second}) = {result}", callSite);
+		_randomOperations++;
+	}
+
+	public void RecordRandom(string operation, double value, string? callSite = null)
+	{
+		var result = BitConverter.DoubleToInt64Bits(value).ToString(System.Globalization.CultureInfo.InvariantCulture);
+		Record("random");
+		Record(operation);
+		Record(result);
+		RecordTrace(_randomHash, "random", operation, result);
+		RecordTrace(_randomCheckpointHash, "random", operation, result);
+		RecordRecentRandomOperation($"{operation} = {result}", callSite);
+		_randomOperations++;
+	}
+
+	public void RecordRandomBytes(ReadOnlySpan<byte> values, string? callSite = null)
+	{
+		var result = Convert.ToHexString(values);
+		Record("random-bytes");
+		Record(result);
+		RecordTrace(_randomHash, "random-bytes", result);
+		RecordTrace(_randomCheckpointHash, "random-bytes", result);
+		RecordRecentRandomOperation($"bytes = {result}", callSite);
+		_randomOperations++;
+	}
+
+	public void RecordState(string description)
+	{
+		if (!CaptureRandomCallSites)
+		{
+			return;
+		}
+
+		if (_recentStateOperations.Count >= MaximumDetailedStateOperations)
+		{
+			_recentStateOperations.Dequeue();
+		}
+
+		_recentStateOperations.Enqueue(new CombatSimulationStateTraceEntry(
+			_recentStateOperations.Count == 0
+				? 1
+				: _recentStateOperations.Last().OperationIndex + 1,
+			description));
+	}
+
+	public void RecordTranscript(string participant, TimeSpan elapsed, string line)
+	{
+		var ticks = elapsed.Ticks.ToString(System.Globalization.CultureInfo.InvariantCulture);
+		Record("output");
+		Record(participant);
+		Record(ticks);
+		Record(line);
+		RecordTrace(_transcriptHash, "output", participant, ticks, line);
+		RecordTrace(_transcriptCheckpointHash, "output", participant, ticks, line);
+		_transcriptEntries++;
+	}
+
+	public void RecordSchedulerTick(DateTimeOffset utc, int schedulerFired, int effectSchedulerFired, int totalEvents)
+	{
+		var ticks = utc.Ticks.ToString(System.Globalization.CultureInfo.InvariantCulture);
+		var scheduler = schedulerFired.ToString(System.Globalization.CultureInfo.InvariantCulture);
+		var effects = effectSchedulerFired.ToString(System.Globalization.CultureInfo.InvariantCulture);
+		var total = totalEvents.ToString(System.Globalization.CultureInfo.InvariantCulture);
+		Record("scheduler");
+		Record(ticks);
+		Record(scheduler);
+		Record(effects);
+		Record(total);
+		RecordTrace(_schedulerHash, "scheduler", ticks, scheduler, effects, total);
+		RecordTrace(_schedulerCheckpointHash, "scheduler", ticks, scheduler, effects, total);
+		_schedulerTicks++;
+		if (totalEvents >= _nextCheckpointEvent)
+		{
+			CaptureCheckpoint(totalEvents);
+			_nextCheckpointEvent = ((totalEvents / TraceCheckpointInterval) + 1) * TraceCheckpointInterval;
+		}
+	}
+
+	public string Complete(CombatSimulationRunStatus status, string? winningTeam, TimeSpan virtualDuration,
+		int eventCount, IEnumerable<CombatSimulationParticipantResult> participants)
+	{
+		if (_completedFingerprint is not null)
+		{
+			return _completedFingerprint;
+		}
+
+		var terminalTrace = new List<string>
+		{
+			"terminal",
+			((int)status).ToString(System.Globalization.CultureInfo.InvariantCulture),
+			winningTeam ?? string.Empty,
+			virtualDuration.Ticks.ToString(System.Globalization.CultureInfo.InvariantCulture),
+			eventCount.ToString(System.Globalization.CultureInfo.InvariantCulture)
+		};
+		foreach (var value in terminalTrace)
+		{
+			Record(value);
+		}
+
+		foreach (var participant in participants.OrderBy(x => x.Slot))
+		{
+			var participantTrace = new[]
+			{
+				"participant",
+				participant.Slot.ToString(System.Globalization.CultureInfo.InvariantCulture),
+				participant.Team,
+				((int)participant.Outcome).ToString(System.Globalization.CultureInfo.InvariantCulture),
+				((long)participant.FinalState).ToString(System.Globalization.CultureInfo.InvariantCulture),
+				BitConverter.DoubleToInt64Bits(participant.BloodRatio)
+					.ToString(System.Globalization.CultureInfo.InvariantCulture),
+				BitConverter.DoubleToInt64Bits(participant.StaminaRatio)
+					.ToString(System.Globalization.CultureInfo.InvariantCulture),
+				participant.WoundCount.ToString(System.Globalization.CultureInfo.InvariantCulture),
+				participant.UnderFullGrappleControl ? "1" : "0"
+			};
+			foreach (var value in participantTrace)
+			{
+				Record(value);
+			}
+
+			terminalTrace.AddRange(participantTrace);
+		}
+
+		if (eventCount > 0 && eventCount != _lastCheckpointEventCount)
+		{
+			CaptureCheckpoint(eventCount);
+		}
+
+		_completedFingerprint = $"{Version}:{Convert.ToHexString(_hash.GetHashAndReset()).ToLowerInvariant()}";
+		_traceSummary = new CombatSimulationExecutionTraceSummary(
+			_materialisationOperations,
+			Digest(_materialisationHash),
+			_materialisationEntries.AsReadOnly(),
+			_randomOperations,
+			Digest(_randomHash),
+			_schedulerTicks,
+			Digest(_schedulerHash),
+			_transcriptEntries,
+			Digest(_transcriptHash),
+			Digest(_terminalHash, terminalTrace),
+			_recentRandomOperations.ToArray(),
+			_recentStateOperations.ToArray(),
+			_checkpoints.AsReadOnly(),
+			_checkpointsTruncated);
+		return _completedFingerprint;
+	}
+
+	private void Record(string value)
+	{
+		Append(_hash, value);
+	}
+
+	private void CaptureCheckpoint(int eventCount)
+	{
+		if (_checkpoints.Count >= MaximumTraceCheckpoints)
+		{
+			_checkpointsTruncated = true;
+			return;
+		}
+
+		_checkpoints.Add(new CombatSimulationExecutionTraceCheckpoint(
+			eventCount,
+			_randomOperations,
+			Digest(_randomCheckpointHash),
+			_schedulerTicks,
+			Digest(_schedulerCheckpointHash),
+			_transcriptEntries,
+			Digest(_transcriptCheckpointHash)));
+		_lastCheckpointEventCount = eventCount;
+	}
+
+	private void RecordRecentRandomOperation(string description, string? callSite)
+	{
+		var maximumOperations = CaptureRandomCallSites
+			? MaximumDetailedRandomOperations
+			: MaximumRecentRandomOperations;
+		if (_recentRandomOperations.Count >= maximumOperations)
+		{
+			_recentRandomOperations.Dequeue();
+		}
+
+		_recentRandomOperations.Enqueue(new CombatSimulationRandomTraceEntry(
+			_randomOperations + 1,
+			string.IsNullOrEmpty(callSite) ? description : $"{description} from {callSite}"));
+	}
+
+	private static void RecordTrace(IncrementalHash hash, params string[] values)
+	{
+		foreach (var value in values)
+		{
+			Append(hash, value);
+		}
+	}
+
+	private static string Digest(IncrementalHash hash, IEnumerable<string>? trailingValues = null)
+	{
+		if (trailingValues is not null)
+		{
+			foreach (var value in trailingValues)
+			{
+				Append(hash, value);
+			}
+		}
+
+		return Convert.ToHexString(hash.GetHashAndReset()).ToLowerInvariant();
+	}
+
+	private static void Append(IncrementalHash hash, string value)
+	{
+		var bytes = Encoding.UTF8.GetBytes(value);
+		hash.AppendData(bytes);
+		hash.AppendData([0]);
+	}
+
+	private static string ShortDigest(string value)
+	{
+		return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value)))[..12].ToLowerInvariant();
+	}
+}
+
+internal sealed class CombatSimulationRecordingRandom(Random inner, CombatSimulationExecutionFingerprint fingerprint)
+	: Random
+{
+	public override int Next()
+	{
+		var value = inner.Next();
+		fingerprint.RecordRandom("next", value, callSite: GetCallSite());
+		return value;
+	}
+
+	public override int Next(int maxValue)
+	{
+		var value = inner.Next(maxValue);
+		fingerprint.RecordRandom("next-max", value, maxValue, callSite: GetCallSite());
+		return value;
+	}
+
+	public override int Next(int minValue, int maxValue)
+	{
+		var value = inner.Next(minValue, maxValue);
+		fingerprint.RecordRandom("next-range", value, minValue, maxValue, GetCallSite());
+		return value;
+	}
+
+	public override double NextDouble()
+	{
+		var value = inner.NextDouble();
+		fingerprint.RecordRandom("next-double", value, GetCallSite());
+		return value;
+	}
+
+	public override float NextSingle()
+	{
+		var value = inner.NextSingle();
+		fingerprint.RecordRandom("next-single", value, GetCallSite());
+		return value;
+	}
+
+	public override long NextInt64()
+	{
+		var value = inner.NextInt64();
+		fingerprint.RecordRandom("next-int64", value, GetCallSite());
+		return value;
+	}
+
+	public override long NextInt64(long maxValue)
+	{
+		var value = inner.NextInt64(maxValue);
+		fingerprint.RecordRandom("next-int64-max", value, maxValue, callSite: GetCallSite());
+		return value;
+	}
+
+	public override long NextInt64(long minValue, long maxValue)
+	{
+		var value = inner.NextInt64(minValue, maxValue);
+		fingerprint.RecordRandom("next-int64-range", value, minValue, maxValue, GetCallSite());
+		return value;
+	}
+
+	public override void NextBytes(byte[] buffer)
+	{
+		inner.NextBytes(buffer);
+		fingerprint.RecordRandomBytes(buffer, GetCallSite());
+	}
+
+	public override void NextBytes(Span<byte> buffer)
+	{
+		inner.NextBytes(buffer);
+		fingerprint.RecordRandomBytes(buffer, GetCallSite());
+	}
+
+	private string? GetCallSite()
+	{
+		if (!fingerprint.CaptureRandomCallSites)
+		{
+			return null;
+		}
+
+		var callSites = new StackTrace(skipFrames: 1, fNeedFileInfo: false)
+			.GetFrames()?
+			.Select(x => x.GetMethod())
+			.Where(x => x?.DeclaringType != typeof(CombatSimulationRecordingRandom))
+			.Take(4)
+			.Select(x => $"{x!.DeclaringType?.FullName}.{x.Name}")
+			.ToList();
+		return callSites is { Count: > 0 }
+			? string.Join(" <- ", callSites)
+			: null;
+	}
+}

--- a/MudSharpCore/Combat/Simulation/CombatSimulationRuntimeScope.cs
+++ b/MudSharpCore/Combat/Simulation/CombatSimulationRuntimeScope.cs
@@ -1,0 +1,78 @@
+using System.Threading;
+using ExpressionEngine;
+using MudSharp.Effects;
+using MudSharp.Framework;
+using MudSharp.Framework.Save;
+using MudSharp.Framework.Scheduling;
+
+#nullable enable
+
+namespace MudSharp.Combat.Simulation;
+
+/// <summary>
+/// Replaces only the mutable runtime services used by a combat simulation on the current execution flow.
+/// The live game loop and other threads continue to see their ordinary services.
+/// </summary>
+internal sealed class CombatSimulationRuntimeScope : IDisposable
+{
+	private static readonly AsyncLocal<CombatSimulationRuntimeScope?> _current = new();
+	private readonly IDisposable _clockScope;
+	private readonly IDisposable _expressionRandomScope;
+	private readonly IDisposable _randomScope;
+	private readonly IDisposable _sideEffectScope;
+	private readonly AsyncFlowControl? _executionContextFlowControl;
+	private bool _disposed;
+
+	public CombatSimulationRuntimeScope(IFuturemud gameworld, TimeProvider timeProvider, int seed,
+		CombatSimulationExecutionFingerprint fingerprint)
+	{
+		if (_current.Value is not null)
+		{
+			throw new InvalidOperationException("A combat simulation runtime scope is already active.");
+		}
+
+		TimeProvider = timeProvider;
+		Scheduler = new Scheduler(timeProvider);
+		EffectScheduler = new EffectScheduler(gameworld, timeProvider);
+		SaveManager = new CombatSimulationSaveManager();
+		HeartbeatManager = new HeartbeatManager(gameworld);
+		ExecutionFingerprint = fingerprint;
+		var random = new CombatSimulationRecordingRandom(new Random(seed), fingerprint);
+		// The accelerated simulation runs synchronously on the game loop. Do not let any background
+		// task created by an on-load prog, effect or hook inherit this virtual clock/scheduler/random stream.
+		if (!ExecutionContext.IsFlowSuppressed())
+		{
+			_executionContextFlowControl = ExecutionContext.SuppressFlow();
+		}
+
+		_clockScope = RuntimeClock.Push(timeProvider);
+		_randomScope = Constants.PushRandom(random);
+		_expressionRandomScope = Expression.PushRandom(random);
+		_sideEffectScope = RuntimeSideEffectContext.SuppressCrimeCreation();
+		_current.Value = this;
+	}
+
+	public static CombatSimulationRuntimeScope? Current => _current.Value;
+	public TimeProvider TimeProvider { get; }
+	public IScheduler Scheduler { get; }
+	public IEffectScheduler EffectScheduler { get; }
+	public ISaveManager SaveManager { get; }
+	public IHeartbeatManager HeartbeatManager { get; }
+	public CombatSimulationExecutionFingerprint ExecutionFingerprint { get; }
+
+	public void Dispose()
+	{
+		if (_disposed)
+		{
+			return;
+		}
+
+		_current.Value = null;
+		_sideEffectScope.Dispose();
+		_expressionRandomScope.Dispose();
+		_randomScope.Dispose();
+		_clockScope.Dispose();
+		_executionContextFlowControl?.Dispose();
+		_disposed = true;
+	}
+}

--- a/MudSharpCore/Combat/Simulation/CombatSimulationSaveManager.cs
+++ b/MudSharpCore/Combat/Simulation/CombatSimulationSaveManager.cs
@@ -1,0 +1,212 @@
+using System.Diagnostics;
+using MudSharp.Framework;
+using MudSharp.Framework.Save;
+using CharacterItem = MudSharp.Character.Character;
+using NpcCharacter = MudSharp.NPC.NPC;
+
+#nullable enable
+
+namespace MudSharp.Combat.Simulation;
+
+/// <summary>
+/// Supplies deterministic, in-memory identities and discards ordinary persistence work for one combat simulation.
+/// </summary>
+/// <remarks>
+/// A normal <see cref="SaveManager"/> gives materialised characters and items database identities. Even when the
+/// surrounding transaction is rolled back, MySQL auto-increment counters advance, which makes later simulation runs
+/// observably different. This manager instead allocates negative IDs in a stable construction order. Explicit
+/// database work outside the save queue is still protected by the simulation transaction.
+/// </remarks>
+internal sealed class CombatSimulationSaveManager : ISaveManager
+{
+	private readonly List<ILateInitialisingItem> _initialisationQueue = [];
+	private readonly Queue<ILazyLoadDuringIdleTime> _lazyLoaders = new();
+	private readonly List<ISaveable> _saveQueue = [];
+	private bool _flushing;
+	private bool _mudBootingMode;
+	private long _nextTransientId = -1;
+
+	public bool Flushing => _flushing;
+
+	public bool MudBootingMode
+	{
+		get => _mudBootingMode;
+		set => _mudBootingMode = value;
+	}
+
+	public void Add(ISaveable item)
+	{
+		if (IsNoSave(item) || _saveQueue.Contains(item))
+		{
+			return;
+		}
+
+		_saveQueue.Add(item);
+	}
+
+	public void AddInitialisation(ILateInitialisingItem item)
+	{
+		if (item.GetNoSave() || item.IdHasBeenRegistered || _initialisationQueue.Contains(item))
+		{
+			return;
+		}
+
+		_initialisationQueue.Add(item);
+	}
+
+	public void AddLazyLoad(ILazyLoadDuringIdleTime item)
+	{
+		_lazyLoaders.Enqueue(item);
+	}
+
+	public void Abort(ISaveable item)
+	{
+		_saveQueue.Remove(item);
+		if (item is ILateInitialisingItem lateItem)
+		{
+			_initialisationQueue.Remove(lateItem);
+		}
+
+		AbortLazyLoad(item as ILazyLoadDuringIdleTime);
+	}
+
+	public void AbortLazyLoad(ILazyLoadDuringIdleTime? item)
+	{
+		if (item is null || !_lazyLoaders.Contains(item))
+		{
+			return;
+		}
+
+		var remaining = _lazyLoaders.Where(x => !ReferenceEquals(x, item)).ToList();
+		_lazyLoaders.Clear();
+		foreach (var remainingItem in remaining)
+		{
+			_lazyLoaders.Enqueue(remainingItem);
+		}
+	}
+
+	public void DirectInitialise(ILateInitialisingItem item)
+	{
+		if (item.GetNoSave())
+		{
+			Abort(item);
+			return;
+		}
+
+		Initialise(item);
+		Abort(item);
+	}
+
+	public string DebugInfo(IFuturemud gameworld)
+	{
+		return $"The combat simulation save manager is {(Flushing ? "initialising" : "idle")}; " +
+		       $"{_initialisationQueue.Count:N0} item(s) await transient identities and " +
+		       $"{_saveQueue.Count:N0} item(s) await discarded saves.";
+	}
+
+	public void Flush()
+	{
+		if (_flushing)
+		{
+			return;
+		}
+
+		_flushing = true;
+		try
+		{
+			while (_initialisationQueue.Count > 0)
+			{
+				var queued = _initialisationQueue.ToList();
+				_initialisationQueue.Clear();
+				foreach (var phase in Enum.GetValues<InitialisationPhase>())
+				{
+					foreach (var item in queued.Where(x => x.InitialisationPhase == phase))
+					{
+						if (item.GetNoSave())
+						{
+							item.Changed = false;
+							continue;
+						}
+
+						Initialise(item);
+					}
+				}
+			}
+
+			foreach (var item in _saveQueue)
+			{
+				item.Changed = false;
+			}
+
+			_saveQueue.Clear();
+		}
+		finally
+		{
+			_flushing = false;
+		}
+	}
+
+	public void FlushLazyLoad(TimeSpan maximumTime)
+	{
+		var stopwatch = Stopwatch.StartNew();
+		while (_lazyLoaders.TryDequeue(out var loader))
+		{
+			loader.DoLoad();
+			if (stopwatch.Elapsed >= maximumTime)
+			{
+				return;
+			}
+		}
+	}
+
+	public bool IsQueued(ISaveable saveable)
+	{
+		return _saveQueue.Contains(saveable) ||
+		       (saveable is ILateInitialisingItem lateItem && _initialisationQueue.Contains(lateItem)) ||
+		       (saveable is ILazyLoadDuringIdleTime lazyLoad && _lazyLoaders.Contains(lazyLoad));
+	}
+
+	private void Initialise(ILateInitialisingItem item)
+	{
+		if (item.IdHasBeenRegistered)
+		{
+			return;
+		}
+
+		switch (item)
+		{
+			case NpcCharacter npc:
+				npc.InitialiseCombatSimulationIdentity(NextId(), NextId(), NextId(), NextId());
+				return;
+			case CharacterItem character:
+				character.InitialiseCombatSimulationIdentity(NextId(), NextId(), NextId());
+				return;
+			case LateInitialisingItem lateItem:
+				lateItem.InitialiseWithoutPersistence(NextId());
+				return;
+			case LateKeywordedInitialisingItem lateKeywordedItem:
+				lateKeywordedItem.InitialiseWithoutPersistence(NextId());
+				return;
+			default:
+				throw new InvalidOperationException(
+					$"{item.FrameworkItemType} cannot be given a transient combat-simulation identity.");
+		}
+	}
+
+	private long NextId()
+	{
+		return _nextTransientId--;
+	}
+
+	private static bool IsNoSave(ISaveable item)
+	{
+		return item switch
+		{
+			SaveableItem saveableItem => saveableItem.GetNoSave(),
+			SavableKeywordedItem saveableKeywordedItem => saveableKeywordedItem.GetNoSave(),
+			LateInitialisingItem lateInitialisingItem => lateInitialisingItem.GetNoSave(),
+			LateKeywordedInitialisingItem lateKeywordedInitialisingItem => lateKeywordedInitialisingItem.GetNoSave(),
+			_ => false
+		};
+	}
+}

--- a/MudSharpCore/Combat/Simulation/CombatSimulationService.cs
+++ b/MudSharpCore/Combat/Simulation/CombatSimulationService.cs
@@ -1,0 +1,974 @@
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.EntityFrameworkCore.Storage;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Database;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Events;
+using MudSharp.Framework;
+using MudSharp.NPC;
+using MudSharp.NPC.Templates;
+using BodyImplementation = MudSharp.Body.Implementations.Body;
+
+#nullable enable
+
+namespace MudSharp.Combat.Simulation;
+
+public sealed class CombatSimulationService : ICombatSimulationService
+{
+	private const int NoCombatProgressEventThreshold = 1_000;
+	private static readonly TimeSpan NoCombatProgressVirtualTimeThreshold = TimeSpan.FromSeconds(30);
+
+	private sealed record SourceSnapshot(
+		CombatSimulationParticipantRequest Request,
+		XElement? CharacterEffects,
+		XElement? BodyEffects);
+
+	private sealed record RuntimeParticipant(
+		CombatSimulationParticipantRequest Request,
+		ICharacter Character,
+		string Name);
+
+	private sealed record CombatProgressSnapshot(
+		CharacterState State,
+		IPerceiver? Target,
+		bool MeleeRange,
+		CombatStrategyMode Strategy,
+		double BloodVolume,
+		double Stamina,
+		int Wounds,
+		int TranscriptEntries);
+
+	private static int _simulationRunning;
+	private static long _nextTemporaryCellId = -1_000_000;
+
+	public IReadOnlyList<CombatSimulationValidationMessage> Validate(CombatSimulationRequest request)
+	{
+		var messages = new List<CombatSimulationValidationMessage>();
+		if (request.Scene is null)
+		{
+			messages.Add(new CombatSimulationValidationMessage(true, "A combat scene is required."));
+		}
+
+		if (request.Participants.Count < 2)
+		{
+			messages.Add(new CombatSimulationValidationMessage(true, "At least two combatants are required."));
+		}
+
+		if (request.Participants
+			    .Select(x => x.Team)
+			    .Distinct(StringComparer.InvariantCultureIgnoreCase)
+			    .Count() < 2)
+		{
+			messages.Add(new CombatSimulationValidationMessage(true, "At least two opposing teams are required."));
+		}
+
+		if (request.Participants.GroupBy(x => x.Slot).Any(x => x.Count() > 1))
+		{
+			messages.Add(new CombatSimulationValidationMessage(true, "Combatant slot numbers must be unique."));
+		}
+
+		if (request.MaximumVirtualTime <= TimeSpan.Zero || request.MaximumVirtualTime > TimeSpan.FromDays(1))
+		{
+			messages.Add(new CombatSimulationValidationMessage(true,
+				"The virtual-time limit must be greater than zero and no more than one day."));
+		}
+
+		if (request.MaximumEvents is < 1 or > 1_000_000)
+		{
+			messages.Add(new CombatSimulationValidationMessage(true,
+				"The event limit must be between 1 and 1,000,000."));
+		}
+
+		if (request.MaximumTranscriptEntries is < 0 or > 100_000)
+		{
+			messages.Add(new CombatSimulationValidationMessage(true,
+				"The transcript limit must be between 0 and 100,000 entries."));
+		}
+
+		if (request.MaximumWallClockTime <= TimeSpan.Zero || request.MaximumWallClockTime > TimeSpan.FromMinutes(10))
+		{
+			messages.Add(new CombatSimulationValidationMessage(true,
+				"The wall-clock limit must be greater than zero and no more than ten minutes."));
+		}
+
+		foreach (var participant in request.Participants)
+		{
+			if (string.IsNullOrWhiteSpace(participant.Team))
+			{
+				messages.Add(new CombatSimulationValidationMessage(true,
+					$"Combatant slot {participant.Slot:N0} has no team."));
+			}
+
+			var settings = participant.SourceType switch
+			{
+				CombatSimulationSourceType.Character => participant.Character?.CombatSettings,
+				CombatSimulationSourceType.NpcTemplate => participant.NpcTemplate?.DefaultCombatSetting,
+				_ => null
+			};
+
+			switch (participant.SourceType)
+			{
+				case CombatSimulationSourceType.Character when participant.Character is null:
+					messages.Add(new CombatSimulationValidationMessage(true,
+						$"Combatant slot {participant.Slot:N0} has no character source."));
+					continue;
+				case CombatSimulationSourceType.NpcTemplate when participant.NpcTemplate is null:
+					messages.Add(new CombatSimulationValidationMessage(true,
+						$"Combatant slot {participant.Slot:N0} has no NPC-template source."));
+					continue;
+			}
+
+			if (participant.Character?.State.HasFlag(CharacterState.Dead) == true)
+			{
+				messages.Add(new CombatSimulationValidationMessage(true,
+					$"{participant.SourceDescription} is dead and cannot enter a simulation."));
+			}
+
+			if (participant.Character?.Combat is not null)
+			{
+				messages.Add(new CombatSimulationValidationMessage(false,
+					$"{participant.SourceDescription} is already in combat; its pre-combat live state will be cloned."));
+			}
+
+			if (settings is null)
+			{
+				messages.Add(new CombatSimulationValidationMessage(false,
+					$"{participant.SourceDescription} has no explicit combat settings; the engine fallback will be used."));
+			}
+			else if (settings.InventoryManagement == AutomaticInventorySettings.FullyManual)
+			{
+				messages.Add(new CombatSimulationValidationMessage(false,
+					$"{participant.SourceDescription} uses fully manual inventory management and may not draw or reload weapons."));
+			}
+
+			if (settings is not null &&
+			    (settings.MovementManagement == AutomaticMovementSettings.FullyManual ||
+			     settings.ManualPositionManagement))
+			{
+				messages.Add(new CombatSimulationValidationMessage(false,
+					$"{participant.SourceDescription} uses manual movement or position management and may stall without input."));
+			}
+
+			if (settings?.RangedManagement == AutomaticRangedSettings.FullyManual)
+			{
+				messages.Add(new CombatSimulationValidationMessage(false,
+					$"{participant.SourceDescription} uses fully manual ranged management and may not fire automatically."));
+			}
+
+			if (settings is not null &&
+			    settings.WeaponUsePercentage + settings.NaturalWeaponPercentage + settings.MagicUsePercentage +
+			    settings.PsychicUsePercentage + settings.AuxiliaryPercentage <= 0.0)
+			{
+				messages.Add(new CombatSimulationValidationMessage(false,
+					$"{participant.SourceDescription} has no weighted automatic attack type."));
+			}
+
+			if (participant.NpcTemplate?.OnLoadProg is not null)
+			{
+				messages.Add(new CombatSimulationValidationMessage(false,
+					$"{participant.SourceDescription} has an on-load prog. It will run in the simulation and may have external side effects."));
+			}
+		}
+
+		messages.Add(new CombatSimulationValidationMessage(false,
+			"EF SaveChanges calls and ordinary save-queue work are suppressed in the simulation; direct Dapper commands and external services invoked by hooks or progs cannot be unwound."));
+		return messages;
+	}
+
+	public IReadOnlyList<CombatSimulationValidationMessage> ValidateBatch(CombatSimulationBatchRequest request)
+	{
+		var messages = Validate(new CombatSimulationRequest(
+			request.BatchId,
+			request.RequestedBy,
+			request.Scene,
+			request.Participants,
+			request.FirstSeed,
+			request.MaximumVirtualTime,
+			request.MaximumEvents,
+			0,
+			request.MaximumWallClockTime,
+			request.Force)).ToList();
+
+		if (request.RunCount is < 1 or > 100)
+		{
+			messages.Add(new CombatSimulationValidationMessage(true,
+				"The batch run count must be between 1 and 100."));
+		}
+
+		if (request.MaximumBatchWallClockTime <= TimeSpan.Zero ||
+		    request.MaximumBatchWallClockTime > TimeSpan.FromMinutes(10))
+		{
+			messages.Add(new CombatSimulationValidationMessage(true,
+				"The batch wall-clock limit must be greater than zero and no more than ten minutes."));
+		}
+
+		if (request.RunCount > 0 && !TryGetBatchSeed(request, request.RunCount - 1, out _))
+		{
+			messages.Add(new CombatSimulationValidationMessage(true,
+				"The starting seed and increment must produce a valid 32-bit seed for every run."));
+		}
+
+		return messages;
+	}
+
+	public CombatSimulationBatchResult RunBatch(CombatSimulationBatchRequest request)
+	{
+		var validation = ValidateBatch(request).ToList();
+		if (validation.Any(x => x.IsError) || (!request.Force && validation.Any()))
+		{
+			return EmptyBatchResult(request, validation,
+				validation.Any(x => x.IsError)
+					? "The combat-simulation batch has validation errors."
+					: "The combat-simulation batch has warnings; run it with force after reviewing them.");
+		}
+
+		var batchWallClock = Stopwatch.StartNew();
+		var batchEpoch = TimeProvider.System.GetUtcNow();
+		var results = new List<CombatSimulationResult>();
+		string? errorMessage = null;
+		for (var runIndex = 0; runIndex < request.RunCount; runIndex++)
+		{
+			var remainingWallClock = request.MaximumBatchWallClockTime - batchWallClock.Elapsed;
+			if (remainingWallClock <= TimeSpan.Zero)
+			{
+				errorMessage = $"The batch wall-clock limit of {request.MaximumBatchWallClockTime.Describe(request.RequestedBy)} was reached after {results.Count:N0} run(s).";
+				break;
+			}
+
+			if (!TryGetBatchSeed(request, runIndex, out var seed))
+			{
+				errorMessage = "The batch seed sequence exceeded the supported 32-bit range.";
+				break;
+			}
+
+			var perRunWallClock = remainingWallClock < request.MaximumWallClockTime
+				? remainingWallClock
+				: request.MaximumWallClockTime;
+			results.Add(Run(new CombatSimulationRequest(
+				Guid.NewGuid(),
+				request.RequestedBy,
+				request.Scene,
+				request.Participants,
+				seed,
+				request.MaximumVirtualTime,
+				request.MaximumEvents,
+				0,
+				perRunWallClock,
+				request.Force), batchEpoch, request.RunCount > 1 && request.SeedIncrement == 0));
+		}
+
+		return BuildBatchResult(request, results, validation, batchWallClock.Elapsed, errorMessage);
+	}
+
+	public CombatSimulationResult Run(CombatSimulationRequest request)
+	{
+		return Run(request, TimeProvider.System.GetUtcNow(), false);
+	}
+
+	private CombatSimulationResult Run(
+		CombatSimulationRequest request,
+		DateTimeOffset simulationEpoch,
+		bool captureRandomCallSites)
+	{
+		var validation = Validate(request).ToList();
+		if (validation.Any(x => x.IsError) || (!request.Force && validation.Any()))
+		{
+			return EmptyResult(request, CombatSimulationRunStatus.ValidationFailed, validation,
+				validation.Any(x => x.IsError)
+					? "The simulation has validation errors."
+					: "The simulation has warnings; run it with force after reviewing them.");
+		}
+
+		if (Interlocked.CompareExchange(ref _simulationRunning, 1, 0) != 0)
+		{
+			return EmptyResult(request, CombatSimulationRunStatus.Error, validation,
+				"Another combat simulation is already running.");
+		}
+
+		var wallClock = Stopwatch.StartNew();
+		var snapshots = new List<SourceSnapshot>();
+		XElement? sceneEffects = null;
+		var originalActors = new HashSet<ICharacter>(ReferenceEqualityComparer.Instance);
+		var originalCachedActors = new HashSet<ICharacter>(ReferenceEqualityComparer.Instance);
+		var originalBodies = new HashSet<MudSharp.Body.IBody>(ReferenceEqualityComparer.Instance);
+		var originalItems = new HashSet<MudSharp.GameItems.IGameItem>(ReferenceEqualityComparer.Instance);
+		var cleanupSimulationArtifacts = false;
+		var runtimeParticipants = new List<RuntimeParticipant>();
+		Cell? simulationCell = null;
+		CombatSimulationTranscript? transcript = null;
+		IDbContextTransaction? transaction = null;
+		IDisposable? databaseScope = null;
+		FMDB? database = null;
+		CombatSimulationRuntimeScope? runtimeScope = null;
+		var timeProvider = new AdvancingTimeProvider(simulationEpoch);
+		var startedAt = timeProvider.GetUtcNow();
+		var eventCount = 0;
+		var status = CombatSimulationRunStatus.Error;
+		string? winningTeam = null;
+		string? errorMessage = null;
+		CombatSimulationResult? result = null;
+		var executionFingerprint = new CombatSimulationExecutionFingerprint(request.Seed, captureRandomCallSites);
+
+		try
+		{
+			runtimeScope = new CombatSimulationRuntimeScope(
+				request.RequestedBy.Gameworld,
+				timeProvider,
+				request.Seed,
+				executionFingerprint);
+
+			snapshots = CaptureSourceSnapshots(request);
+			sceneEffects = request.Scene is Cell sourceCell ? sourceCell.SaveEffects() : null;
+			originalActors.UnionWith(request.RequestedBy.Gameworld.Actors);
+			originalCachedActors.UnionWith(request.RequestedBy.Gameworld.CachedActors);
+			originalBodies.UnionWith(request.RequestedBy.Gameworld.Bodies);
+			originalItems.UnionWith(request.RequestedBy.Gameworld.Items);
+			cleanupSimulationArtifacts = true;
+
+			databaseScope = FMDB.BeginIsolatedScope(suppressEfWrites: true);
+			database = new FMDB();
+			transaction = FMDB.Context!.Database.BeginTransaction();
+
+			transcript = new CombatSimulationTranscript(timeProvider, startedAt, request.MaximumTranscriptEntries,
+				executionFingerprint);
+			simulationCell = new Cell(request.Scene, Interlocked.Decrement(ref _nextTemporaryCellId));
+			request.RequestedBy.Gameworld.Add(simulationCell);
+			if (sceneEffects is not null)
+			{
+				TryRestoreEffects(() => simulationCell.RestoreCombatSimulationEffects(sceneEffects), validation,
+					"Some scene effects could not be cloned and were omitted.");
+			}
+
+			foreach (var snapshot in snapshots)
+			{
+				executionFingerprint.RecordMaterialisation(snapshot.Request);
+				var participant = MaterialiseParticipant(snapshot, simulationCell, transcript, validation,
+					executionFingerprint);
+				runtimeParticipants.Add(participant);
+			}
+
+			request.RequestedBy.Gameworld.SaveManager.Flush();
+
+			var combat = new CombatSimulationCombat(request.RequestedBy.Gameworld);
+			foreach (var participant in runtimeParticipants)
+			{
+				combat.JoinCombat(participant.Character, participant.Request.Team);
+			}
+
+			foreach (var participant in runtimeParticipants)
+			{
+				participant.Character.AcquireTarget();
+			}
+
+			request.RequestedBy.Gameworld.HeartbeatManager.StartHeartbeatTick();
+			var terminal = new Dictionary<ICharacter, CombatSimulationOutcome>(ReferenceEqualityComparer.Instance);
+			var lastProgress = CaptureCombatProgress(runtimeParticipants, transcript);
+			var lastProgressAt = timeProvider.GetUtcNow();
+			var eventCountAtLastProgress = eventCount;
+			while (true)
+			{
+				UpdateTerminalParticipants(runtimeParticipants, terminal, combat);
+				var activeTeams = runtimeParticipants
+					.Where(x => !terminal.ContainsKey(x.Character))
+					.Select(x => x.Request.Team)
+					.Distinct(StringComparer.InvariantCultureIgnoreCase)
+					.ToList();
+				if (activeTeams.Count <= 1)
+				{
+					winningTeam = activeTeams.SingleOrDefault();
+					status = CombatSimulationRunStatus.Completed;
+					break;
+				}
+
+				if (wallClock.Elapsed >= request.MaximumWallClockTime)
+				{
+					status = CombatSimulationRunStatus.WallClockLimit;
+					break;
+				}
+
+				if (eventCount >= request.MaximumEvents)
+				{
+					status = CombatSimulationRunStatus.EventLimit;
+					break;
+				}
+
+				var elapsed = timeProvider.GetUtcNow() - startedAt;
+				if (elapsed >= request.MaximumVirtualTime)
+				{
+					status = CombatSimulationRunStatus.VirtualTimeLimit;
+					break;
+				}
+
+				var nextTrigger = new[]
+					{
+						request.RequestedBy.Gameworld.Scheduler.NextTriggerUtc,
+						request.RequestedBy.Gameworld.EffectScheduler.NextTriggerUtc
+					}
+					.Where(x => x.HasValue)
+					.Select(x => x!.Value)
+					.DefaultIfEmpty()
+					.Min();
+				if (nextTrigger == default)
+				{
+					status = CombatSimulationRunStatus.Stalemate;
+					break;
+				}
+
+				var maximumUtc = (startedAt + request.MaximumVirtualTime).UtcDateTime;
+				timeProvider.AdvanceTo(nextTrigger > maximumUtc ? maximumUtc : nextTrigger);
+				request.RequestedBy.Gameworld.Scheduler.CheckSchedules();
+				var schedulerFired = request.RequestedBy.Gameworld.Scheduler.LastCheckFiredCount;
+				eventCount += schedulerFired;
+				request.RequestedBy.Gameworld.EffectScheduler.CheckSchedules();
+				var effectSchedulerFired = request.RequestedBy.Gameworld.EffectScheduler.LastCheckFiredCount;
+				eventCount += effectSchedulerFired;
+				executionFingerprint.RecordSchedulerTick(timeProvider.GetUtcNow(), schedulerFired,
+					effectSchedulerFired, eventCount);
+
+				var currentProgress = CaptureCombatProgress(runtimeParticipants, transcript);
+				if (!currentProgress.SequenceEqual(lastProgress))
+				{
+					lastProgress = currentProgress;
+					lastProgressAt = timeProvider.GetUtcNow();
+					eventCountAtLastProgress = eventCount;
+					continue;
+				}
+
+				if (eventCount - eventCountAtLastProgress >= NoCombatProgressEventThreshold &&
+				    timeProvider.GetUtcNow() - lastProgressAt >= NoCombatProgressVirtualTimeThreshold)
+				{
+					validation.Add(new CombatSimulationValidationMessage(false,
+						$"No combat-relevant participant state changed for {NoCombatProgressVirtualTimeThreshold.Describe(request.RequestedBy)} virtual time and {NoCombatProgressEventThreshold:N0} fired schedules. The staged combat is stalled and may require automatic engagement or a different combat setting."));
+					status = CombatSimulationRunStatus.Stalemate;
+					break;
+				}
+			}
+
+			UpdateTerminalParticipants(runtimeParticipants, terminal, combat);
+			foreach (var participant in runtimeParticipants.Where(x => !terminal.ContainsKey(x.Character)))
+			{
+				terminal[participant.Character] = status == CombatSimulationRunStatus.Completed
+					? CombatSimulationOutcome.SurvivingWinner
+					: CombatSimulationOutcome.Stalemate;
+			}
+
+			combat.EndCombat(false);
+			request.RequestedBy.Gameworld.SaveManager.Flush();
+			result = BuildResult(request, status, winningTeam, eventCount, runtimeParticipants, terminal,
+				validation, transcript, timeProvider.GetUtcNow() - startedAt, wallClock.Elapsed, errorMessage,
+				executionFingerprint);
+		}
+		catch (Exception ex)
+		{
+			errorMessage = DescribeFailure(ex);
+			result = BuildResult(request, CombatSimulationRunStatus.Error, null, eventCount, runtimeParticipants,
+				new Dictionary<ICharacter, CombatSimulationOutcome>(ReferenceEqualityComparer.Instance), validation,
+				transcript, timeProvider.GetUtcNow() - startedAt, wallClock.Elapsed, errorMessage, executionFingerprint);
+		}
+		finally
+		{
+			var cleanupErrors = new List<string>();
+			if (cleanupSimulationArtifacts)
+			{
+				TryCleanup(
+					() => Cleanup(request.RequestedBy.Gameworld, originalActors, originalCachedActors, originalBodies,
+						originalItems, simulationCell), cleanupErrors);
+			}
+
+			TryCleanup(() => transaction?.Rollback(), cleanupErrors);
+			TryCleanup(() => transaction?.Dispose(), cleanupErrors);
+			TryCleanup(() => runtimeScope?.Dispose(), cleanupErrors);
+			TryCleanup(() => database?.Dispose(), cleanupErrors);
+			TryCleanup(() => databaseScope?.Dispose(), cleanupErrors);
+			Interlocked.Exchange(ref _simulationRunning, 0);
+
+			if (cleanupErrors.Count > 0)
+			{
+				var cleanupMessage = $"Combat simulation cleanup reported errors: {cleanupErrors.ListToString()}.";
+				validation.Add(new CombatSimulationValidationMessage(true, cleanupMessage));
+				if (result is not null)
+				{
+					result = result with
+					{
+						Status = CombatSimulationRunStatus.Error,
+						ErrorMessage = string.IsNullOrWhiteSpace(result.ErrorMessage)
+							? cleanupMessage
+							: $"{result.ErrorMessage} {cleanupMessage}"
+					};
+				}
+
+				request.RequestedBy.OutputHandler.Send(
+					cleanupMessage.ColourError());
+			}
+		}
+
+		return result ?? EmptyResult(request, CombatSimulationRunStatus.Error, validation,
+			"The simulation did not produce a result.");
+	}
+
+	private static void TryCleanup(Action action, ICollection<string> errors)
+	{
+		try
+		{
+			action();
+		}
+		catch (Exception ex)
+		{
+			errors.Add(ex.Message);
+		}
+	}
+
+	private static string DescribeFailure(Exception exception)
+	{
+		var message = exception.GetBaseException().Message;
+		var lines = message
+			.Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+		var embeddedInnerException = lines.FirstOrDefault(x => x.StartsWith("--->", StringComparison.Ordinal));
+		if (embeddedInnerException is not null)
+		{
+			var separator = embeddedInnerException.IndexOf(": ", StringComparison.Ordinal);
+			if (separator >= 0)
+			{
+				return embeddedInnerException[(separator + 2)..];
+			}
+		}
+
+		return lines.FirstOrDefault() ?? exception.GetType().Name;
+	}
+
+	private static List<SourceSnapshot> CaptureSourceSnapshots(CombatSimulationRequest request)
+	{
+		return request.Participants.Select(participant =>
+		{
+			if (participant.Character is not Character.Character character ||
+			    participant.Character.Body is not BodyImplementation body)
+			{
+				return new SourceSnapshot(participant, null, null);
+			}
+
+			return new SourceSnapshot(participant, character.SaveEffects(), body.SaveEffects());
+		}).ToList();
+	}
+
+	private static RuntimeParticipant MaterialiseParticipant(
+		SourceSnapshot snapshot,
+		Cell simulationCell,
+		CombatSimulationTranscript transcript,
+		ICollection<CombatSimulationValidationMessage> validation,
+		CombatSimulationExecutionFingerprint executionFingerprint)
+	{
+		ICharacter character;
+		if (snapshot.Request.SourceType == CombatSimulationSourceType.Character)
+		{
+			var source = snapshot.Request.Character!;
+			var template = (SimpleCharacterTemplate)source.GetCharacterTemplate() with
+			{
+				SelectedStartingLocation = simulationCell,
+				SelectedRoles = []
+			};
+			var clone = new CombatSimulationCharacter(source.Gameworld, template);
+			character = clone;
+			source.Gameworld.Add(clone, true);
+			simulationCell.Enter(clone, noSave: true, roomLayer: source.RoomLayer);
+			clone.CopyCombatSimulationStateFrom(source);
+			((BodyImplementation)clone.Body).CopyCombatSimulationBiologyFrom(source.Body);
+			CharacterInstanceService.CloneInventory(source, clone, out var inventoryResult);
+			if (inventoryResult.FailedCloned > 0)
+			{
+				validation.Add(new CombatSimulationValidationMessage(false,
+					$"{inventoryResult.FailedCloned:N0} inventory item(s) could not be cloned for {snapshot.Request.SourceDescription}."));
+			}
+
+			if (snapshot.CharacterEffects is not null)
+			{
+				TryRestoreEffects(() => clone.RestoreCombatSimulationEffects(snapshot.CharacterEffects), validation,
+					$"Some character effects could not be cloned for {snapshot.Request.SourceDescription}.");
+			}
+
+			if (snapshot.BodyEffects is not null)
+			{
+				TryRestoreEffects(() => ((BodyImplementation)clone.Body).RestoreCombatSimulationEffects(snapshot.BodyEffects), validation,
+					$"Some body effects could not be cloned for {snapshot.Request.SourceDescription}.");
+			}
+		}
+		else
+		{
+			var npcTemplate = snapshot.Request.NpcTemplate!;
+			var template = npcTemplate.GetCharacterTemplate(simulationCell);
+			var npc = new CombatSimulationNpc(npcTemplate.Gameworld, template, npcTemplate);
+			character = npc;
+			npcTemplate.Gameworld.Add(npc, true);
+			simulationCell.Enter(npc, noSave: true, roomLayer: npc.RoomLayer);
+			foreach (var warning in npcTemplate.ApplyTemplateLoadAdditions(npc, false))
+			{
+				validation.Add(new CombatSimulationValidationMessage(false,
+					$"{snapshot.Request.SourceDescription}: {warning}"));
+			}
+
+			npcTemplate.OnLoadProg?.Execute(npc);
+			npc.HandleEvent(EventType.NPCOnGameLoadFinished, npc);
+		}
+
+		RecordMaterialisedRuntimeState(executionFingerprint, snapshot.Request.Slot, character);
+		var name = character.PersonalName.GetName(Character.Name.NameStyle.SimpleFull);
+		character.Register(new CombatSimulationOutputHandler(transcript,
+			$"#{snapshot.Request.Slot:N0} {name}",
+			$"slot:{snapshot.Request.Slot}"));
+		return new RuntimeParticipant(snapshot.Request, character, name);
+	}
+
+	private static void RecordMaterialisedRuntimeState(
+		CombatSimulationExecutionFingerprint fingerprint,
+		int slot,
+		ICharacter character)
+	{
+		var template = character.GetCharacterTemplate();
+		fingerprint.RecordMaterialisationRuntimeState(slot, "identity",
+		[
+			$"race:{character.Race.Id}",
+			$"culture:{character.Culture.Id}",
+			$"gender:{(int)character.Gender.Enum}",
+			$"height:{character.Height.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}",
+			$"weight:{character.Weight.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}",
+			$"stamina:{character.CurrentStamina.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}"
+		]);
+		fingerprint.RecordMaterialisationRuntimeState(slot, "attributes", template.SelectedAttributes
+			.OrderBy(x => x.Definition.Id)
+			.Select(x => $"{x.Definition.Id}:{x.RawValue.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}"));
+		fingerprint.RecordMaterialisationRuntimeState(slot, "skills", template.SkillValues
+			.OrderBy(x => x.Item1.Id)
+			.Select(x => $"{x.Item1.Id}:{x.Item2.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}"));
+		fingerprint.RecordMaterialisationRuntimeState(slot, "characteristics", template.SelectedCharacteristics
+			.OrderBy(x => x.Item1.Id)
+			.Select(x => $"{x.Item1.Id}:{x.Item2.Id}"));
+		fingerprint.RecordMaterialisationRuntimeState(slot, "bodyparts", character.Body.Bodyparts
+			.OrderBy(x => x.Id)
+			.Select(x => x.Id.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+		fingerprint.RecordMaterialisationRuntimeState(slot, "organs", character.Body.Organs
+			.OrderBy(x => x.Id)
+			.Select(x => x.Id.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+		fingerprint.RecordMaterialisationRuntimeState(slot, "bones", character.Body.Bones
+			.OrderBy(x => x.Id)
+			.Select(x => x.Id.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+		fingerprint.RecordMaterialisationRuntimeState(slot, "character-effects", character.Effects
+			.Select(x => x.GetType().FullName ?? x.GetType().Name)
+			.Order());
+		fingerprint.RecordMaterialisationRuntimeState(slot, "body-effects", character.Body.Effects
+			.Select(x => x.GetType().FullName ?? x.GetType().Name)
+			.Order());
+	}
+
+	private static void TryRestoreEffects(
+		Action action,
+		ICollection<CombatSimulationValidationMessage> validation,
+		string warning)
+	{
+		try
+		{
+			action();
+		}
+		catch (Exception ex)
+		{
+			validation.Add(new CombatSimulationValidationMessage(false, $"{warning} {ex.Message}"));
+		}
+	}
+
+	private static void UpdateTerminalParticipants(
+		IEnumerable<RuntimeParticipant> participants,
+		IDictionary<ICharacter, CombatSimulationOutcome> terminal,
+		CombatSimulationCombat combat)
+	{
+		var participantList = participants.ToList();
+		foreach (var participant in participantList)
+		{
+			var character = participant.Character;
+			if (character.State.HasFlag(CharacterState.Dead))
+			{
+				// A combatant may be removed as incapacitated or grappled and subsequently die from
+				// bleeding or another heartbeat-driven effect. Death is the final state and must
+				// supersede that earlier terminal outcome in the report.
+				terminal[character] = CombatSimulationOutcome.Dead;
+				if (character.Combat == combat)
+				{
+					combat.LeaveCombat(character);
+				}
+
+				continue;
+			}
+
+			if (terminal.ContainsKey(character))
+			{
+				continue;
+			}
+
+			CombatSimulationOutcome? outcome = null;
+			if (character.CombinedEffectsOfType<IBeingGrappled>().Any(x => x.UnderControl))
+			{
+				outcome = CombatSimulationOutcome.FullGrappleControl;
+			}
+			else if (!character.State.IsAble())
+			{
+				outcome = CombatSimulationOutcome.Incapacitated;
+			}
+			if (outcome is null)
+			{
+				continue;
+			}
+
+			terminal[character] = outcome.Value;
+			if (character.Combat == combat)
+			{
+				combat.LeaveCombat(character);
+			}
+		}
+
+		foreach (var participant in participantList
+			         .Where(x => !terminal.ContainsKey(x.Character) && x.Character.Combat is null)
+			         .ToList())
+		{
+			var hasActiveOpponent = participantList.Any(x =>
+				!string.Equals(x.Request.Team, participant.Request.Team,
+					StringComparison.InvariantCultureIgnoreCase) &&
+				!terminal.ContainsKey(x.Character));
+			if (!hasActiveOpponent)
+			{
+				continue;
+			}
+
+			terminal[participant.Character] = combat.DepartureModeFor(participant.Character) == CombatStrategyMode.Flee
+				? CombatSimulationOutcome.Fled
+				: CombatSimulationOutcome.Withdrew;
+		}
+	}
+
+	private static IReadOnlyList<CombatProgressSnapshot> CaptureCombatProgress(
+		IEnumerable<RuntimeParticipant> participants,
+		CombatSimulationTranscript transcript)
+	{
+		var transcriptEntries = transcript.Entries.Count;
+		return participants
+			.OrderBy(x => x.Request.Slot)
+			.Select(x => new CombatProgressSnapshot(
+				x.Character.State,
+				x.Character.CombatTarget,
+				x.Character.MeleeRange,
+				x.Character.CombatStrategyMode,
+				x.Character.Body.CurrentBloodVolumeLitres,
+				x.Character.Body.CurrentStamina,
+				x.Character.Body.Wounds.Count(),
+				transcriptEntries))
+			.ToList();
+	}
+
+	private static CombatSimulationResult BuildResult(
+		CombatSimulationRequest request,
+		CombatSimulationRunStatus status,
+		string? winningTeam,
+		int eventCount,
+		IEnumerable<RuntimeParticipant> participants,
+		IReadOnlyDictionary<ICharacter, CombatSimulationOutcome> outcomes,
+		IReadOnlyList<CombatSimulationValidationMessage> validation,
+		CombatSimulationTranscript? transcript,
+		TimeSpan virtualDuration,
+		TimeSpan wallClockDuration,
+		string? errorMessage,
+		CombatSimulationExecutionFingerprint executionFingerprint)
+	{
+		var results = participants.Select(x =>
+		{
+			var body = x.Character.Body;
+			return new CombatSimulationParticipantResult(
+				x.Request.Slot,
+				x.Request.Team,
+				x.Name,
+				outcomes.GetValueOrDefault(x.Character, CombatSimulationOutcome.Unknown),
+				x.Character.State,
+				body.TotalBloodVolumeLitres > 0.0
+					? body.CurrentBloodVolumeLitres / body.TotalBloodVolumeLitres
+					: 0.0,
+				body.MaximumStamina > 0.0 ? body.CurrentStamina / body.MaximumStamina : 0.0,
+				body.Wounds.Count(),
+				x.Character.CombinedEffectsOfType<IBeingGrappled>().Any(y => y.UnderControl));
+		}).ToList();
+
+		var boundedVirtualDuration = virtualDuration < TimeSpan.Zero || virtualDuration > request.MaximumVirtualTime
+			? request.MaximumVirtualTime
+			: virtualDuration;
+		var fingerprint = executionFingerprint.Complete(status, winningTeam, boundedVirtualDuration, eventCount, results);
+
+		return new CombatSimulationResult(
+			request.RunId,
+			status,
+			winningTeam,
+			request.Seed,
+			boundedVirtualDuration,
+			wallClockDuration,
+			eventCount,
+			results,
+			validation,
+			transcript?.Entries.ToList() ?? [],
+			request.MaximumTranscriptEntries > 0 && transcript?.Truncated == true,
+			fingerprint,
+			executionFingerprint.TraceSummary,
+			errorMessage);
+	}
+
+	private static bool TryGetBatchSeed(CombatSimulationBatchRequest request, int runIndex, out int seed)
+	{
+		var value = (long)request.FirstSeed + ((long)request.SeedIncrement * runIndex);
+		if (value is < int.MinValue or > int.MaxValue)
+		{
+			seed = default;
+			return false;
+		}
+
+		seed = (int)value;
+		return true;
+	}
+
+	private static CombatSimulationBatchResult BuildBatchResult(
+		CombatSimulationBatchRequest request,
+		IReadOnlyList<CombatSimulationResult> runs,
+		IReadOnlyList<CombatSimulationValidationMessage> validation,
+		TimeSpan batchWallClockDuration,
+		string? errorMessage)
+	{
+		var totalVirtualDuration = runs.Aggregate(TimeSpan.Zero, (total, run) => total + run.VirtualDuration);
+		var totalWallClockDuration = runs.Aggregate(TimeSpan.Zero, (total, run) => total + run.WallClockDuration);
+		var teamResults = request.Participants
+			.Select(x => x.Team)
+			.Distinct(StringComparer.InvariantCultureIgnoreCase)
+			.OrderBy(x => x)
+			.Select(team => new CombatSimulationBatchTeamResult(
+				team,
+				runs.Count(x => string.Equals(x.WinningTeam, team, StringComparison.InvariantCultureIgnoreCase)),
+				runs.Count == 0
+					? 0.0
+					: (double)runs.Count(x => string.Equals(x.WinningTeam, team,
+						StringComparison.InvariantCultureIgnoreCase)) / runs.Count))
+			.ToList();
+		var statusResults = runs
+			.GroupBy(x => x.Status)
+			.OrderBy(x => (int)x.Key)
+			.Select(x => new CombatSimulationBatchStatusResult(x.Key, x.Count()))
+			.ToList();
+		var outcomeResults = runs
+			.SelectMany(x => x.Participants)
+			.GroupBy(x => x.Outcome)
+			.OrderBy(x => (int)x.Key)
+			.Select(x => new CombatSimulationBatchOutcomeResult(x.Key, x.Count()))
+			.ToList();
+
+		return new CombatSimulationBatchResult(
+			request.BatchId,
+			request.FirstSeed,
+			request.SeedIncrement,
+			request.RunCount,
+			runs,
+			teamResults,
+			statusResults,
+			outcomeResults,
+			totalVirtualDuration,
+			runs.Count == 0 ? TimeSpan.Zero : TimeSpan.FromTicks(totalVirtualDuration.Ticks / runs.Count),
+			runs.Count == 0 ? TimeSpan.Zero : runs.Min(x => x.VirtualDuration),
+			runs.Count == 0 ? TimeSpan.Zero : runs.Max(x => x.VirtualDuration),
+			totalWallClockDuration,
+			runs.Count == 0 ? TimeSpan.Zero : TimeSpan.FromTicks(totalWallClockDuration.Ticks / runs.Count),
+			batchWallClockDuration,
+			validation,
+			errorMessage);
+	}
+
+	private static CombatSimulationResult EmptyResult(
+		CombatSimulationRequest request,
+		CombatSimulationRunStatus status,
+		IReadOnlyList<CombatSimulationValidationMessage> validation,
+		string error)
+	{
+		var executionFingerprint = new CombatSimulationExecutionFingerprint(request.Seed);
+		var fingerprint = executionFingerprint.Complete(status, null, TimeSpan.Zero, 0, []);
+		return new CombatSimulationResult(request.RunId, status, null, request.Seed, TimeSpan.Zero, TimeSpan.Zero, 0,
+			[], validation, [], false, fingerprint, executionFingerprint.TraceSummary, error);
+	}
+
+	private static CombatSimulationBatchResult EmptyBatchResult(
+		CombatSimulationBatchRequest request,
+		IReadOnlyList<CombatSimulationValidationMessage> validation,
+		string error)
+	{
+		return new CombatSimulationBatchResult(
+			request.BatchId,
+			request.FirstSeed,
+			request.SeedIncrement,
+			request.RunCount,
+			[],
+			[],
+			[],
+			[],
+			TimeSpan.Zero,
+			TimeSpan.Zero,
+			TimeSpan.Zero,
+			TimeSpan.Zero,
+			TimeSpan.Zero,
+			TimeSpan.Zero,
+			TimeSpan.Zero,
+			validation,
+			error);
+	}
+
+	private static void Cleanup(
+		IFuturemud gameworld,
+		ISet<ICharacter> originalActors,
+		ISet<ICharacter> originalCachedActors,
+		ISet<MudSharp.Body.IBody> originalBodies,
+		ISet<MudSharp.GameItems.IGameItem> originalItems,
+		Cell? simulationCell)
+	{
+		foreach (var actor in gameworld.Actors.Where(x => !originalActors.Contains(x)).ToList())
+		{
+			DetachActor(actor);
+			gameworld.Destroy(actor);
+			(gameworld as ICombatSimulationRuntimeRegistry)?.ForgetCombatSimulationActor(actor);
+		}
+
+		if (gameworld is ICombatSimulationRuntimeRegistry registry)
+		{
+			foreach (var actor in gameworld.CachedActors.Where(x => !originalCachedActors.Contains(x)).ToList())
+			{
+				DetachActor(actor);
+				registry.ForgetCombatSimulationActor(actor);
+			}
+		}
+
+		foreach (var item in gameworld.Items.Where(x => !originalItems.Contains(x)).ToList())
+		{
+			item.Location?.Extract(item);
+			gameworld.Destroy(item);
+		}
+
+		foreach (var body in gameworld.Bodies.Where(x => !originalBodies.Contains(x)).ToList())
+		{
+			gameworld.Destroy(body);
+		}
+
+		if (simulationCell is not null)
+		{
+			gameworld.Destroy(simulationCell);
+		}
+	}
+
+	private static void DetachActor(ICharacter actor)
+	{
+		actor.Combat?.LeaveCombat(actor);
+		if (actor.Location is Cell location && actor is Character.Character character)
+		{
+			location.RemoveCombatSimulationArtifact(actor);
+			character.DetachCombatSimulationLocation();
+			return;
+		}
+
+		actor.Location?.Leave(actor);
+	}
+}

--- a/MudSharpCore/Combat/Simulation/CombatSimulationTranscript.cs
+++ b/MudSharpCore/Combat/Simulation/CombatSimulationTranscript.cs
@@ -1,0 +1,88 @@
+using MudSharp.Framework;
+using MudSharp.PerceptionEngine;
+
+#nullable enable
+
+namespace MudSharp.Combat.Simulation;
+
+internal sealed class CombatSimulationTranscript(TimeProvider timeProvider, DateTimeOffset startedAt, int maximumEntries,
+	CombatSimulationExecutionFingerprint fingerprint)
+{
+	private readonly List<string> _entries = [];
+
+	public IReadOnlyList<string> Entries => _entries;
+	public bool Truncated { get; private set; }
+
+	public void Add(string participant, string traceParticipant, string text)
+	{
+		if (string.IsNullOrWhiteSpace(text))
+		{
+			return;
+		}
+
+		foreach (var line in text.RawText()
+		         .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+		{
+			var elapsed = timeProvider.GetUtcNow() - startedAt;
+			fingerprint.RecordTranscript(traceParticipant, elapsed, line);
+			if (_entries.Count >= maximumEntries)
+			{
+				Truncated = true;
+				return;
+			}
+
+			_entries.Add($"[{elapsed:hh\\:mm\\:ss\\.fff}] {participant}: {line}");
+		}
+	}
+}
+
+internal sealed class CombatSimulationOutputHandler(
+	CombatSimulationTranscript transcript,
+	string participant,
+	string traceParticipant) : IOutputHandler
+{
+	public IPerceiver? Perceiver { get; private set; }
+	public bool HasBufferedOutput => false;
+	public string BufferedOutput => string.Empty;
+	public bool QuietMode { get; set; }
+
+	public bool Register(IPerceiver perceiver)
+	{
+		Perceiver = perceiver;
+		return true;
+	}
+
+	public bool Send(string text, bool newline = true, bool nopage = false)
+	{
+		if (QuietMode || string.IsNullOrEmpty(text))
+		{
+			return false;
+		}
+
+		transcript.Add(participant, traceParticipant, text);
+		return true;
+	}
+
+	public bool Send(IOutput output, bool newline = true, bool nopage = false)
+	{
+		if (output is null || Perceiver is null || !output.ShouldSee(Perceiver))
+		{
+			return false;
+		}
+
+		return Send(output.ParseFor(Perceiver), newline, nopage);
+	}
+
+	public void More()
+	{
+	}
+
+	public void Flush()
+	{
+	}
+
+	public bool SendPrompt()
+	{
+		return true;
+	}
+}

--- a/MudSharpCore/Combat/Strategies/ClinchStrategy.cs
+++ b/MudSharpCore/Combat/Strategies/ClinchStrategy.cs
@@ -1,7 +1,9 @@
 ﻿using MudSharp.Body.Position;
 using MudSharp.Body.Position.PositionStates;
 using MudSharp.Combat.Moves;
+using MudSharp.Combat.Simulation;
 using MudSharp.Effects.Concrete;
+using MudSharp.Framework;
 using MudSharp.GameItems;
 
 namespace MudSharp.Combat.Strategies;
@@ -195,10 +197,23 @@ public class ClinchStrategy : StandardMeleeStrategy
             attacks = preferredAttacks;
         }
 
-        IWeaponAttack attack = attacks.GetWeightedRandom(x => x.Weighting * ManualCombatCommandResolver.AiWeightMultiplier(ch, x));
+        List<(IWeaponAttack Attack, double Weight)> weightedAttacks = attacks
+            .Select(x => (Attack: x, Weight: x.Weighting * ManualCombatCommandResolver.AiWeightMultiplier(ch, x)))
+            .ToList();
+        IWeaponAttack attack = SelectWeightedAttack(weightedAttacks, out var selectionRoll);
         if (attack == null)
         {
             return null;
+        }
+
+        var simulationScope = CombatSimulationRuntimeScope.Current;
+        if (simulationScope?.ExecutionFingerprint.CaptureRandomCallSites == true)
+        {
+            var lastRandom = simulationScope.ExecutionFingerprint.LastRandomOperation;
+            var candidates = string.Join(",", weightedAttacks.Select(x =>
+                $"{x.Attack.Id}:{x.Attack.Orientation}:{x.Attack.Alignment}:{x.Attack.Weighting.ToString(System.Globalization.CultureInfo.InvariantCulture)}:{x.Weight.ToString(System.Globalization.CultureInfo.InvariantCulture)}"));
+            simulationScope.ExecutionFingerprint.RecordState(
+                $"clinch-attack actor:{ch.Id} weapon:{weapon.Parent.Id} roll:{selectionRoll.ToString(System.Globalization.CultureInfo.InvariantCulture)} random:{lastRandom?.OperationIndex ?? 0}:{lastRandom?.Description ?? string.Empty} candidates:{candidates} selected:{attack.Id}:{attack.Orientation}:{attack.Alignment}");
         }
 
         if (ch.CombatTarget is ICharacter charTarget)
@@ -208,6 +223,29 @@ public class ClinchStrategy : StandardMeleeStrategy
 
         throw new NotImplementedException("Unimplemented Combatant type in ClinchStrategy.AttemptClinchAttack - " +
                                           ch.CombatTarget.GetType().FullName);
+    }
+
+    private static IWeaponAttack SelectWeightedAttack(
+        IReadOnlyList<(IWeaponAttack Attack, double Weight)> attacks,
+        out double selectionRoll)
+    {
+        var totalWeight = attacks.Sum(x => x.Weight);
+        selectionRoll = Constants.Random.NextDouble() * totalWeight;
+        var remainingRoll = selectionRoll;
+        foreach (var attack in attacks)
+        {
+            if (attack.Weight <= 0.0)
+            {
+                continue;
+            }
+
+            if ((remainingRoll -= attack.Weight) <= 0.0)
+            {
+                return attack.Attack;
+            }
+        }
+
+        return attacks[^1].Attack;
     }
 
     private ICombatMove AttemptUnarmedClinchAttack(ICharacter ch)

--- a/MudSharpCore/Commands/Modules/BuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/BuilderModule.cs
@@ -2056,6 +2056,7 @@ Here are some examples of plausible trait expressions applying the above:
 
         StringBuilder sb = new();
         sb.AppendLine($"Evaluating Trait Expression #{te.Id.ToStringN0(actor)} ({te.Name.ColourName()}) for {target.HowSeen(actor)}...");
+        List<(string Name, object Value)> values = new();
 
         if (te.NonTraitParameters.Any())
         {
@@ -2073,12 +2074,12 @@ Here are some examples of plausible trait expressions applying the above:
                     return;
                 }
 
-                te.Formula.Parameters[item] = value;
+                values.Add((item, value));
                 sb.AppendLine($"...{item.ColourName()} = {value.ToString("N", actor).ColourValue()}");
             }
         }
 
-        sb.AppendLine($"Result: {te.Evaluate(target).ToString("N", actor).ColourValue()}");
+        sb.AppendLine($"Result: {te.EvaluateWith(target, values: values.ToArray()).ToString("N", actor).ColourValue()}");
         actor.OutputHandler.Send(sb.ToString());
     }
 

--- a/MudSharpCore/Commands/Modules/CharacterInformation.cs
+++ b/MudSharpCore/Commands/Modules/CharacterInformation.cs
@@ -1166,11 +1166,10 @@ The syntax is simply #3attributes#0 or #3attributes <target>#0 to see someone el
 
         public override CheckOutcome TestAgainst(ICharacter actor, Difficulty difficulty)
         {
-            TestChance.Parameters["difficulty"] = (int)Difficulty.Normal;
-            TestChance.Parameters["height"] = actor.Height;
-            double origTN = (double)TestChance.Evaluate();
-            TestChance.Parameters["difficulty"] = (int)difficulty;
-            double targetNumber = (double)TestChance.Evaluate();
+            double origTN = TestChance.EvaluateDoubleWith(("difficulty", (int)Difficulty.Normal),
+                ("height", actor.Height));
+            double targetNumber = TestChance.EvaluateDoubleWith(("difficulty", (int)difficulty),
+                ("height", actor.Height));
             Outcome outcome = GetOutcome(RandomUtilities.ConsecutiveRoll(100, targetNumber, 3, out List<double> rolls));
 
             CheckOutcome result = new()
@@ -1219,11 +1218,10 @@ The syntax is simply #3attributes#0 or #3attributes <target>#0 to see someone el
 
         public override CheckOutcome TestAgainst(ICharacter actor, Difficulty difficulty)
         {
-            TestChance.Parameters["weight"] = actor.Weight;
-            TestChance.Parameters["difficulty"] = (int)Difficulty.Normal;
-            double origTN = (double)TestChance.Evaluate();
-            TestChance.Parameters["difficulty"] = (int)difficulty;
-            double targetNumber = (double)TestChance.Evaluate();
+            double origTN = TestChance.EvaluateDoubleWith(("weight", actor.Weight),
+                ("difficulty", (int)Difficulty.Normal));
+            double targetNumber = TestChance.EvaluateDoubleWith(("weight", actor.Weight),
+                ("difficulty", (int)difficulty));
             Outcome outcome = GetOutcome(RandomUtilities.ConsecutiveRoll(100, targetNumber, 3, out List<double> rolls));
 
             CheckOutcome result = new()

--- a/MudSharpCore/Commands/Modules/GameModule.cs
+++ b/MudSharpCore/Commands/Modules/GameModule.cs
@@ -1170,14 +1170,12 @@ The syntax is #3tagsearch <tag>#0.", AutoHelp.HelpArgOrNoArg)]
                 TraitExpression expr = IncreasedBranchChance.IncreasedCapExpression;
                 foreach ((ISkillDefinition Skill, int Attempts) skill in skills)
                 {
-                    expr.Formula.Parameters["base"] = 1.0;
-                    expr.Formula.Parameters["attempts"] = skill.Attempts;
                     ILanguage language = actor.Gameworld.Languages.FirstOrDefault(x => x.LinkedTrait == skill.Skill);
                     string skillName = language == null
                         ? skill.Skill.Name
                         : language.UnknownLanguageSpokenDescription;
                     sb.AppendLine(
-                        $"\t{expr.Evaluate(actor).ToString("N2", actor)}x with {skillName.Colour(Telnet.Green)}");
+                        $"\t{expr.EvaluateWith(actor, values: [("base", 1.0), ("attempts", skill.Attempts)]).ToString("N2", actor)}x with {skillName.Colour(Telnet.Green)}");
                 }
             }
             else

--- a/MudSharpCore/Commands/Modules/HealthModule.cs
+++ b/MudSharpCore/Commands/Modules/HealthModule.cs
@@ -2528,13 +2528,6 @@ Your options are to name the specific bodypart, #3random#0 for a random part, #3
                 }
             }
 
-            attack.Profile.DamageExpression.Formula.Parameters["degree"] = (int)degree;
-            attack.Profile.DamageExpression.Formula.Parameters["quality"] = (int)weapon.Parent.Quality;
-            attack.Profile.StunExpression.Formula.Parameters["degree"] = (int)degree;
-            attack.Profile.StunExpression.Formula.Parameters["quality"] = (int)weapon.Parent.Quality;
-            attack.Profile.PainExpression.Formula.Parameters["degree"] = (int)degree;
-            attack.Profile.PainExpression.Formula.Parameters["quality"] = (int)weapon.Parent.Quality;
-
             double angle = RandomUtilities.DoubleRandom(Math.PI * 0.1, Math.PI);
             List<IWound> wounds = new();
             if (targetBodyparts.Count == 0)
@@ -2546,12 +2539,15 @@ Your options are to name the specific bodypart, #3random#0 for a random part, #3
                     ToolOrigin = targetItem,
                     AngleOfIncidentRadians = angle,
                     Bodypart = null,
-                    DamageAmount = attack.Profile.DamageExpression.Evaluate(actor) * 2 * angle / Math.PI,
+                    DamageAmount = attack.Profile.DamageExpression.EvaluateWith(actor,
+                        values: [("degree", (int)degree), ("quality", (int)weapon.Parent.Quality)]) * 2 * angle / Math.PI,
                     DamageType = attack.Profile.DamageType,
-                    PainAmount = attack.Profile.PainExpression.Evaluate(actor) * 2 * angle / Math.PI,
+                    PainAmount = attack.Profile.PainExpression.EvaluateWith(actor,
+                        values: [("degree", (int)degree), ("quality", (int)weapon.Parent.Quality)]) * 2 * angle / Math.PI,
                     PenetrationOutcome = outcome,
                     ShockAmount = 0,
-                    StunAmount = attack.Profile.DamageExpression.Evaluate(actor) * 2 * angle / Math.PI
+                    StunAmount = attack.Profile.DamageExpression.EvaluateWith(actor,
+                        values: [("degree", (int)degree), ("quality", (int)weapon.Parent.Quality)]) * 2 * angle / Math.PI
                 };
 
                 wounds.AddRange(woundable.SufferDamage(finalDamage));
@@ -2567,12 +2563,15 @@ Your options are to name the specific bodypart, #3random#0 for a random part, #3
                         ToolOrigin = targetItem,
                         AngleOfIncidentRadians = angle,
                         Bodypart = bodypart,
-                        DamageAmount = attack.Profile.DamageExpression.Evaluate(actor) * 2 * angle / Math.PI,
+                        DamageAmount = attack.Profile.DamageExpression.EvaluateWith(actor,
+                            values: [("degree", (int)degree), ("quality", (int)weapon.Parent.Quality)]) * 2 * angle / Math.PI,
                         DamageType = attack.Profile.DamageType,
-                        PainAmount = attack.Profile.PainExpression.Evaluate(actor) * 2 * angle / Math.PI,
+                        PainAmount = attack.Profile.PainExpression.EvaluateWith(actor,
+                            values: [("degree", (int)degree), ("quality", (int)weapon.Parent.Quality)]) * 2 * angle / Math.PI,
                         PenetrationOutcome = outcome,
                         ShockAmount = 0,
-                        StunAmount = attack.Profile.DamageExpression.Evaluate(actor) * 2 * angle / Math.PI
+                        StunAmount = attack.Profile.DamageExpression.EvaluateWith(actor,
+                            values: [("degree", (int)degree), ("quality", (int)weapon.Parent.Quality)]) * 2 * angle / Math.PI
                     };
 
                     wounds.AddRange(woundable.SufferDamage(finalDamage));

--- a/MudSharpCore/Commands/Modules/ImplementorModule.cs
+++ b/MudSharpCore/Commands/Modules/ImplementorModule.cs
@@ -9,6 +9,7 @@ using MudSharp.Character.Name;
 using MudSharp.Climate;
 using MudSharp.Climate.Analysis;
 using MudSharp.Combat;
+using MudSharp.Combat.Simulation;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Database;
@@ -382,6 +383,7 @@ The syntax is:
 	#3config <which>#0 - shows the value of a static config
 	#3dream <who>#0 - gives a dream to the specified PC
 	#3combatspeed <multiplier>#0 - sets a global multiplier to combat speed
+	#3combatsim ...#0 - stages and runs an accelerated, group-capable combat simulation
 	#3progfunctions#0 - writes out all the prog function help to a file (saved to disk)
 	#3cleanupcorpses#0 - deletes all NPC corpses of skeletal decay level. Loads up all PCs to check their inventories
 	#3descriptions short|full [<person>]#0 - writes all valid descriptors for that person to a file on disk.
@@ -524,6 +526,10 @@ The syntax is:
             case "combatspeed":
                 DebugCombatSpeed(actor, ss);
                 return;
+			case "combatsim":
+			case "combatsimulation":
+				CombatSimulationCommand.Execute(actor, ss);
+				return;
             case "time":
                 MudDateTime datetime = new(actor.Location.Date(actor.Location.Calendars.First()),
                     actor.Location.Time(actor.Location.Clocks.First()),

--- a/MudSharpCore/Construction/Cell.cs
+++ b/MudSharpCore/Construction/Cell.cs
@@ -42,6 +42,12 @@ namespace MudSharp.Construction;
 
 public partial class Cell : Location, IDisposable, ICell
 {
+	private readonly bool _isCombatSimulationCell;
+	private readonly long _combatSimulationDatabaseLocationId;
+
+	internal long DatabaseLocationId => _isCombatSimulationCell
+		? _combatSimulationDatabaseLocationId
+		: Id;
     private readonly List<IRangedCover> _localCover = new();
 	private RouteCellDefinition _routeDefinition;
 	private long? _hostedVehicleId;
@@ -129,6 +135,25 @@ public partial class Cell : Location, IDisposable, ICell
         Room = room;
         SetupCell(cell);
     }
+
+	/// <summary>
+	/// Creates a transient cell which borrows environmental data from a real cell but owns its
+	/// contents independently. It is never registered with its room or written to the database.
+	/// </summary>
+	internal Cell(ICell combatSimulationTemplate, long temporaryId) : base(combatSimulationTemplate.Gameworld)
+	{
+		_isCombatSimulationCell = true;
+		_combatSimulationDatabaseLocationId = combatSimulationTemplate.Id;
+		_noSave = true;
+		_id = temporaryId;
+		Room = combatSimulationTemplate.Room;
+		CurrentOverlay = combatSimulationTemplate.CurrentOverlay;
+		_overlays = combatSimulationTemplate.Overlays
+			.OfType<IEditableCellOverlay>()
+			.ToList();
+		Movements = [];
+		Temporary = true;
+	}
 
     public bool ContentsChanged
     {
@@ -306,7 +331,10 @@ public partial class Cell : Location, IDisposable, ICell
 
         thing.ContainedIn = null;
         base.Insert(thing, newStack);
-        Room.Insert(thing, newStack);
+		if (!_isCombatSimulationCell)
+		{
+			Room.Insert(thing, newStack);
+		}
         _gameItems = _gameItems.OrderBy(x => !x.HighPriority).ToList();
         if (IsSwimmingLayer(newLayer))
         {
@@ -340,7 +368,9 @@ public partial class Cell : Location, IDisposable, ICell
         return lowest;
     }
 
-    public IEnumerable<ICell> Surrounds => Gameworld.ExitManager.GetExitsFor(this).Select(x => x.Destination);
+    public IEnumerable<ICell> Surrounds => _isCombatSimulationCell
+        ? Enumerable.Empty<ICell>()
+        : Gameworld.ExitManager.GetExitsFor(this).Select(x => x.Destination);
 
     public override string Name => CurrentOverlay.CellName;
 
@@ -353,7 +383,10 @@ public partial class Cell : Location, IDisposable, ICell
 
         base.Extract(thing);
 		RouteSpatialService.Instance.UntrackPerceivable(thing);
-        Room.Extract(thing);
+		if (!_isCombatSimulationCell)
+		{
+			Room.Extract(thing);
+		}
         ContentsChanged = true;
         CheckFallExitStatus();
         new MagicPortalTopologyService().RebuildNetworksForItem(Gameworld, thing);
@@ -410,6 +443,11 @@ public partial class Cell : Location, IDisposable, ICell
 
     public IEnumerable<ICellExit> ExitsFor(IPerceiver voyeur, bool ignoreLayers = false)
     {
+		if (_isCombatSimulationCell)
+		{
+			return Enumerable.Empty<ICellExit>();
+		}
+
 		return Gameworld.ExitManager
 			.GetExitsFor(this, GetOverlayFor(voyeur), ignoreLayers ? default : voyeur?.RoomLayer)
 			.Where(x => IsSpatiallyAccessibleExit(voyeur, x));
@@ -417,24 +455,44 @@ public partial class Cell : Location, IDisposable, ICell
 
     public ICellExit GetExit(CardinalDirection direction, IPerceiver voyeur)
     {
+		if (_isCombatSimulationCell)
+		{
+			return null;
+		}
+
 		var exit = Gameworld.ExitManager.GetExit(this, direction, voyeur);
 		return exit is not null && IsSpatiallyAccessibleExit(voyeur, exit) ? exit : null;
     }
 
     public ICellExit GetExit(string direction, string target, IPerceiver voyeur)
     {
+		if (_isCombatSimulationCell)
+		{
+			return null;
+		}
+
 		var exit = Gameworld.ExitManager.GetExit(this, direction, target, voyeur, GetOverlayFor(voyeur));
 		return exit is not null && IsSpatiallyAccessibleExit(voyeur, exit) ? exit : null;
     }
 
     public ICellExit GetExitKeyword(string direction, IPerceiver voyeur)
     {
+		if (_isCombatSimulationCell)
+		{
+			return null;
+		}
+
 		var exit = Gameworld.ExitManager.GetExitKeyword(this, direction, voyeur, GetOverlayFor(voyeur));
 		return exit is not null && IsSpatiallyAccessibleExit(voyeur, exit) ? exit : null;
     }
 
     public ICellExit GetExitTo(ICell otherCell, IPerceiver voyeur, bool ignoreLayers = false)
     {
+		if (_isCombatSimulationCell)
+		{
+			return null;
+		}
+
         return
             Gameworld.ExitManager.GetExitsFor(this, GetOverlayFor(voyeur), ignoreLayers ? default : voyeur?.RoomLayer)
 					 .Where(x => IsSpatiallyAccessibleExit(voyeur, x))
@@ -776,7 +834,10 @@ public partial class Cell : Location, IDisposable, ICell
 		{
 			movingCharacter.MoveTo(this, roomLayer, exit, noSave);
 		}
-        Room.Enter(movingCharacter, exit);
+		if (!_isCombatSimulationCell)
+		{
+			Room.Enter(movingCharacter, exit);
+		}
         DoEnterEvent(movingCharacter);
 
         if (exit != null && exit.InboundDirection != CardinalDirection.Unknown)
@@ -836,7 +897,10 @@ public partial class Cell : Location, IDisposable, ICell
         ForceDisembarkVehicleOccupantLeavingWithoutVehicle(movingCharacter);
         base.Leave(movingCharacter);
 		RouteSpatialService.Instance.UntrackPerceivable(movingCharacter);
-        Room.Leave(movingCharacter);
+		if (!_isCombatSimulationCell)
+		{
+			Room.Leave(movingCharacter);
+		}
         DoLeaveEvent(movingCharacter);
         movingCharacter.HandleEvent(EventType.CharacterLeaveCell, movingCharacter, this,
             movingCharacter.Movement?.Exit);
@@ -1491,8 +1555,7 @@ public partial class Cell : Location, IDisposable, ICell
     {
         if (!WindLevels.ContainsKey(level))
         {
-            ItemWeightPerWindLevelExpression.Parameters["wind"] = (int)level;
-            WindLevels[level] = Convert.ToDouble(ItemWeightPerWindLevelExpression.Evaluate());
+            WindLevels[level] = ItemWeightPerWindLevelExpression.EvaluateDoubleWith(("wind", (int)level));
         }
 
         return WindLevels[level];

--- a/MudSharpCore/Construction/CellCombatSimulation.cs
+++ b/MudSharpCore/Construction/CellCombatSimulation.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+namespace MudSharp.Construction;
+
+public partial class Cell
+{
+	internal void RemoveCombatSimulationArtifact(ICharacter character)
+	{
+		base.Leave(character);
+		RouteSpatialService.Instance.UntrackPerceivable(character);
+	}
+
+	internal void RestoreCombatSimulationEffects(XElement effects)
+	{
+		LoadEffects(effects);
+		ScheduleCachedEffects();
+	}
+}

--- a/MudSharpCore/Database/FMDB.cs
+++ b/MudSharpCore/Database/FMDB.cs
@@ -1,91 +1,263 @@
-﻿using Microsoft.EntityFrameworkCore;
-using MudSharp.Database;
-using MudSharp.Models;
-using MySqlConnector;
 using System.Data;
 using System.Data.Common;
+using System.Threading;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using MudSharp.Models;
+using MySqlConnector;
 
 namespace MudSharp.Database;
 
 public sealed class FMDB : IDisposable
 {
-    public FMDB()
-    {
-        lock (_lock)
-        {
-            if (Context == null)
-            {
-                InitialiseContext();
-            }
-            else
-            {
-                InstanceCount++;
-            }
-        }
-    }
+	private sealed class SuppressEfWritesInterceptor : SaveChangesInterceptor
+	{
+		public static SuppressEfWritesInterceptor Instance { get; } = new();
 
-    private static readonly object _lock = new();
+		public override InterceptionResult<int> SavingChanges(DbContextEventData eventData,
+			InterceptionResult<int> result)
+		{
+			return InterceptionResult<int>.SuppressWithResult(0);
+		}
 
-    public static FuturemudDatabaseContext Context { get; private set; }
+		public override ValueTask<InterceptionResult<int>> SavingChangesAsync(DbContextEventData eventData,
+			InterceptionResult<int> result, CancellationToken cancellationToken = default)
+		{
+			return ValueTask.FromResult(InterceptionResult<int>.SuppressWithResult(0));
+		}
+	}
 
-    private static uint InstanceCount { get; set; }
+	private sealed class DatabaseSession
+	{
+		public FuturemudDatabaseContext Context { get; set; }
+		public DbConnection Connection { get; set; }
+		public uint InstanceCount { get; set; }
+	}
 
-    public static DbConnection Connection { get; private set; }
+	private sealed class IsolatedScope(DatabaseSession previous) : IDisposable
+	{
+		private bool _disposed;
 
-    public static string ConnectionString { get; set; }
+		public void Dispose()
+		{
+			if (_disposed)
+			{
+				return;
+			}
 
-    public static string Provider { get; set; }
+			lock (_lock)
+			{
+				var session = _ambientSession.Value;
+				try
+				{
+					DisposeSession(session);
+				}
+				finally
+				{
+					_ambientSession.Value = previous;
+					_disposed = true;
+				}
+			}
+		}
+	}
 
-    #region IDisposable Members
+	private static readonly object _lock = new();
+	private static readonly AsyncLocal<DatabaseSession> _ambientSession = new();
+	private static DatabaseSession _defaultSession;
+	private readonly DatabaseSession _session;
+	private bool _disposed;
 
-    public void Dispose()
-    {
-        Dispose(true);
-        GC.SuppressFinalize(this);
-    }
+	public FMDB()
+	{
+		lock (_lock)
+		{
+			_session = CurrentSession ?? InitialiseContext();
+			_session.InstanceCount++;
+		}
+	}
 
-    public void Dispose(bool disposing)
-    {
-        lock (_lock)
-        {
-            if (--InstanceCount > 0)
-            {
-                return;
-            }
+	public static FuturemudDatabaseContext Context
+	{
+		get => CurrentSession?.Context;
+		private set
+		{
+			lock (_lock)
+			{
+				EnsureDefaultSession().Context = value;
+				RemoveEmptyDefaultSession();
+			}
+		}
+	}
 
-            Context.Dispose();
-            Context = null;
-            Connection.StateChange -= OnStateChange;
-            Connection.Close();
-            Connection.Dispose();
-            Connection = null;
-        }
-    }
+	public static DbConnection Connection
+	{
+		get => CurrentSession?.Connection;
+		private set
+		{
+			lock (_lock)
+			{
+				EnsureDefaultSession().Connection = value;
+				RemoveEmptyDefaultSession();
+			}
+		}
+	}
 
-    #endregion
+	private static uint InstanceCount
+	{
+		get => _defaultSession?.InstanceCount ?? 0;
+		set
+		{
+			lock (_lock)
+			{
+				EnsureDefaultSession().InstanceCount = value;
+				RemoveEmptyDefaultSession();
+			}
+		}
+	}
 
-    private void InitialiseContext()
-    {
-        lock (_lock)
-        {
-            Context = new FuturemudDatabaseContext(new DbContextOptionsBuilder<FuturemudDatabaseContext>()
-                                                   .UseLazyLoadingProxies().UseMySql(ConnectionString,
-                                                       ServerVersion.AutoDetect(ConnectionString)).Options);
-            Connection = new MySqlConnection(ConnectionString);
-            Connection.Open();
-            InstanceCount++;
-            Connection.StateChange += OnStateChange;
-        }
-    }
+	public static string ConnectionString { get; set; } = string.Empty;
+	public static string Provider { get; set; } = string.Empty;
+	public static bool IsIsolated => _ambientSession.Value is not null;
 
-    private static void OnStateChange(object sender,
-        StateChangeEventArgs args)
-    {
-        if (args.OriginalState != args.CurrentState)
-        {
-            Console.WriteLine(
-                "The current Connection state has changed from {0} to {1}.",
-                args.OriginalState, args.CurrentState);
-        }
-    }
+	private static DatabaseSession CurrentSession => _ambientSession.Value ?? _defaultSession;
+
+	private static DatabaseSession EnsureDefaultSession()
+	{
+		return _defaultSession ??= new DatabaseSession();
+	}
+
+	private static void RemoveEmptyDefaultSession()
+	{
+		if (_defaultSession is { Context: null, Connection: null, InstanceCount: 0 })
+		{
+			_defaultSession = null;
+		}
+	}
+
+	/// <summary>
+	/// Creates an async-flow-local database session. Nested <see cref="FMDB"/> handles use this
+	/// session without disturbing the live engine's static session. Set <paramref name="suppressEfWrites"/>
+	/// for a sandbox that must retain in-memory EF state without issuing database writes.
+	/// </summary>
+	public static IDisposable BeginIsolatedScope(bool suppressEfWrites = false)
+	{
+		lock (_lock)
+		{
+			var previous = _ambientSession.Value;
+			if (previous is not null)
+			{
+				throw new InvalidOperationException("Nested isolated FMDB scopes are not supported.");
+			}
+
+			_ambientSession.Value = CreateSession(suppressEfWrites);
+			return new IsolatedScope(previous);
+		}
+	}
+
+	public void Dispose()
+	{
+		if (_disposed)
+		{
+			return;
+		}
+
+		lock (_lock)
+		{
+			if (_session.InstanceCount > 0)
+			{
+				_session.InstanceCount--;
+			}
+
+			if (_session.InstanceCount == 0 && ReferenceEquals(_session, _defaultSession))
+			{
+				DisposeSession(_session);
+				_defaultSession = null;
+			}
+		}
+
+		_disposed = true;
+		GC.SuppressFinalize(this);
+	}
+
+	private static DatabaseSession InitialiseContext()
+	{
+		var session = CreateSession();
+		if (_ambientSession.Value is not null)
+		{
+			_ambientSession.Value = session;
+		}
+		else
+		{
+			_defaultSession = session;
+		}
+
+		return session;
+	}
+
+	private static DatabaseSession CreateSession(bool suppressEfWrites = false)
+	{
+		var options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseLazyLoadingProxies()
+			.UseMySql(ConnectionString, ServerVersion.AutoDetect(ConnectionString));
+		if (suppressEfWrites)
+		{
+			options.AddInterceptors(SuppressEfWritesInterceptor.Instance);
+		}
+
+		var context = new FuturemudDatabaseContext(options.Options);
+		var connection = new MySqlConnection(ConnectionString);
+		try
+		{
+			connection.Open();
+			connection.StateChange += OnStateChange;
+			return new DatabaseSession
+			{
+				Context = context,
+				Connection = connection
+			};
+		}
+		catch
+		{
+			context.Dispose();
+			connection.Dispose();
+			throw;
+		}
+	}
+
+	private static void DisposeSession(DatabaseSession session)
+	{
+		if (session is null)
+		{
+			return;
+		}
+
+		session.Context?.Dispose();
+		if (session.Connection is null)
+		{
+			return;
+		}
+
+		session.Connection.StateChange -= OnStateChange;
+		try
+		{
+			session.Connection.Close();
+		}
+		finally
+		{
+			session.Connection.Dispose();
+		}
+	}
+
+	private static void OnStateChange(object sender, StateChangeEventArgs args)
+	{
+		if (args.OriginalState == args.CurrentState)
+		{
+			return;
+		}
+
+		Console.WriteLine(
+			"The current Connection state has changed from {0} to {1}.",
+			args.OriginalState,
+			args.CurrentState);
+	}
 }

--- a/MudSharpCore/Economy/Employment/OngoingJobListing.cs
+++ b/MudSharpCore/Economy/Employment/OngoingJobListing.cs
@@ -577,15 +577,15 @@ You will be paid {PayDescriptionForJobListing()}.{(PersonalProject is not null ?
             return false;
         }
 
-        foreach (KeyValuePair<string, object> parameter in expr.Parameters)
+        foreach (string parameter in expr.ParameterNames)
         {
-            if (parameter.Key.EqualTo("effort"))
+            if (parameter.EqualTo("effort"))
             {
                 continue;
             }
 
             actor.OutputHandler.Send(
-                $"The variable {parameter.Key.ColourName()} from your expression is not valid.");
+                $"The variable {parameter.ColourName()} from your expression is not valid.");
             return false;
         }
 

--- a/MudSharpCore/Effects/Concrete/BodyLiquidContamination.cs
+++ b/MudSharpCore/Effects/Concrete/BodyLiquidContamination.cs
@@ -324,9 +324,9 @@ public class BodyLiquidContamination : Effect, ILiquidContaminationEffect, IDesc
             ICell location = BodyOwner.Location;
             if (location != null && !location.IsSwimmingLayer(BodyOwner.RoomLayer))
             {
-                if (DateTime.UtcNow - _lastDripEcho > TimeSpan.FromSeconds(120) && ShouldDripsEcho)
+                if (RuntimeClock.UtcNow - _lastDripEcho > TimeSpan.FromSeconds(120) && ShouldDripsEcho)
                 {
-                    _lastDripEcho = DateTime.UtcNow;
+                    _lastDripEcho = RuntimeClock.UtcNow;
                     string amount, verb;
                     if (difference <= 0.002 / Gameworld.UnitManager.BaseFluidToLitres)
                     {

--- a/MudSharpCore/Effects/Concrete/CriticalInjureKnockout.cs
+++ b/MudSharpCore/Effects/Concrete/CriticalInjureKnockout.cs
@@ -14,7 +14,7 @@ public class CriticalInjureKnockout : Effect
 
     protected CriticalInjureKnockout(XElement root, IPerceivable owner) : base(root, owner)
     {
-        WakeupTime = DateTime.Parse(root.Element("WakeupTime")?.Value ?? DateTime.UtcNow.ToString("O"), null,
+        WakeupTime = DateTime.Parse(root.Element("WakeupTime")?.Value ?? RuntimeClock.UtcNow.ToString("O"), null,
             System.Globalization.DateTimeStyles.RoundtripKind);
     }
 

--- a/MudSharpCore/Effects/Concrete/LearningFatigueEffect.cs
+++ b/MudSharpCore/Effects/Concrete/LearningFatigueEffect.cs
@@ -1,4 +1,4 @@
-﻿
+
 namespace MudSharp.Effects.Concrete;
 
 public class LearningFatigueEffect : Effect, ILearningFatigueEffect
@@ -6,7 +6,7 @@ public class LearningFatigueEffect : Effect, ILearningFatigueEffect
     public LearningFatigueEffect(IPerceivable owner, bool freshBlock, int fatigueDegrees) : base(owner)
     {
         BlockUntil = freshBlock
-            ? DateTime.UtcNow + TimeSpan.FromSeconds(Dice.Roll(LearningBlockLengthDiceExpression))
+            ? RuntimeClock.UtcNow + TimeSpan.FromSeconds(Dice.Roll(LearningBlockLengthDiceExpression))
             : DateTime.MinValue;
         FatigueDegrees = fatigueDegrees;
     }
@@ -58,7 +58,7 @@ public class LearningFatigueEffect : Effect, ILearningFatigueEffect
         }
         else
         {
-            BlockUntil = DateTime.UtcNow + timespan;
+            BlockUntil = RuntimeClock.UtcNow + timespan;
         }
 
         element = root.Element("FatigueDegrees");
@@ -75,7 +75,7 @@ public class LearningFatigueEffect : Effect, ILearningFatigueEffect
         return
             new XElement("Effect",
                 new XElement("BlockUntil",
-                    (BlockUntil > DateTime.UtcNow ? BlockUntil - DateTime.UtcNow : TimeSpan.FromSeconds(0))
+                    (BlockUntil > RuntimeClock.UtcNow ? BlockUntil - RuntimeClock.UtcNow : TimeSpan.FromSeconds(0))
                     .TotalSeconds), new XElement("FatigueDegrees", FatigueDegrees));
     }
 
@@ -84,7 +84,7 @@ public class LearningFatigueEffect : Effect, ILearningFatigueEffect
     public override string Describe(IPerceiver voyeur)
     {
         return
-            $"{Owner.HowSeen(voyeur, true)} is fatigued of learning, making it {FatigueDegrees:N0} degrees harder{(BlockUntil > DateTime.UtcNow ? $" and completely blocking learning for {(BlockUntil - DateTime.UtcNow).Describe(voyeur).Colour(Telnet.Green)}" : "")}";
+            $"{Owner.HowSeen(voyeur, true)} is fatigued of learning, making it {FatigueDegrees:N0} degrees harder{(BlockUntil > RuntimeClock.UtcNow ? $" and completely blocking learning for {(BlockUntil - RuntimeClock.UtcNow).Describe(voyeur).Colour(Telnet.Green)}" : "")}";
     }
 
     #region Overrides of Object
@@ -98,7 +98,7 @@ public class LearningFatigueEffect : Effect, ILearningFatigueEffect
     public override string ToString()
     {
         return
-            $"Owner is fatigued of learning, making it {FatigueDegrees:N0} degrees harder{(BlockUntil > DateTime.UtcNow ? $" and completely blocking learning for {(BlockUntil - DateTime.UtcNow).Describe().Colour(Telnet.Green)}" : "")}";
+            $"Owner is fatigued of learning, making it {FatigueDegrees:N0} degrees harder{(BlockUntil > RuntimeClock.UtcNow ? $" and completely blocking learning for {(BlockUntil - RuntimeClock.UtcNow).Describe().Colour(Telnet.Green)}" : "")}";
     }
 
     #endregion

--- a/MudSharpCore/Effects/Concrete/LiquidContamination.cs
+++ b/MudSharpCore/Effects/Concrete/LiquidContamination.cs
@@ -103,9 +103,9 @@ public class LiquidContamination : Effect, ILiquidContaminationEffect, IDescript
             if (location != null && ownerItem.ContainedIn == null &&
                 !ownerItem.Location.IsSwimmingLayer(ownerItem.RoomLayer))
             {
-                if (DateTime.UtcNow - _lastDripEcho > TimeSpan.FromSeconds(120) && ShouldDripsEcho)
+                if (RuntimeClock.UtcNow - _lastDripEcho > TimeSpan.FromSeconds(120) && ShouldDripsEcho)
                 {
-                    _lastDripEcho = DateTime.UtcNow;
+                    _lastDripEcho = RuntimeClock.UtcNow;
                     string amount, verb;
                     if (difference <= 0.002 / Gameworld.UnitManager.BaseFluidToLitres)
                     {

--- a/MudSharpCore/Effects/Concrete/LoadingMusket.cs
+++ b/MudSharpCore/Effects/Concrete/LoadingMusket.cs
@@ -24,11 +24,12 @@ public class UnjammingGun : CharacterActionWithTargetAndTool
 
         CheckOutcome outcome = check.Check(actor, difficulty, Weapon.Parent, Weapon);
         TraitExpression te = new(actor.Gameworld.GetStaticConfiguration("UnjammingGunDurationExpression"), actor.Gameworld);
-        te.Formula.Parameters["degrees"] = outcome.CheckDegrees();
-        te.Formula.Parameters["faildegrees"] = outcome.FailureDegrees();
-        te.Formula.Parameters["successdegrees"] = outcome.SuccessDegrees();
-        te.Formula.Parameters["difficulty"] = (int)difficulty;
-        return TimeSpan.FromSeconds(te.Evaluate(actor, Weapon.WeaponType.OperateTrait, TraitBonusContext.UnjamGunDuration));
+        return TimeSpan.FromSeconds(te.EvaluateWith(actor, Weapon.WeaponType.OperateTrait,
+            TraitBonusContext.UnjamGunDuration,
+            ("degrees", outcome.CheckDegrees()),
+            ("faildegrees", outcome.FailureDegrees()),
+            ("successdegrees", outcome.SuccessDegrees()),
+            ("difficulty", (int)difficulty)));
     }
 
     public IJammableWeapon Weapon { get; private set; }

--- a/MudSharpCore/Effects/Concrete/NpcKnownThreatLocationsEffect.cs
+++ b/MudSharpCore/Effects/Concrete/NpcKnownThreatLocationsEffect.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using MudSharp.Construction;
 using System.Globalization;
 
@@ -26,7 +26,7 @@ public sealed class NpcKnownThreatLocationsEffect : Effect
 			DateTime remembered = DateTime.TryParse(cell.Attribute("utc")?.Value, CultureInfo.InvariantCulture,
 				DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out DateTime parsed)
 				? parsed
-				: DateTime.UtcNow;
+				: RuntimeClock.UtcNow;
 			if (_knownThreatCellIds.All(x => x.CellId != id))
 			{
 				_knownThreatCellIds.Add((id, remembered));
@@ -75,7 +75,7 @@ public sealed class NpcKnownThreatLocationsEffect : Effect
 	public void Remember(ICell cell)
 	{
 		_knownThreatCellIds.RemoveAll(x => x.CellId == cell.Id);
-		_knownThreatCellIds.Insert(0, (cell.Id, DateTime.UtcNow));
+		_knownThreatCellIds.Insert(0, (cell.Id, RuntimeClock.UtcNow));
 		if (_knownThreatCellIds.Count > MaximumRememberedThreatLocations)
 		{
 			_knownThreatCellIds.RemoveRange(MaximumRememberedThreatLocations,
@@ -109,7 +109,7 @@ public sealed class NpcKnownThreatLocationsEffect : Effect
 			return;
 		}
 
-		DateTime cutoff = DateTime.UtcNow.Subtract(memory);
+		DateTime cutoff = RuntimeClock.UtcNow.Subtract(memory);
 		int removed = _knownThreatCellIds.RemoveAll(x => x.RememberedAtUtc < cutoff);
 		if (removed > 0)
 		{

--- a/MudSharpCore/Effects/Concrete/PsionicPowerEffects.cs
+++ b/MudSharpCore/Effects/Concrete/PsionicPowerEffects.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using MudSharp.Construction;
 using MudSharp.Magic;
@@ -176,9 +176,9 @@ public sealed class MagicDangerSenseEffect : ConcentrationConsumingEffect, IMagi
 	private void TenSecondHeartbeat()
 	{
 		Power.DoSustainCostsTick(CharacterOwner, Power.SustainTickMultiplier);
-		if (DateTime.UtcNow >= _nextWarning && Power.CheckNearbyThreats(CharacterOwner))
+		if (RuntimeClock.UtcNow >= _nextWarning && Power.CheckNearbyThreats(CharacterOwner))
 		{
-			_nextWarning = DateTime.UtcNow + Power.ThreatWarningInterval;
+			_nextWarning = RuntimeClock.UtcNow + Power.ThreatWarningInterval;
 		}
 
 		Power.RefreshDefensiveEdge(CharacterOwner);

--- a/MudSharpCore/Effects/Concrete/PsionicTraceEffect.cs
+++ b/MudSharpCore/Effects/Concrete/PsionicTraceEffect.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using MudSharp.Construction;
 using MudSharp.Magic;
@@ -55,7 +55,7 @@ public sealed class PsionicTraceEffect : Effect, IPsionicTraceEffect
 		ReadDifficulty = (Difficulty)int.Parse(trueRoot?.Element("ReadDifficulty")?.Value ??
 		                                       ((int)Difficulty.Normal).ToString());
 		ConcealmentDifficultyStages = int.Parse(trueRoot?.Element("ConcealmentDifficultyStages")?.Value ?? "0");
-		CreatedUtc = DateTime.Parse(trueRoot?.Element("CreatedUtc")?.Value ?? DateTime.UtcNow.ToString("O"),
+		CreatedUtc = DateTime.Parse(trueRoot?.Element("CreatedUtc")?.Value ?? RuntimeClock.UtcNow.ToString("O"),
 			CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
 		TraceDuration = TimeSpan.FromSeconds(double.Parse(trueRoot?.Element("TraceDurationSeconds")?.Value ?? "0",
 			CultureInfo.InvariantCulture));

--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellTransformFormEffect.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellTransformFormEffect.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 namespace MudSharp.Effects.Concrete.SpellEffects;
 
@@ -24,7 +24,7 @@ public class SpellTransformFormEffect : SimpleSpellStatusEffectBase
 		_priorBodyId = priorBodyId;
 		_priorityBand = priorityBand;
 		_priorityOffset = priorityOffset;
-		_appliedAtUtcTicks = DateTime.UtcNow.Ticks;
+		_appliedAtUtcTicks = RuntimeClock.UtcNow.Ticks;
 	}
 
 	private SpellTransformFormEffect(XElement root, IPerceivable owner)

--- a/MudSharpCore/Effects/Concrete/WildAnimalHerdEffect.cs
+++ b/MudSharpCore/Effects/Concrete/WildAnimalHerdEffect.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Construction;
+using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.NPC;
 using MudSharp.NPC.AI;
@@ -30,7 +30,7 @@ public class WildAnimalHerdEffect : Effect, IEffectSubtype
         {
             _state = value;
             Changed = true;
-            LastStateChange = DateTime.UtcNow;
+            LastStateChange = RuntimeClock.UtcNow;
         }
     }
 
@@ -125,7 +125,7 @@ public class WildAnimalHerdEffect : Effect, IEffectSubtype
         _role = (WildAnimalHerdRole)int.Parse(root.Element("Role").Value);
         _state = (WildAnimalHerdState)int.Parse(root.Element("State").Value);
         _priority = (WildAnimalHerdPriority)int.Parse(root.Element("Priority").Value);
-        LastStateChange = DateTime.UtcNow;
+        LastStateChange = RuntimeClock.UtcNow;
         if (_role == WildAnimalHerdRole.Alpha)
         {
             HerdLeader = (ICharacter)Owner;

--- a/MudSharpCore/Effects/Concrete/WildlifeShelterClaimEffect.cs
+++ b/MudSharpCore/Effects/Concrete/WildlifeShelterClaimEffect.cs
@@ -26,7 +26,7 @@ public sealed class WildlifeShelterClaimEffect : Effect
 		_ownerInstanceId = CharacterInstanceIdentityComparer.InstanceId(claimant);
 		_groupId = (claimant as INPC)?.GroupAI?.Id;
 		_allowGroupSharing = allowGroupSharing;
-		_lastOccupiedUtc = DateTime.UtcNow;
+		_lastOccupiedUtc = RuntimeClock.UtcNow;
 	}
 
 	private WildlifeShelterClaimEffect(XElement root, IPerceivable owner)
@@ -47,7 +47,7 @@ public sealed class WildlifeShelterClaimEffect : Effect
 			CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
 			out DateTime lastOccupied)
 			? lastOccupied
-			: DateTime.UtcNow;
+			: RuntimeClock.UtcNow;
 	}
 
 	public static void InitialiseEffectType()
@@ -116,12 +116,12 @@ public sealed class WildlifeShelterClaimEffect : Effect
 
 	public bool IsReclaimable()
 	{
-		return DateTime.UtcNow - _lastOccupiedUtc >= ReclaimAfter && !HasValidOwner();
+		return RuntimeClock.UtcNow - _lastOccupiedUtc >= ReclaimAfter && !HasValidOwner();
 	}
 
 	public void RefreshOccupancy()
 	{
-		_lastOccupiedUtc = DateTime.UtcNow;
+		_lastOccupiedUtc = RuntimeClock.UtcNow;
 		Changed = true;
 	}
 

--- a/MudSharpCore/Effects/EffectSchedule.cs
+++ b/MudSharpCore/Effects/EffectSchedule.cs
@@ -34,7 +34,7 @@ public class EffectSchedule : ScheduleBase, IEffectSchedule
     {
         return string.Format(voyeur, "{0} {3}[{1:N1}s] (original {2:N1}s){4}",
             Effect.Describe(voyeur),
-            (TriggerETA - DateTime.UtcNow).TotalSeconds,
+            (TriggerETA - RuntimeClock.UtcNow).TotalSeconds,
             Duration.TotalSeconds,
             Telnet.Green.Colour,
             Telnet.RESETALL

--- a/MudSharpCore/Effects/EffectScheduler.cs
+++ b/MudSharpCore/Effects/EffectScheduler.cs
@@ -9,6 +9,8 @@ public class EffectScheduler : IScheduler, IHaveFuturemud, IEffectScheduler
 	protected readonly Dictionary<IEffect, IEffectSchedule> _scheduleMap = new();
 	private readonly StableScheduleHeap<IEffectSchedule> _schedules = new();
 	private readonly TimeProvider _timeProvider;
+	public DateTime? NextTriggerUtc => _schedules.TryPeek(out var next) ? next.TriggerUtc : null;
+	public int LastCheckFiredCount { get; private set; }
 
 	public IFuturemud Gameworld { get; protected set; }
 
@@ -116,6 +118,8 @@ public class EffectScheduler : IScheduler, IHaveFuturemud, IEffectScheduler
 
 			fired++;
 		}
+
+		LastCheckFiredCount = fired;
 
 		(Gameworld as IRuntimePerformanceMonitorProvider)?.RuntimePerformanceMonitor.RecordSchedulerCheck(
 			RuntimeSchedulerKind.Effect,

--- a/MudSharpCore/Framework/FuturemudCombatSimulation.cs
+++ b/MudSharpCore/Framework/FuturemudCombatSimulation.cs
@@ -1,0 +1,11 @@
+#nullable enable
+
+namespace MudSharp.Framework;
+
+public sealed partial class Futuremud
+{
+	public void ForgetCombatSimulationActor(ICharacter actor)
+	{
+		_cachedActors.Remove(actor);
+	}
+}

--- a/MudSharpCore/Framework/FuturemudLoaders.cs
+++ b/MudSharpCore/Framework/FuturemudLoaders.cs
@@ -13,6 +13,7 @@ using MudSharp.Celestial;
 using MudSharp.CharacterCreation;
 using MudSharp.CharacterCreation.Resources;
 using MudSharp.Combat;
+using MudSharp.Combat.Simulation;
 using MudSharp.Commands;
 using MudSharp.Commands.Modules;
 using MudSharp.Documentation.Export;
@@ -149,14 +150,19 @@ using Plane = MudSharp.Planes.Plane;
 
 namespace MudSharp.Framework;
 
-public sealed partial class Futuremud : IFuturemudLoader, IFuturemud, IDisposable
+public sealed partial class Futuremud : IFuturemudLoader, IFuturemud, ICombatSimulationRuntimeRegistry, IDisposable
 {
     private List<ICharacterCommandTree> _actorCommandTrees = new();
     private readonly ConnectionSnapshotRegistry _connections = new();
 	private readonly List<IPlayerConnection> _pendingCommandConnections = [];
     public IServer Server { get; private set; }
 	public IRuntimePerformanceMonitor RuntimePerformanceMonitor { get; }
-    public IScheduler Scheduler { get; private set; }
+	private IScheduler _scheduler;
+	public IScheduler Scheduler
+	{
+		get => CombatSimulationRuntimeScope.Current?.Scheduler ?? _scheduler;
+		private set => _scheduler = value;
+	}
     public IArenaLifecycleService ArenaLifecycleService { get; private set; }
     public IArenaScheduler ArenaScheduler { get; private set; }
     public IArenaObservationService ArenaObservationService { get; private set; }
@@ -166,12 +172,27 @@ public sealed partial class Futuremud : IFuturemudLoader, IFuturemud, IDisposabl
     public IArenaNpcService ArenaNpcService { get; private set; }
     public IArenaParticipationService ArenaParticipationService { get; private set; }
     public IArenaCommandService ArenaCommandService { get; private set; }
-    public IEffectScheduler EffectScheduler { get; private set; }
-    public ISaveManager SaveManager { get; private set; }
+	private IEffectScheduler _effectScheduler;
+	public IEffectScheduler EffectScheduler
+	{
+		get => CombatSimulationRuntimeScope.Current?.EffectScheduler ?? _effectScheduler;
+		private set => _effectScheduler = value;
+	}
+	private ISaveManager _saveManager;
+	public ISaveManager SaveManager
+	{
+		get => CombatSimulationRuntimeScope.Current?.SaveManager ?? _saveManager;
+		private set => _saveManager = value;
+	}
     public IGameItemComponentManager GameItemComponentManager { get; private set; }
     public IClockManager ClockManager { get; private set; }
     public IUnitManager UnitManager { get; private set; }
-    public IHeartbeatManager HeartbeatManager { get; private set; }
+	private IHeartbeatManager _heartbeatManager;
+	public IHeartbeatManager HeartbeatManager
+	{
+		get => CombatSimulationRuntimeScope.Current?.HeartbeatManager ?? _heartbeatManager;
+		private set => _heartbeatManager = value;
+	}
     public IProximityEventService ProximityEventService { get; private set; }
     public IComputerExecutionService ComputerExecutionService { get; private set; }
     public IComputerHelpService ComputerHelpService { get; private set; }

--- a/MudSharpCore/Framework/RuntimeSideEffectContext.cs
+++ b/MudSharpCore/Framework/RuntimeSideEffectContext.cs
@@ -1,0 +1,39 @@
+using System.Threading;
+
+#nullable enable
+
+namespace MudSharp.Framework;
+
+/// <summary>
+/// Supplies flow-local policy for runtime work that must suppress selected external side effects.
+/// Ordinary engine execution permits all side effects.
+/// </summary>
+internal static class RuntimeSideEffectContext
+{
+	private static readonly AsyncLocal<bool> AmbientCrimeCreationSuppression = new();
+
+	public static bool IsCrimeCreationSuppressed => AmbientCrimeCreationSuppression.Value;
+
+	public static IDisposable SuppressCrimeCreation()
+	{
+		var previous = AmbientCrimeCreationSuppression.Value;
+		AmbientCrimeCreationSuppression.Value = true;
+		return new PopScope(previous);
+	}
+
+	private sealed class PopScope(bool previous) : IDisposable
+	{
+		private bool _disposed;
+
+		public void Dispose()
+		{
+			if (_disposed)
+			{
+				return;
+			}
+
+			AmbientCrimeCreationSuppression.Value = previous;
+			_disposed = true;
+		}
+	}
+}

--- a/MudSharpCore/Framework/Save/LateInitialisingItem.cs
+++ b/MudSharpCore/Framework/Save/LateInitialisingItem.cs
@@ -82,6 +82,21 @@ public abstract class LateInitialisingItem : FrameworkItem, ILateInitialisingIte
         };
     }
 
+    /// <summary>
+    /// Assigns an identity to a transient item without creating a database row.
+    /// </summary>
+    /// <remarks>
+    /// This supports short-lived in-memory worlds such as combat simulations. The caller must allocate an
+    /// identity that cannot collide with persistent items in its own lookup scope.
+    /// </remarks>
+    public void InitialiseWithoutPersistence(long id)
+    {
+        _id = id;
+        IdInitialised = true;
+        _changed = false;
+        IdRegistered?.Invoke(this);
+    }
+
     public abstract object DatabaseInsert();
 
     public abstract void SetIDFromDatabase(object dbitem);
@@ -205,6 +220,21 @@ public abstract class LateKeywordedInitialisingItem : KeywordedItem, ILateInitia
                 IdRegistered?.Invoke(this);
             }
         };
+    }
+
+    /// <summary>
+    /// Assigns an identity to a transient item without creating a database row.
+    /// </summary>
+    /// <remarks>
+    /// This supports short-lived in-memory worlds such as combat simulations. The caller must allocate an
+    /// identity that cannot collide with persistent items in its own lookup scope.
+    /// </remarks>
+    public void InitialiseWithoutPersistence(long id)
+    {
+        _id = id;
+        IdInitialised = true;
+        _changed = false;
+        IdRegistered?.Invoke(this);
     }
 
     public abstract object DatabaseInsert();

--- a/MudSharpCore/Framework/Scheduling/RuntimeClock.cs
+++ b/MudSharpCore/Framework/Scheduling/RuntimeClock.cs
@@ -1,0 +1,42 @@
+using System.Threading;
+
+#nullable enable
+
+namespace MudSharp.Framework.Scheduling;
+
+/// <summary>
+/// Supplies an ambient time provider for accelerated or otherwise isolated runtime work.
+/// Ordinary engine execution continues to use <see cref="TimeProvider.System"/>.
+/// </summary>
+public static class RuntimeClock
+{
+	private static readonly AsyncLocal<TimeProvider?> AmbientProvider = new();
+
+	public static TimeProvider TimeProvider => AmbientProvider.Value ?? System.TimeProvider.System;
+
+	public static DateTime UtcNow => TimeProvider.GetUtcNow().UtcDateTime;
+
+	public static IDisposable Push(TimeProvider timeProvider)
+	{
+		ArgumentNullException.ThrowIfNull(timeProvider);
+		var previous = AmbientProvider.Value;
+		AmbientProvider.Value = timeProvider;
+		return new PopScope(previous);
+	}
+
+	private sealed class PopScope(TimeProvider? previous) : IDisposable
+	{
+		private bool _disposed;
+
+		public void Dispose()
+		{
+			if (_disposed)
+			{
+				return;
+			}
+
+			AmbientProvider.Value = previous;
+			_disposed = true;
+		}
+	}
+}

--- a/MudSharpCore/Framework/Scheduling/Scheduler.cs
+++ b/MudSharpCore/Framework/Scheduling/Scheduler.cs
@@ -8,6 +8,8 @@ public class Scheduler : IScheduler
 	private readonly StableScheduleHeap<ISchedule> _schedules = new();
 	private readonly TimeProvider _timeProvider;
 	private readonly IRuntimePerformanceMonitor _performanceMonitor;
+	public DateTime? NextTriggerUtc => _schedules.TryPeek(out var next) ? next.TriggerUtc : null;
+	public int LastCheckFiredCount { get; private set; }
 
 	public Scheduler(TimeProvider timeProvider = null, IRuntimePerformanceMonitor performanceMonitor = null)
 	{
@@ -84,6 +86,8 @@ public class Scheduler : IScheduler
 
 			fired++;
 		}
+
+		LastCheckFiredCount = fired;
 
 		_performanceMonitor?.RecordSchedulerCheck(RuntimeSchedulerKind.Main, _schedules.Count, fired, overdue,
 			Stopwatch.GetTimestamp() - started);

--- a/MudSharpCore/Framework/Scheduling/Schedules.cs
+++ b/MudSharpCore/Framework/Scheduling/Schedules.cs
@@ -7,7 +7,7 @@ public abstract class ScheduleBase : IComparable<ScheduleBase>, ISchedule
         int milliseconds = 0)
     {
         Type = type;
-        CreatedAt = DateTime.UtcNow;
+        CreatedAt = RuntimeClock.UtcNow;
         Duration = new TimeSpan(days, hours, minutes, seconds, milliseconds);
         TriggerETA = CreatedAt + Duration;
     }
@@ -15,7 +15,7 @@ public abstract class ScheduleBase : IComparable<ScheduleBase>, ISchedule
     protected ScheduleBase(ScheduleType type, TimeSpan duration)
     {
         Type = type;
-        CreatedAt = DateTime.UtcNow;
+        CreatedAt = RuntimeClock.UtcNow;
         Duration = duration;
         TriggerETA = CreatedAt + Duration;
     }

--- a/MudSharpCore/FutureProg/Functions/BuiltIn/CollectionUtilityFunctions.cs
+++ b/MudSharpCore/FutureProg/Functions/BuiltIn/CollectionUtilityFunctions.cs
@@ -118,7 +118,7 @@ internal class CollectionUtilityFunction : BuiltInFunction
 				Result = ToCollection(Distinct(collection));
 				return StatementResult.Normal;
 			case CollectionOperation.Shuffle:
-				Result = ToCollection(collection.OrderBy(_ => Random.Shared.Next()));
+				Result = ToCollection(collection.OrderBy(_ => Constants.Random.Next()));
 				return StatementResult.Normal;
 			case CollectionOperation.IsValidIndex:
 				var index = GetInteger(1);

--- a/MudSharpCore/FutureProg/Functions/GameItem/LoadLootTableFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/GameItem/LoadLootTableFunction.cs
@@ -35,7 +35,9 @@ internal sealed class LoadLootTableFunction : BuiltInFunction
 		if (table is null) return Receipt("ERROR code=TABLE_NOT_FOUND message=The exact LootTable revision does not exist.");
 		if (!table.Status.In(RevisionStatus.Current, RevisionStatus.Revised)) return Receipt("ERROR code=TABLE_NOT_APPROVED message=The exact LootTable revision is not approved.");
 		var variant = ParameterFunctions[3].Result.GetObject?.ToString() ?? string.Empty;
-		var seed = _seeded ? (long)(decimal)ParameterFunctions[4].Result.GetObject : Random.Shared.NextInt64(long.MaxValue);
+		var seed = _seeded
+			? (long)(decimal)ParameterFunctions[4].Result.GetObject
+			: Constants.Random.NextInt64(long.MaxValue);
 		if (seed < 0) return Receipt("ERROR code=INVALID_SEED message=The seed must be non-negative.");
 		var materialiser = new LootTableMaterialiser(_gameworld);
 		var target = ParameterFunctions[2].Result?.GetObject;

--- a/MudSharpCore/GameItems/Components/AmmunitionGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/AmmunitionGameItemComponent.cs
@@ -12,6 +12,7 @@ using MudSharp.RPG.Checks;
 using MudSharp.Vehicles;
 using MudSharp.RPG.Merits.Interfaces;
 using MudSharp.RPG.Law;
+using MoreLinq;
 
 namespace MudSharp.GameItems.Components;
 
@@ -445,7 +446,7 @@ public class AmmunitionGameItemComponent : GameItemComponent, IAmmo
     private bool TryResolveObstruction(ICharacter actor, IPerceiver target, IGameItem ammo,
         IRangedWeaponType weaponType, OpposedOutcome defenseOutcome, IBodypart bodypart, IReadOnlyList<ICellExit> path)
     {
-        IRangedObstructionEffect obstructionEffect = target.EffectsOfType<IRangedObstructionEffect>().Where(x => x.Applies(actor)).Shuffle()
+        IRangedObstructionEffect obstructionEffect = target.EffectsOfType<IRangedObstructionEffect>().Where(x => x.Applies(actor)).Shuffle(Constants.Random)
                                          .FirstOrDefault();
         if (obstructionEffect == null)
         {
@@ -523,35 +524,31 @@ public class AmmunitionGameItemComponent : GameItemComponent, IAmmo
         var payloadEffects = ammo.EffectsOfType<IMagicProjectilePayloadEffect>(x =>
             x.AppliesToProjectileAttack(actor, target, ammo)).ToList();
         var effectiveQuality = (int)ammo.Quality + (int)Math.Round(payloadEffects.Sum(x => x.ProjectileQualityBonus));
-        AmmoType.DamageProfile.DamageExpression.Formula.Parameters["quality"] = effectiveQuality;
-        AmmoType.DamageProfile.DamageExpression.Formula.Parameters["degree"] = (int)defenseOutcome.Degree;
-        AmmoType.DamageProfile.DamageExpression.Formula.Parameters["pointblank"] = actor == target ? 1 : 0;
-        AmmoType.DamageProfile.DamageExpression.Formula.Parameters["inmelee"] = actor.MeleeRange ? 1 : 0;
-        AmmoType.DamageProfile.DamageExpression.Formula.Parameters["range"] = target.DistanceBetween(actor, 10);
-        AmmoType.DamageProfile.PainExpression.Formula.Parameters["quality"] = effectiveQuality;
-        AmmoType.DamageProfile.PainExpression.Formula.Parameters["degree"] = (int)defenseOutcome.Degree;
-        AmmoType.DamageProfile.PainExpression.Formula.Parameters["pointblank"] = actor == target ? 1 : 0;
-        AmmoType.DamageProfile.PainExpression.Formula.Parameters["inmelee"] = actor.MeleeRange ? 1 : 0;
-        AmmoType.DamageProfile.PainExpression.Formula.Parameters["range"] = target.DistanceBetween(actor, 10);
-        AmmoType.DamageProfile.StunExpression.Formula.Parameters["quality"] = effectiveQuality;
-        AmmoType.DamageProfile.StunExpression.Formula.Parameters["degree"] = (int)defenseOutcome.Degree;
-        AmmoType.DamageProfile.StunExpression.Formula.Parameters["pointblank"] = actor == target ? 1 : 0;
-        AmmoType.DamageProfile.StunExpression.Formula.Parameters["inmelee"] = actor.MeleeRange ? 1 : 0;
-        AmmoType.DamageProfile.StunExpression.Formula.Parameters["range"] = target.DistanceBetween(actor, 10);
-
-        weaponType.DamageBonusExpression.Formula.Parameters["range"] = target.DistanceBetween(actor, 10);
-        weaponType.DamageBonusExpression.Formula.Parameters["quality"] = (int)Parent.Quality;
-        weaponType.DamageBonusExpression.Formula.Parameters["degree"] = (int)defenseOutcome.Degree;
-        weaponType.DamageBonusExpression.Formula.Parameters["pointblank"] = actor == target ? 1 : 0;
-        weaponType.DamageBonusExpression.Formula.Parameters["inmelee"] = actor.MeleeRange ? 1 : 0;
+        var profileValues = new (string Name, object Value)[]
+        {
+            ("quality", effectiveQuality),
+            ("degree", (int)defenseOutcome.Degree),
+            ("pointblank", actor == target ? 1 : 0),
+            ("inmelee", actor.MeleeRange ? 1 : 0),
+            ("range", target.DistanceBetween(actor, 10))
+        };
+        var weaponBonusValues = new (string Name, object Value)[]
+        {
+            ("range", target.DistanceBetween(actor, 10)),
+            ("quality", (int)Parent.Quality),
+            ("degree", (int)defenseOutcome.Degree),
+            ("pointblank", actor == target ? 1 : 0),
+            ("inmelee", actor.MeleeRange ? 1 : 0)
+        };
 
         damageMultiplier *= _currentFireContext?.DamageMultiplier ?? 1.0;
-        double finalDamage = (AmmoType.DamageProfile.DamageExpression.Evaluate(actor) +
-                          weaponType.DamageBonusExpression.Evaluate(actor, weaponType.FireTrait) +
+        double finalDamage = (AmmoType.DamageProfile.DamageExpression.EvaluateWith(actor, values: profileValues) +
+                          weaponType.DamageBonusExpression.EvaluateWith(actor, weaponType.FireTrait,
+                              values: weaponBonusValues) +
                           payloadEffects.Sum(x => x.ProjectileDamageBonus)) * damageMultiplier;
-        double finalPain = (AmmoType.DamageProfile.PainExpression.Evaluate(actor) +
+        double finalPain = (AmmoType.DamageProfile.PainExpression.EvaluateWith(actor, values: profileValues) +
                            payloadEffects.Sum(x => x.ProjectilePainBonus)) * damageMultiplier;
-        double finalStun = (AmmoType.DamageProfile.StunExpression.Evaluate(actor) +
+        double finalStun = (AmmoType.DamageProfile.StunExpression.EvaluateWith(actor, values: profileValues) +
                            payloadEffects.Sum(x => x.ProjectileStunBonus)) * damageMultiplier;
         return new Damage
         {

--- a/MudSharpCore/GameItems/Components/BombGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/BombGameItemComponent.cs
@@ -71,15 +71,13 @@ public class BombGameItemComponent : GameItemComponent, IDetonatable
 
         List<Damage> damages = _prototype.Damages.Select(x =>
         {
-            x.DamageExpression.Parameters["quality"] = (int)Parent.Quality;
-            x.StunExpression.Parameters["quality"] = (int)Parent.Quality;
-            double finalDamage = Convert.ToDouble(x.DamageExpression.Evaluate());
+            double finalDamage = x.DamageExpression.EvaluateDoubleWith(("quality", (int)Parent.Quality));
             return new Damage
             {
                 DamageType = x.DamageType,
                 DamageAmount = finalDamage,
                 PainAmount = finalDamage,
-                StunAmount = Convert.ToDouble(x.StunExpression.Evaluate())
+                StunAmount = x.StunExpression.EvaluateDoubleWith(("quality", (int)Parent.Quality))
             };
         }).ToList();
 

--- a/MudSharpCore/GameItems/Components/CountdownDetonatorGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/CountdownDetonatorGameItemComponent.cs
@@ -86,7 +86,7 @@ public class CountdownDetonatorGameItemComponent : DeadlineExplosiveTriggerGameI
 		}
 
 		TryResolveDelay(actor, argument, out var delay, out _);
-		if (!ExplosiveDeadlineScheduler.TryGetDeadline(DateTime.UtcNow, delay, out var deadline))
+		if (!ExplosiveDeadlineScheduler.TryGetDeadline(RuntimeClock.UtcNow, delay, out var deadline))
 		{
 			actor.Send("That countdown is too long to schedule safely.");
 			return false;
@@ -154,7 +154,7 @@ public class CountdownDetonatorGameItemComponent : DeadlineExplosiveTriggerGameI
 			return false;
 		}
 
-		if (!ExplosiveDeadlineScheduler.TryGetDeadline(DateTime.UtcNow, delay, out _))
+		if (!ExplosiveDeadlineScheduler.TryGetDeadline(RuntimeClock.UtcNow, delay, out _))
 		{
 			error = "That countdown is too long to schedule safely.";
 			return false;

--- a/MudSharpCore/GameItems/Components/DeadlineExplosiveTriggerGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/DeadlineExplosiveTriggerGameItemComponent.cs
@@ -88,7 +88,7 @@ public abstract class DeadlineExplosiveTriggerGameItemComponent : GameItemCompon
 	protected TimeSpan RemainingDuration(DateTime? now = null)
 	{
 		return DetonationDeadlineUtc is { } deadline
-			? deadline - (now ?? DateTime.UtcNow)
+			? deadline - (now ?? RuntimeClock.UtcNow)
 			: TimeSpan.Zero;
 	}
 
@@ -140,7 +140,7 @@ public abstract class DeadlineExplosiveTriggerGameItemComponent : GameItemCompon
 
 	private void CheckDeadline()
 	{
-		if (DetonationDeadlineUtc is not { } deadline || !ExplosiveDeadlineScheduler.IsDue(deadline, DateTime.UtcNow))
+		if (DetonationDeadlineUtc is not { } deadline || !ExplosiveDeadlineScheduler.IsDue(deadline, RuntimeClock.UtcNow))
 		{
 			return;
 		}

--- a/MudSharpCore/GameItems/Components/DestroyableGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/DestroyableGameItemComponent.cs
@@ -74,9 +74,8 @@ public class DestroyableGameItemComponent : GameItemComponent, IDestroyable, IAf
     {
         get
         {
-            _prototype.HpExpression.Parameters["quality"] = (int)Parent.Prototype.BaseItemQuality;
-            _prototype.HpExpression.Parameters["size"] = (int)Parent.Size;
-            return Convert.ToDouble(_prototype.HpExpression.Evaluate());
+            return _prototype.HpExpression.EvaluateDoubleWith(
+                ("quality", (int)Parent.Prototype.BaseItemQuality), ("size", (int)Parent.Size));
         }
     }
 

--- a/MudSharpCore/GameItems/Components/MusketGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/MusketGameItemComponent.cs
@@ -1272,6 +1272,25 @@ It is classified as {WeaponType.Classification.Describe().Colour(Telnet.Green)}.
             "Unknown WhyCannotFire reason in MusketGameItemComponent.WhyCannotFire");
     }
 
+    private double EvaluateFaultChance(ITraitExpression expression, ICharacter actor, IMusketCartridge cartridge,
+        bool wadUsed)
+    {
+        var weather = actor.Location.CurrentWeather(actor);
+        return expression.EvaluateWith(actor, WeaponType.FireTrait, TraitBonusContext.MusketMisfire,
+            ("operate", actor.TraitValue(WeaponType.OperateTrait)),
+            ("skipclean", NeedsCleaning ? 1.0 : 0.0),
+            ("precipitation", weather?.Precipitation.PrecipitationIntensityForGunpowder() ?? 0.0),
+            ("gunquality", (int)Parent.Quality),
+            ("cartridgeused", _magazineContents.Count == 1 && cartridge is not null ? 1.0 : 0.0),
+            ("cartridgequality", _magazineContents.Count == 1 && cartridge is not null
+                ? (int)cartridge.Parent.Quality
+                : (int)ItemQuality.Standard),
+            ("condition", Parent.Condition),
+            ("wadused", wadUsed ? 1.0 : 0.0),
+            ("wetpowder", _magazineContents.Any(x => x.SurfaceLiquidState.IsWet) ? 1.0 : 0.0),
+            ("taploaded", TapLoaded ? 1.0 : 0.0));
+    }
+
     /// <inheritdoc />
     public void Fire(ICharacter actor, IPerceiver target, Outcome shotOutcome, Outcome coverOutcome, OpposedOutcome defenseOutcome, IBodypart bodypart, IEmoteOutput defenseEmote, IPerceiver originalTarget)
     {
@@ -1382,17 +1401,7 @@ It is classified as {WeaponType.Classification.Describe().Colour(Telnet.Green)}.
         if (!misfire)
         {
             ITraitExpression misExpression = _prototype.MisfireChance;
-            misExpression.Formula.Parameters["operate"] = actor.TraitValue(WeaponType.OperateTrait);
-            misExpression.Formula.Parameters["skipclean"] = NeedsCleaning ? 1.0 : 0.0;
-            misExpression.Formula.Parameters["precipitation"] = actor.Location.CurrentWeather(actor) is not null ? (actor.Location.CurrentWeather(actor)?.Precipitation ?? PrecipitationLevel.Parched).PrecipitationIntensityForGunpowder() : 0.0;
-            misExpression.Formula.Parameters["gunquality"] = (int)Parent.Quality;
-            misExpression.Formula.Parameters["cartridgeused"] = _magazineContents.Count == 1 && cartridge is not null ? 1.0 : 0.0;
-            misExpression.Formula.Parameters["cartridgequality"] = _magazineContents.Count == 1 && cartridge is not null ? (int)cartridge.Parent.Quality : (int)ItemQuality.Standard;
-            misExpression.Formula.Parameters["condition"] = Parent.Condition;
-            misExpression.Formula.Parameters["wadused"] = wadused ? 1.0 : 0.0;
-            misExpression.Formula.Parameters["wetpowder"] = _magazineContents.Any(x => x.SurfaceLiquidState.IsWet) ? 1.0 : 0.0;
-            misExpression.Formula.Parameters["taploaded"] = TapLoaded ? 1.0 : 0.0;
-            double chance = misExpression.Evaluate(actor, WeaponType.FireTrait, TraitBonusContext.MusketMisfire);
+            double chance = EvaluateFaultChance(misExpression, actor, cartridge, wadused);
             double roll = RandomUtilities.DoubleRandom(0.0, 1.0);
             Gameworld.DebugMessage($"Musket misfire chance #2{chance:P3}#0 rolled {roll:P3}");
             if (roll < chance)
@@ -1454,17 +1463,7 @@ It is classified as {WeaponType.Classification.Describe().Colour(Telnet.Green)}.
         if (misfire)
         {
             ITraitExpression jamExpression = _prototype.JamChance;
-            jamExpression.Formula.Parameters["operate"] = actor.TraitValue(WeaponType.OperateTrait);
-            jamExpression.Formula.Parameters["skipclean"] = NeedsCleaning ? 1.0 : 0.0;
-            jamExpression.Formula.Parameters["precipitation"] = actor.Location.CurrentWeather(actor) is not null ? (actor.Location.CurrentWeather(actor)?.Precipitation ?? PrecipitationLevel.Parched).PrecipitationIntensityForGunpowder() : 0.0;
-            jamExpression.Formula.Parameters["gunquality"] = (int)Parent.Quality;
-            jamExpression.Formula.Parameters["cartridgeused"] = _magazineContents.Count == 1 && cartridge is not null ? 1.0 : 0.0;
-            jamExpression.Formula.Parameters["cartridgequality"] = _magazineContents.Count == 1 && cartridge is not null ? (int)cartridge.Parent.Quality : (int)ItemQuality.Standard;
-            jamExpression.Formula.Parameters["condition"] = Parent.Condition;
-            jamExpression.Formula.Parameters["wadused"] = wadused ? 1.0 : 0.0;
-            jamExpression.Formula.Parameters["wetpowder"] = _magazineContents.Any(x => x.SurfaceLiquidState.IsWet) ? 1.0 : 0.0;
-            jamExpression.Formula.Parameters["taploaded"] = TapLoaded ? 1.0 : 0.0;
-            double chance = jamExpression.Evaluate(actor, WeaponType.FireTrait, TraitBonusContext.MusketMisfire);
+            double chance = EvaluateFaultChance(jamExpression, actor, cartridge, wadused);
             double roll = RandomUtilities.DoubleRandom(0.0, 1.0);
             Gameworld.DebugMessage($"Musket jam chance #2{chance:P3}#0 rolled {roll:P3}");
             if (roll < chance)

--- a/MudSharpCore/GameItems/Components/PinPullDetonatorGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/PinPullDetonatorGameItemComponent.cs
@@ -56,7 +56,7 @@ public class PinPullDetonatorGameItemComponent : DeadlineExplosiveTriggerGameIte
 	public bool CanPullPin(ICharacter actor)
 	{
 		return !PinPulled && Parent.IsItemType<IDetonatable>() &&
-		       ExplosiveDeadlineScheduler.TryGetDeadline(DateTime.UtcNow, _prototype.Delay, out _);
+		       ExplosiveDeadlineScheduler.TryGetDeadline(RuntimeClock.UtcNow, _prototype.Delay, out _);
 	}
 
 	public string WhyCannotPullPin(ICharacter actor)
@@ -66,7 +66,7 @@ public class PinPullDetonatorGameItemComponent : DeadlineExplosiveTriggerGameIte
 			return $"The pin has already been pulled from {Parent.HowSeen(actor)}.";
 		}
 
-		if (!ExplosiveDeadlineScheduler.TryGetDeadline(DateTime.UtcNow, _prototype.Delay, out _))
+		if (!ExplosiveDeadlineScheduler.TryGetDeadline(RuntimeClock.UtcNow, _prototype.Delay, out _))
 		{
 			return $"The configured delay on {Parent.HowSeen(actor)} is too long to schedule safely.";
 		}
@@ -84,7 +84,7 @@ public class PinPullDetonatorGameItemComponent : DeadlineExplosiveTriggerGameIte
 			return false;
 		}
 
-		if (!ExplosiveDeadlineScheduler.TryGetDeadline(DateTime.UtcNow, _prototype.Delay, out var deadline))
+		if (!ExplosiveDeadlineScheduler.TryGetDeadline(RuntimeClock.UtcNow, _prototype.Delay, out var deadline))
 		{
 			actor.Send($"The configured delay on {Parent.HowSeen(actor)} is too long to schedule safely.");
 			return false;

--- a/MudSharpCore/GameItems/Components/PowerPackGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/PowerPackGameItemComponent.cs
@@ -8,6 +8,7 @@ using MudSharp.Health;
 using MudSharp.RPG.Checks;
 using MudSharp.RPG.Merits.Interfaces;
 using MudSharp.Vehicles;
+using MoreLinq;
 
 namespace MudSharp.GameItems.Components;
 
@@ -107,12 +108,11 @@ public class PowerPackGameItemComponent : GameItemComponent, ILaserPowerPack
     {
         var payloadEffects = Parent.EffectsOfType<IMagicProjectilePayloadEffect>(x =>
             x.AppliesToProjectileAttack(actor, target, Parent)).ToList();
-        weaponType.DamageBonusExpression.Formula.Parameters["range"] = target.DistanceBetween(actor, 10);
-        weaponType.DamageBonusExpression.Formula.Parameters["quality"] =
-            (int)Parent.Quality + (int)Math.Round(payloadEffects.Sum(x => x.ProjectileQualityBonus));
-        weaponType.DamageBonusExpression.Formula.Parameters["degrees"] = (int)defenseOutcome.Degree;
-
-        double finalDamage = weaponType.DamageBonusExpression.Evaluate(actor) +
+        double finalDamage = weaponType.DamageBonusExpression.EvaluateWith(actor,
+                                 values: [("range", target.DistanceBetween(actor, 10)),
+                                     ("quality", (int)Parent.Quality +
+                                                 (int)Math.Round(payloadEffects.Sum(x => x.ProjectileQualityBonus))),
+                                     ("degrees", (int)defenseOutcome.Degree)]) +
                              payloadEffects.Sum(x => x.ProjectileDamageBonus);
         return new Damage
         {
@@ -397,7 +397,7 @@ public class PowerPackGameItemComponent : GameItemComponent, ILaserPowerPack
         OpposedOutcome defenseOutcome, IBodypart bodypart, double painMultiplier, double stunMultiplier,
         IReadOnlyList<ICellExit> path)
     {
-        IRangedObstructionEffect obstructionEffect = target.EffectsOfType<IRangedObstructionEffect>().Where(x => x.Applies(actor)).Shuffle()
+        IRangedObstructionEffect obstructionEffect = target.EffectsOfType<IRangedObstructionEffect>().Where(x => x.Applies(actor)).Shuffle(Constants.Random)
                                          .FirstOrDefault();
         if (obstructionEffect == null)
         {

--- a/MudSharpCore/GameItems/Components/ThrownWeaponGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/ThrownWeaponGameItemComponent.cs
@@ -189,20 +189,18 @@ public class ThrownWeaponGameItemComponent : GameItemComponent, IRangedWeapon, I
 
         var payloadEffects = Parent.EffectsOfType<IMagicProjectilePayloadEffect>(x =>
             x.AppliesToProjectileAttack(actor, target, Parent)).ToList();
-        _prototype.RangedWeaponType.DamageBonusExpression.Formula.Parameters["quality"] =
-            (int)Parent.Quality + (int)Math.Round(payloadEffects.Sum(x => x.ProjectileQualityBonus));
-        _prototype.RangedWeaponType.DamageBonusExpression.Formula.Parameters["degrees"] =
-            (int)defenseOutcome.Degree;
-        _prototype.RangedWeaponType.DamageBonusExpression.Formula.Parameters["range"] = actor.DistanceBetween(
-            target, 10);
         Damage damage = new()
         {
             ActorOrigin = actor,
             ToolOrigin = Parent,
             Bodypart = bodypart,
             DamageAmount =
-                _prototype.RangedWeaponType.DamageBonusExpression.Evaluate(actor,
-                    _prototype.RangedWeaponType.FireTrait) + payloadEffects.Sum(x => x.ProjectileDamageBonus),
+                _prototype.RangedWeaponType.DamageBonusExpression.EvaluateWith(actor,
+                    _prototype.RangedWeaponType.FireTrait,
+                    values: [("quality", (int)Parent.Quality +
+                                         (int)Math.Round(payloadEffects.Sum(x => x.ProjectileQualityBonus))),
+                        ("degrees", (int)defenseOutcome.Degree), ("range", actor.DistanceBetween(target, 10))]) +
+                payloadEffects.Sum(x => x.ProjectileDamageBonus),
             DamageType = _prototype.MeleeWeaponType.Attacks.FirstMax(x => x.Weighting).Profile.DamageType,
             PainAmount = payloadEffects.Sum(x => x.ProjectilePainBonus),
             StunAmount = payloadEffects.Sum(x => x.ProjectileStunBonus),

--- a/MudSharpCore/GameItems/Components/TimerSensorGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/TimerSensorGameItemComponent.cs
@@ -70,7 +70,7 @@ public class TimerSensorGameItemComponent : PoweredMachineBaseGameItemComponent,
 		: base(proto, parent, temporary)
 	{
 		_prototype = proto;
-		var now = DateTime.UtcNow;
+		var now = RuntimeClock.UtcNow;
 		_cycleAnchor = now;
 		_startsActive = proto.StartActive;
 		RefreshState(now, false);
@@ -119,8 +119,8 @@ public class TimerSensorGameItemComponent : PoweredMachineBaseGameItemComponent,
 	public override string Decorate(IPerceiver voyeur, string name, string description, DescriptionType type, bool colour,
 		PerceiveIgnoreFlags flags)
 	{
-		var untilTransition = _nextTransition > DateTime.UtcNow
-			? (_nextTransition - DateTime.UtcNow).Describe(voyeur).ColourValue()
+		var untilTransition = _nextTransition > RuntimeClock.UtcNow
+			? (_nextTransition - RuntimeClock.UtcNow).Describe(voyeur).ColourValue()
 			: "less than a second".ColourValue();
 		return
 			$"{description}\n\nIts timer sensor is {(SwitchedOn ? "switched on".ColourValue() : "switched off".ColourError())}, {(_onAndPowered ? "powered".ColourValue() : "not powered".ColourError())}, alternates between {_prototype.ActiveValue.ToString("N2", voyeur).ColourValue()} for {_prototype.ActiveDuration.Describe(voyeur).ColourValue()} and {_prototype.InactiveValue.ToString("N2", voyeur).ColourValue()} for {_prototype.InactiveDuration.Describe(voyeur).ColourValue()}. It is currently {(_isActive ? "active".ColourValue() : "inactive".ColourName())} and will change state in {untilTransition}.";
@@ -132,7 +132,7 @@ public class TimerSensorGameItemComponent : PoweredMachineBaseGameItemComponent,
 	{
 		base.UpdateComponentNewPrototype(newProto);
 		_prototype = (TimerSensorGameItemComponentProto)newProto;
-		RefreshState(DateTime.UtcNow, true);
+		RefreshState(RuntimeClock.UtcNow, true);
 	}
 
 	protected override void LoadFromXml(XElement root)
@@ -146,7 +146,7 @@ public class TimerSensorGameItemComponent : PoweredMachineBaseGameItemComponent,
 		}
 		else
 		{
-			_cycleAnchor = DateTime.UtcNow;
+			_cycleAnchor = RuntimeClock.UtcNow;
 		}
 
 		var startsActiveElement = root.Element("StartsActive");
@@ -157,7 +157,7 @@ public class TimerSensorGameItemComponent : PoweredMachineBaseGameItemComponent,
 
 	public override void FinaliseLoad()
 	{
-		var now = DateTime.UtcNow;
+		var now = RuntimeClock.UtcNow;
 		if (_cycleAnchor == default)
 		{
 			_cycleAnchor = now;
@@ -171,7 +171,7 @@ public class TimerSensorGameItemComponent : PoweredMachineBaseGameItemComponent,
 	{
 		base.Login();
 		EnsureHeartbeatSubscription();
-		RefreshState(DateTime.UtcNow, false);
+		RefreshState(RuntimeClock.UtcNow, false);
 	}
 
 	public override void Delete()
@@ -195,7 +195,7 @@ public class TimerSensorGameItemComponent : PoweredMachineBaseGameItemComponent,
 
 	protected override void OnPowerCutInAction()
 	{
-		RefreshState(DateTime.UtcNow, true);
+		RefreshState(RuntimeClock.UtcNow, true);
 	}
 
 	protected override void OnPowerCutOutAction()
@@ -206,7 +206,7 @@ public class TimerSensorGameItemComponent : PoweredMachineBaseGameItemComponent,
 
 	private void HeartbeatTick()
 	{
-		RefreshState(DateTime.UtcNow, true);
+		RefreshState(RuntimeClock.UtcNow, true);
 	}
 
 	private void EnsureHeartbeatSubscription()

--- a/MudSharpCore/GameItems/GameItem.cs
+++ b/MudSharpCore/GameItems/GameItem.cs
@@ -1101,7 +1101,7 @@ public partial class GameItem : PerceiverItem, IGameItem, IDisposable, IPostChar
                 }
                 else
                 {
-                    CachedMorphTime = rhs.MorphTime - DateTime.UtcNow;
+                    CachedMorphTime = rhs.MorphTime - RuntimeClock.UtcNow;
                 }
             }
             else
@@ -1402,9 +1402,8 @@ public partial class GameItem : PerceiverItem, IGameItem, IDisposable, IPostChar
         var damageMultiplier = fallMitigationEffects.Aggregate(1.0,
             (current, effect) => current * Math.Max(0.0, effect.FallDamageMultiplier));
 
-        FallDamageExpression.Parameters["weight"] = Weight;
-        FallDamageExpression.Parameters["rooms"] = effectiveFallDistance;
-        var damageAmount = Convert.ToDouble(FallDamageExpression.Evaluate()) * damageMultiplier;
+        var damageAmount = FallDamageExpression.EvaluateDoubleWith(("weight", Weight),
+            ("rooms", effectiveFallDistance)) * damageMultiplier;
         if (damageAmount <= 0.0)
         {
             return;
@@ -2838,7 +2837,7 @@ public partial class GameItem : PerceiverItem, IGameItem, IDisposable, IPostChar
     {
         if (CachedMorphTime is not null)
         {
-            MorphTime = DateTime.UtcNow + CachedMorphTime.Value;
+            MorphTime = RuntimeClock.UtcNow + CachedMorphTime.Value;
             CachedMorphTime = null;
         }
 
@@ -2848,7 +2847,7 @@ public partial class GameItem : PerceiverItem, IGameItem, IDisposable, IPostChar
                 item => item.Changed = true, ScheduleType.MorphSaving, TimeSpan.FromSeconds(30),
                 $"Morph Saver for {HowSeen(this)} #{Id}"));
             Gameworld.Scheduler.AddSchedule(new Schedule<IGameItem>(this, Morph, ScheduleType.Morph,
-                MorphTime > DateTime.UtcNow ? MorphTime - DateTime.UtcNow : TimeSpan.FromTicks(1),
+                MorphTime > RuntimeClock.UtcNow ? MorphTime - RuntimeClock.UtcNow : TimeSpan.FromTicks(1),
                 $"Morph checker for {HowSeen(this)} #{Id}"));
         }
     }
@@ -2859,7 +2858,7 @@ public partial class GameItem : PerceiverItem, IGameItem, IDisposable, IPostChar
         {
             Gameworld.Scheduler.Destroy(this, ScheduleType.Morph);
             Gameworld.Scheduler.Destroy(this, ScheduleType.MorphSaving);
-            CachedMorphTime = MorphTime - DateTime.UtcNow;
+            CachedMorphTime = MorphTime - RuntimeClock.UtcNow;
             MorphTime = DateTime.MinValue;
         }
     }

--- a/MudSharpCore/GlobalUsings.cs
+++ b/MudSharpCore/GlobalUsings.cs
@@ -9,6 +9,7 @@ global using MudSharp.Character;
 global using MudSharp.Effects.Interfaces;
 global using MudSharp.Form.Shape;
 global using MudSharp.Framework;
+global using MudSharp.Framework.Scheduling;
 global using MudSharp.FutureProg;
 global using MudSharp.GameItems.Interfaces;
 global using MudSharp.PerceptionEngine;

--- a/MudSharpCore/Health/Infections/Gangrene.cs
+++ b/MudSharpCore/Health/Infections/Gangrene.cs
@@ -41,8 +41,7 @@ public class Gangrene : Infection
     {
         get
         {
-            PainExpression.Parameters["intensity"] = Intensity;
-            return Convert.ToDouble(PainExpression.Evaluate());
+            return PainExpression.EvaluateDoubleWith(("intensity", Intensity));
         }
     }
 

--- a/MudSharpCore/Health/Infections/SimpleInfection.cs
+++ b/MudSharpCore/Health/Infections/SimpleInfection.cs
@@ -47,8 +47,7 @@ public class SimpleInfection : Infection
     {
         get
         {
-            PainExpression.Parameters["intensity"] = Intensity;
-            return Convert.ToDouble(PainExpression.Evaluate());
+            return PainExpression.EvaluateDoubleWith(("intensity", Intensity));
         }
     }
 

--- a/MudSharpCore/Health/Strategies/BaseHealthStrategy.cs
+++ b/MudSharpCore/Health/Strategies/BaseHealthStrategy.cs
@@ -594,9 +594,8 @@ public abstract class BaseHealthStrategy : SaveableItem, IHealthStrategy
             return false;
         }
 
-        LodgeDamageExpression.Parameters["damage"] = damage.DamageAmount;
-        LodgeDamageExpression.Parameters["type"] = (int)damage.DamageType;
-        return Dice.Roll(1, 100) < Convert.ToDouble(LodgeDamageExpression.Evaluate());
+        return Dice.Roll(1, 100) < LodgeDamageExpression.EvaluateDoubleWith(
+            ("damage", damage.DamageAmount), ("type", (int)damage.DamageType));
     }
 
     protected string DescribeLodgeDamageCheck()

--- a/MudSharpCore/Health/Strategies/BrainHitpointsStrategy.cs
+++ b/MudSharpCore/Health/Strategies/BrainHitpointsStrategy.cs
@@ -341,11 +341,11 @@ public class BrainHitpointsStrategy : BaseHealthStrategy
             {
                 if (!character.AffectedBy<CriticalInjureKnockout>())
                 {
-                    character.AddEffect(new CriticalInjureKnockout(character, DateTime.UtcNow + KnockoutDuration));
+                    character.AddEffect(new CriticalInjureKnockout(character, RuntimeClock.UtcNow + KnockoutDuration));
                     return HealthTickResult.PassOut;
                 }
 
-                return character.EffectsOfType<CriticalInjureKnockout>().First().WakeupTime > DateTime.UtcNow
+                return character.EffectsOfType<CriticalInjureKnockout>().First().WakeupTime > RuntimeClock.UtcNow
                     ? HealthTickResult.PassOut
                     : HealthTickResult.None;
             }
@@ -397,10 +397,9 @@ public class BrainHitpointsStrategy : BaseHealthStrategy
                 return 0;
         }
 
-        whichExpression.Formula.Parameters["originaldamage"] = wound.OriginalDamage;
-        whichExpression.Formula.Parameters["damage"] = wound.CurrentDamage;
-        whichExpression.Formula.Parameters["outcome"] = outcome.SuccessDegrees();
-        return whichExpression.Evaluate((ICharacter)wound.Parent);
+        return whichExpression.EvaluateWith((ICharacter)wound.Parent,
+            values: [("originaldamage", wound.OriginalDamage), ("damage", wound.CurrentDamage),
+                ("outcome", outcome.SuccessDegrees())]);
     }
 
     public override double WoundPenaltyFor(IHaveWounds owner)

--- a/MudSharpCore/Health/Strategies/ComplexLivingHealthStrategy.cs
+++ b/MudSharpCore/Health/Strategies/ComplexLivingHealthStrategy.cs
@@ -1378,13 +1378,10 @@ public class ComplexLivingHealthStrategy : BaseHealthStrategy
                 return 0;
         }
 
-        whichExpression.Formula.Parameters["originaldamage"] = wound.OriginalDamage;
-        whichExpression.Formula.Parameters["damage"] = wound.CurrentDamage;
-        whichExpression.Formula.Parameters["pain"] = wound.CurrentPain;
-        whichExpression.Formula.Parameters["stun"] = wound.CurrentStun;
-        whichExpression.Formula.Parameters["shock"] = wound.CurrentShock;
-        whichExpression.Formula.Parameters["outcome"] = outcome.SuccessDegrees();
-        return whichExpression.Evaluate((ICharacter)wound.Parent);
+        return whichExpression.EvaluateWith((ICharacter)wound.Parent,
+            values: [("originaldamage", wound.OriginalDamage), ("damage", wound.CurrentDamage),
+                ("pain", wound.CurrentPain), ("stun", wound.CurrentStun), ("shock", wound.CurrentShock),
+                ("outcome", outcome.SuccessDegrees())]);
     }
 
     #region Overrides of BaseHealthStrategy

--- a/MudSharpCore/Health/Strategies/SimpleLivingHealthStrategy.cs
+++ b/MudSharpCore/Health/Strategies/SimpleLivingHealthStrategy.cs
@@ -940,13 +940,10 @@ public class SimpleLivingHealthStrategy : BaseHealthStrategy
                 return 0;
         }
 
-        whichExpression.Formula.Parameters["originaldamage"] = wound.OriginalDamage;
-        whichExpression.Formula.Parameters["damage"] = wound.CurrentDamage;
-        whichExpression.Formula.Parameters["pain"] = wound.CurrentPain;
-        whichExpression.Formula.Parameters["stun"] = wound.CurrentStun;
-        whichExpression.Formula.Parameters["shock"] = wound.CurrentShock;
-        whichExpression.Formula.Parameters["outcome"] = outcome.SuccessDegrees();
-        return whichExpression.Evaluate((ICharacter)wound.Parent);
+        return whichExpression.EvaluateWith((ICharacter)wound.Parent,
+            values: [("originaldamage", wound.OriginalDamage), ("damage", wound.CurrentDamage),
+                ("pain", wound.CurrentPain), ("stun", wound.CurrentStun), ("shock", wound.CurrentShock),
+                ("outcome", outcome.SuccessDegrees())]);
     }
 
     #region Overrides of BaseHealthStrategy

--- a/MudSharpCore/Health/WoundExtensions.cs
+++ b/MudSharpCore/Health/WoundExtensions.cs
@@ -2,6 +2,7 @@
 using MudSharp.Effects.Concrete;
 using MudSharp.GameItems;
 using MudSharp.RPG.Law;
+using MoreLinq;
 
 namespace MudSharp.Health;
 
@@ -40,7 +41,7 @@ public static class WoundExtensions
             }
         }
 
-        wounds = wounds.Shuffle().ToList();
+        wounds = wounds.Shuffle(Constants.Random).ToList();
         foreach (IWound wound in wounds)
         {
             if (wound == null)

--- a/MudSharpCore/Health/Wounds/BoneFracture.cs
+++ b/MudSharpCore/Health/Wounds/BoneFracture.cs
@@ -65,7 +65,7 @@ public class BoneFracture : PerceivedItem, IImmobilisableWound
         Bodypart = bodypart;
         _actorOriginId = actorOrigin?.Id ?? 0;
         _toolOriginId = toolOrigin?.Id ?? 0;
-        RealTimeOfWound = DateTime.UtcNow;
+        RealTimeOfWound = RuntimeClock.UtcNow;
         if (actorOrigin?.Combat?.Friendly == true)
         {
             IsFriendlyWound = true;

--- a/MudSharpCore/Health/Wounds/HealingSimpleWound.cs
+++ b/MudSharpCore/Health/Wounds/HealingSimpleWound.cs
@@ -49,7 +49,7 @@ public class HealingSimpleWound : PerceivedItem, IWound
         _lodged = lodged;
         _actorOriginId = actorOrigin?.Id ?? 0;
         _toolOriginId = toolOrigin?.Id ?? 0;
-        RealTimeOfWound = DateTime.UtcNow;
+        RealTimeOfWound = RuntimeClock.UtcNow;
         BleedStatus = BleedStatus.NeverBled;
         if (actorOrigin?.Combat?.Friendly == true)
         {

--- a/MudSharpCore/Health/Wounds/RobotWound.cs
+++ b/MudSharpCore/Health/Wounds/RobotWound.cs
@@ -43,7 +43,7 @@ public class RobotWound : PerceivedItem, IWound
         Lodged = lodged;
         _toolOriginId = toolOrigin?.Id ?? 0;
         _actorOriginId = actorOrigin?.Id ?? 0;
-        RealTimeOfWound = DateTime.UtcNow;
+        RealTimeOfWound = RuntimeClock.UtcNow;
         if (actorOrigin?.Combat?.Friendly == true)
         {
             IsFriendlyWound = true;

--- a/MudSharpCore/Health/Wounds/SimpleOrganicWound.cs
+++ b/MudSharpCore/Health/Wounds/SimpleOrganicWound.cs
@@ -121,7 +121,7 @@ public class SimpleOrganicWound : PerceivedItem, IWound
         _lodged = lodged;
         _actorOriginId = actorOrigin?.Id ?? 0;
         _toolOriginId = toolOrigin?.Id ?? 0;
-        RealTimeOfWound = DateTime.UtcNow;
+        RealTimeOfWound = RuntimeClock.UtcNow;
         if (actorOrigin?.Combat?.Friendly == true)
         {
             IsFriendlyWound = true;

--- a/MudSharpCore/Health/Wounds/SimpleWound.cs
+++ b/MudSharpCore/Health/Wounds/SimpleWound.cs
@@ -53,7 +53,7 @@ public class SimpleWound : PerceivedItem, IWound
         _toolOriginId = toolOrigin?.Id ?? 0;
         _vehicleId = vehicleId;
         _vehicleDamageZoneId = vehicleDamageZoneId;
-        RealTimeOfWound = DateTime.UtcNow;
+        RealTimeOfWound = RuntimeClock.UtcNow;
         BleedStatus = BleedStatus.NeverBled;
         if (actorOrigin?.Combat?.Friendly == true)
         {

--- a/MudSharpCore/Magic/Capabilities/SkillLevelBasedMagicCapability.cs
+++ b/MudSharpCore/Magic/Capabilities/SkillLevelBasedMagicCapability.cs
@@ -199,10 +199,11 @@ public class SkillLevelBasedMagicCapability : SaveableItem, IMagicCapability
     public Difficulty GetConcentrationDifficulty(ICharacter actor, double concentrationPercentageOfCapability,
         double individualPowerConcentrationPercentage)
     {
-        ConcentrationDifficultyExpression.Formula.Parameters["total"] = concentrationPercentageOfCapability;
-        ConcentrationDifficultyExpression.Formula.Parameters["power"] = individualPowerConcentrationPercentage;
         return (Difficulty)(int)Math.Round(Math.Max(0,
-            Math.Min((int)Difficulty.Impossible, (double)ConcentrationDifficultyExpression.Evaluate(actor, ConcentrationTrait))));
+            Math.Min((int)Difficulty.Impossible, ConcentrationDifficultyExpression.EvaluateWith(actor,
+                ConcentrationTrait,
+                values: [("total", concentrationPercentageOfCapability),
+                    ("power", individualPowerConcentrationPercentage)]))));
     }
 
     private readonly List<IMagicResourceRegenerator> _resourceRegenerators = new();

--- a/MudSharpCore/Magic/MagicSpell.cs
+++ b/MudSharpCore/Magic/MagicSpell.cs
@@ -1398,9 +1398,8 @@ public class MagicSpell : SaveableItem, IMagicSpell
 
         foreach ((IMagicResource resource, ITraitExpression expression) in _castingCosts)
         {
-            expression.Formula.Parameters["power"] = (int)power;
-            expression.Formula.Parameters["self"] = magician == target ? 1 : 0;
-            double cost = expression.Evaluate(magician, CastingTrait, TraitBonusContext.SpellCost);
+            double cost = expression.EvaluateWith(magician, CastingTrait, TraitBonusContext.SpellCost,
+                ("power", (int)power), ("self", magician == target ? 1 : 0));
             if (!magician.CanUseResource(resource, cost))
             {
                 return false;
@@ -1434,9 +1433,8 @@ public class MagicSpell : SaveableItem, IMagicSpell
         List<(IMagicResource Resource, double Cost)> realCosts = new();
         foreach ((IMagicResource resource, ITraitExpression expression) in _castingCosts)
         {
-            expression.Formula.Parameters["power"] = (int)power;
-            expression.Formula.Parameters["self"] = magician == target ? 1 : 0;
-            double cost = expression.Evaluate(magician, CastingTrait, TraitBonusContext.SpellCost);
+            double cost = expression.EvaluateWith(magician, CastingTrait, TraitBonusContext.SpellCost,
+                ("power", (int)power), ("self", magician == target ? 1 : 0));
             if (!magician.CanUseResource(resource, cost))
             {
                 magician.OutputHandler.Send(
@@ -1506,12 +1504,12 @@ public class MagicSpell : SaveableItem, IMagicSpell
 		TimeSpan duration = TimeSpan.Zero;
 		if (EffectDurationExpression is not null)
 		{
-			EffectDurationExpression.Formula.Parameters["degrees"] = result[CastingDifficulty].CheckDegrees();
-			EffectDurationExpression.Formula.Parameters["success"] = result[CastingDifficulty].SuccessDegrees();
-            EffectDurationExpression.Formula.Parameters["power"] = (int)power;
             duration =
                 TimeSpan.FromSeconds(
-					EffectDurationExpression.Evaluate(magician, CastingTrait, TraitBonusContext.SpellDuration));
+					EffectDurationExpression.EvaluateWith(magician, CastingTrait, TraitBonusContext.SpellDuration,
+						("degrees", result[CastingDifficulty].CheckDegrees()),
+						("success", result[CastingDifficulty].SuccessDegrees()),
+						("power", (int)power)));
 		}
 
 		OpposedOutcome baseOutcome = new(result[CastingDifficulty].Outcome, Outcome.NotTested);
@@ -1676,11 +1674,9 @@ public class MagicSpell : SaveableItem, IMagicSpell
 		var duration = TimeSpan.Zero;
 		if (EffectDurationExpression is not null)
 		{
-			EffectDurationExpression.Formula.Parameters["degrees"] = 1;
-			EffectDurationExpression.Formula.Parameters["success"] = 1;
-			EffectDurationExpression.Formula.Parameters["power"] = (int)power;
 			duration = TimeSpan.FromSeconds(
-				EffectDurationExpression.Evaluate(magician, CastingTrait, TraitBonusContext.SpellDuration));
+				EffectDurationExpression.EvaluateWith(magician, CastingTrait, TraitBonusContext.SpellDuration,
+					("degrees", 1), ("success", 1), ("power", (int)power)));
 		}
 
 		var effectOutcome = OpposedOutcomeDegree.None;

--- a/MudSharpCore/Magic/Powers/SustainedMagicPower.cs
+++ b/MudSharpCore/Magic/Powers/SustainedMagicPower.cs
@@ -121,8 +121,7 @@ public abstract class SustainedMagicPower : MagicPowerBase
     {
         if (HasDuration)
         {
-            DurationExpression.Parameters["degrees"] = successDegrees;
-            return TimeSpan.FromMilliseconds(Convert.ToDouble(DurationExpression.Evaluate()));
+            return TimeSpan.FromMilliseconds(DurationExpression.EvaluateDoubleWith(("degrees", successDegrees)));
         }
 
         return TimeSpan.MinValue;

--- a/MudSharpCore/Magic/SpellEffects/HealEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/HealEffect.cs
@@ -3,6 +3,7 @@ using MudSharp.GameItems;
 using MudSharp.Health;
 using MudSharp.RPG.Checks;
 using NCalc;
+using MoreLinq;
 
 namespace MudSharp.Magic.SpellEffects;
 
@@ -192,7 +193,7 @@ You can also use the traits of the caster as per #3TE HELP#0.";
         }
         else
         {
-            wounds = wounds.Shuffle().ToList();
+            wounds = wounds.Shuffle(Constants.Random).ToList();
         }
 
         while (amount > 0.0)

--- a/MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs
+++ b/MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs
@@ -350,21 +350,15 @@ public class ItemDamageEffect : IMagicSpellEffectTemplate
 			return null;
 		}
 
-		foreach (var expression in new[] { DamageFormula, PainFormula, StunFormula })
-		{
-			expression.Parameters["power"] = (int)power;
-			expression.Parameters["outcome"] = (int)outcome;
-		}
-
-		item.SufferDamage(new Damage
+        item.SufferDamage(new Damage
 		{
 			ActorOrigin = caster,
 			ToolOrigin = null,
 			DamageType = DamageType,
-			DamageAmount = DamageFormula.EvaluateDouble(),
-			PainAmount = PainFormula.EvaluateDouble(),
+            DamageAmount = DamageFormula.EvaluateDoubleWith(("power", (int)power), ("outcome", (int)outcome)),
+            PainAmount = PainFormula.EvaluateDoubleWith(("power", (int)power), ("outcome", (int)outcome)),
 			ShockAmount = 0,
-			StunAmount = StunFormula.EvaluateDouble(),
+            StunAmount = StunFormula.EvaluateDoubleWith(("power", (int)power), ("outcome", (int)outcome)),
 			PenetrationOutcome = Outcome.NotTested
 		});
 		return null;

--- a/MudSharpCore/Magic/SpellEffects/MendEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/MendEffect.cs
@@ -1,6 +1,7 @@
 ﻿using MudSharp.Body.Traits;
 using MudSharp.Health;
 using MudSharp.RPG.Checks;
+using MoreLinq;
 
 namespace MudSharp.Magic.SpellEffects;
 
@@ -190,7 +191,7 @@ You can also use the traits of the caster as per #3TE HELP#0.";
         }
         else
         {
-            wounds = wounds.Shuffle().ToList();
+            wounds = wounds.Shuffle(Constants.Random).ToList();
         }
 
         while (amount > 0.0)

--- a/MudSharpCore/Magic/SpellEffects/PersistentSensoryCombatSpellEffects.cs
+++ b/MudSharpCore/Magic/SpellEffects/PersistentSensoryCombatSpellEffects.cs
@@ -151,9 +151,7 @@ public class BurningEffect : IMagicSpellEffectTemplate
 
 	private static double Evaluate(Expression formula, OpposedOutcomeDegree outcome, SpellPower power)
 	{
-		formula.Parameters["power"] = (int)power;
-		formula.Parameters["outcome"] = (int)outcome;
-		return Math.Max(0.0, formula.EvaluateDouble());
+		return Math.Max(0.0, formula.EvaluateDoubleWith(("power", (int)power), ("outcome", (int)outcome)));
 	}
 
 	public IMagicSpellEffectTemplate Clone()

--- a/MudSharpCore/NPC/AI/AggressivePatherAI.cs
+++ b/MudSharpCore/NPC/AI/AggressivePatherAI.cs
@@ -8,6 +8,7 @@ using MudSharp.Effects.Concrete;
 using MudSharp.Events;
 using MudSharp.Models;
 using System.Collections;
+using MoreLinq;
 
 namespace MudSharp.NPC.AI;
 
@@ -85,7 +86,7 @@ public class AggressivePatherAI : PathingAIWithProgTargetsBase
             return false;
         }
 
-        foreach (ICharacter tch in ch.Location.CharactersInSpatialVicinity(ch, false).Except(ch).Shuffle())
+        foreach (ICharacter tch in ch.Location.CharactersInSpatialVicinity(ch, false).Except(ch).Shuffle(Constants.Random))
         {
             if (CheckForAttack(ch, tch))
             {
@@ -103,7 +104,7 @@ public class AggressivePatherAI : PathingAIWithProgTargetsBase
         //Worth revisiting at some point.
         {
             foreach (ICharacter tch in ch.Location.CellsInVicinity(range, true, true).Except(ch.Location)
-                                  .SelectMany(x => x.Characters).Shuffle().ToList())
+                                  .SelectMany(x => x.Characters).Shuffle(Constants.Random).ToList())
             {
                 if (CheckForAttack(ch, tch))
                 {

--- a/MudSharpCore/NPC/AI/AggressorAI.cs
+++ b/MudSharpCore/NPC/AI/AggressorAI.cs
@@ -2,6 +2,7 @@
 using MudSharp.Events;
 using MudSharp.Models;
 using MudSharp.Construction;
+using MoreLinq;
 
 namespace MudSharp.NPC.AI;
 
@@ -76,7 +77,7 @@ public class AggressorAI : ArtificialIntelligenceBase
             return false;
         }
 
-        foreach (ICharacter tch in ch.Location.CharactersInSpatialVicinity(ch).Except(ch).Shuffle())
+        foreach (ICharacter tch in ch.Location.CharactersInSpatialVicinity(ch).Except(ch).Shuffle(Constants.Random))
         {
             if (CheckForAttack(ch, tch))
             {

--- a/MudSharpCore/NPC/AI/AnimalAI.cs
+++ b/MudSharpCore/NPC/AI/AnimalAI.cs
@@ -11,6 +11,7 @@ using MudSharp.GameItems;
 using MudSharp.Models;
 using MudSharp.NPC.AI.Groups;
 using MudSharp.Work.Crafts;
+using MoreLinq;
 
 namespace MudSharp.NPC.AI;
 
@@ -3267,7 +3268,7 @@ public class AnimalAI : PathingAIBase
 			return false;
 		}
 
-		foreach (ICharacter threat in VisibleEcologyCharacters(character).Except(protectedTargets).Shuffle())
+		foreach (ICharacter threat in VisibleEcologyCharacters(character).Except(protectedTargets).Shuffle(Constants.Random))
 		{
 			if (IsSociallyTrusted(character, threat) ||
 			    !IsParentingThreat(character, threat))
@@ -3437,7 +3438,7 @@ public class AnimalAI : PathingAIBase
 
 			if (threat >= 1.0)
 			{
-				foreach (ICharacter activeTarget in activeTargets.Shuffle())
+				foreach (ICharacter activeTarget in activeTargets.Shuffle(Constants.Random))
 				{
 					AnimalThreatResponseType response = ResolveThreatResponse(character, activeTarget);
 					if (response == AnimalThreatResponseType.Attack &&
@@ -3650,7 +3651,7 @@ public class AnimalAI : PathingAIBase
 			RememberThreats(character, candidates);
 		}
 
-		foreach (ICharacter target in candidates.Shuffle())
+		foreach (ICharacter target in candidates.Shuffle(Constants.Random))
 		{
 			AnimalThreatResponseType response = ResolveThreatResponse(character, target);
 			if (response == AnimalThreatResponseType.Inherit)
@@ -4423,7 +4424,7 @@ public class AnimalAI : PathingAIBase
 		                                             .Concat(character.Location.LayerGameItems(character.RoomLayer)
 		                                                              .SelectMany(x => x.ShallowAccessibleItems(character)));
 
-		foreach (IGameItem item in candidates.Shuffle())
+		foreach (IGameItem item in candidates.Shuffle(Constants.Random))
 		{
 			if (item.GetItemType<IEdible>() is IEdible edible &&
 			    character.CanEat(edible, edible.Parent.ContainedIn?.GetItemType<IContainer>(), null, 1.0))
@@ -5134,7 +5135,7 @@ public class AnimalAI : PathingAIBase
 			foreach (ICharacter target in character.Location.LayerCharacters(character.RoomLayer)
 			                                    .Except(character)
 			                                    .Where(x => !ai.IsSociallyTrusted(character, x))
-			                                    .Shuffle())
+				                                    .Shuffle(Constants.Random))
 			{
 				if (ai.TryFlee(character, target))
 				{
@@ -5158,7 +5159,7 @@ public class AnimalAI : PathingAIBase
 			foreach (ICharacter target in character.Location.LayerCharacters(character.RoomLayer)
 			                                    .Except(character)
 			                                    .Where(x => !ai.IsSociallyTrusted(character, x))
-			                                    .Shuffle())
+				                                    .Shuffle(Constants.Random))
 			{
 				if (TryAttack(ai, character, target))
 				{
@@ -5352,7 +5353,7 @@ public class AnimalAI : PathingAIBase
 		{
 			List<ICharacter> threats = ai.VisibleAwarenessThreats(character, witnessedTarget).ToList();
 			ai.RememberThreats(character, threats);
-			foreach (ICharacter threat in threats.Shuffle())
+			foreach (ICharacter threat in threats.Shuffle(Constants.Random))
 			{
 				if (PredatorAIHelpers.CheckForAttack(character, threat, ai.AwarenessThreatProg,
 					    ai.EngageDelayDiceExpression, ai.EngageEmote, false))

--- a/MudSharpCore/NPC/AI/EnforcerAI.cs
+++ b/MudSharpCore/NPC/AI/EnforcerAI.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Internal;
 using MudSharp.Body.Position;
 using MudSharp.Communication;
 using MudSharp.Construction;
@@ -887,7 +887,7 @@ public class EnforcerAI : ArtificialIntelligenceBase, IOverrideAlertEmote
                 {
                     if (enforcer == patrol?.PatrolLeader && patrol.PatrolPhase == PatrolPhase.Patrol &&
                         patrol.ActiveEnforcementTarget is null &&
-                        DateTime.UtcNow - patrol.LastArrivedTime < patrol.PatrolRoute.LingerTimeMinorNode)
+                        RuntimeClock.UtcNow - patrol.LastArrivedTime < patrol.PatrolRoute.LingerTimeMinorNode)
                     {
                         return false;
                     }
@@ -906,7 +906,7 @@ public class EnforcerAI : ArtificialIntelligenceBase, IOverrideAlertEmote
         {
             if (enforcer == patrol?.PatrolLeader && patrol.PatrolPhase == PatrolPhase.Patrol &&
                 patrol.ActiveEnforcementTarget is null &&
-                DateTime.UtcNow - patrol.LastArrivedTime < patrol.PatrolRoute.LingerTimeMinorNode)
+                RuntimeClock.UtcNow - patrol.LastArrivedTime < patrol.PatrolRoute.LingerTimeMinorNode)
             {
                 return false;
             }
@@ -947,8 +947,8 @@ public class EnforcerAI : ArtificialIntelligenceBase, IOverrideAlertEmote
             if (fp != null && enforcer.CouldMove(false, null).Success)
             {
                 bool major = patrol.PatrolRoute.PatrolNodes.Contains(enforcer.Location);
-                if ((major && DateTime.UtcNow - patrol.LastArrivedTime >= patrol.PatrolRoute.LingerTimeMajorNode) ||
-                    (!major && DateTime.UtcNow - patrol.LastArrivedTime >= patrol.PatrolRoute.LingerTimeMinorNode))
+                if ((major && RuntimeClock.UtcNow - patrol.LastArrivedTime >= patrol.PatrolRoute.LingerTimeMajorNode) ||
+                    (!major && RuntimeClock.UtcNow - patrol.LastArrivedTime >= patrol.PatrolRoute.LingerTimeMinorNode))
                 {
                     fp.FollowPathAction();
                     return true;

--- a/MudSharpCore/NPC/AI/Groups/GroupTypes/FamilyPredatorGroup.cs
+++ b/MudSharpCore/NPC/AI/Groups/GroupTypes/FamilyPredatorGroup.cs
@@ -6,6 +6,7 @@ using MudSharp.Construction.Boundary;
 using MudSharp.Effects.Concrete;
 using MudSharp.GameItems;
 using MudSharp.Movement;
+using MoreLinq;
 
 namespace MudSharp.NPC.AI.Groups.GroupTypes;
 
@@ -483,7 +484,7 @@ Home Location: {HomeLocation?.GetFriendlyReference(voyeur).ColourName() ?? "None
         {
             if (fighter.Combat == null || fighter.CombatTarget == null)
             {
-                foreach (ICharacter threat in threats.Shuffle())
+                foreach (ICharacter threat in threats.Shuffle(Constants.Random))
                 {
                     if (!fighter.CanSee(threat))
                     {
@@ -526,7 +527,7 @@ Home Location: {HomeLocation?.GetFriendlyReference(voyeur).ColourName() ?? "None
         {
             if (fighter.Combat == null || fighter.CombatTarget == null)
             {
-                foreach (ICharacter threat in threats.Shuffle())
+                foreach (ICharacter threat in threats.Shuffle(Constants.Random))
                 {
                     if (!fighter.CanSee(threat))
                     {

--- a/MudSharpCore/NPC/AI/Groups/GroupTypes/GroupAIType.cs
+++ b/MudSharpCore/NPC/AI/Groups/GroupTypes/GroupAIType.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Body.Position;
+using MudSharp.Body.Position;
 using MudSharp.Body.Position.PositionStates;
 using MudSharp.Celestial;
 using MudSharp.Character.Heritage;
@@ -68,7 +68,7 @@ public abstract class GroupAIType : IGroupAIType, IHaveFuturemud
         public BaseGroupTypeData(IFuturemud gameworld)
         {
             Gameworld = gameworld;
-            LastEmote = DateTime.UtcNow;
+            LastEmote = RuntimeClock.UtcNow;
         }
 
         public virtual string ShowText(ICharacter voyeur)
@@ -220,7 +220,7 @@ public abstract class GroupAIType : IGroupAIType, IHaveFuturemud
     protected virtual void CheckHerdEmotes(IGroupAI herd)
     {
         BaseGroupTypeData data = (BaseGroupTypeData)herd.Data;
-        if (DateTime.UtcNow - data.LastEmote < MinimumEmoteFrequency)
+        if (RuntimeClock.UtcNow - data.LastEmote < MinimumEmoteFrequency)
         {
             return;
         }
@@ -237,7 +237,7 @@ public abstract class GroupAIType : IGroupAIType, IHaveFuturemud
         }
 
         emote.DoEmote(herd);
-        data.LastEmote = DateTime.UtcNow;
+        data.LastEmote = RuntimeClock.UtcNow;
         herd.Changed = true;
     }
 

--- a/MudSharpCore/NPC/AI/Groups/GroupTypes/HerdGrazers.cs
+++ b/MudSharpCore/NPC/AI/Groups/GroupTypes/HerdGrazers.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Body.Needs;
+using MudSharp.Body.Needs;
 using MudSharp.Body.Position;
 using MudSharp.Body.Position.PositionStates;
 using MudSharp.Celestial;
@@ -653,7 +653,7 @@ public abstract class HerdGrazers : GroupAIType
     {
         foreach (KeyValuePair<ICell, DateTime> location in data.KnownThreatLocations.ToList())
         {
-            if (DateTime.UtcNow - location.Value > TimeSpan.FromHours(12))
+            if (RuntimeClock.UtcNow - location.Value > TimeSpan.FromHours(12))
             {
                 data.KnownThreatLocations.Remove(location.Key);
                 group.Changed = true;

--- a/MudSharpCore/NPC/AI/Groups/GroupTypes/NeutralHerdGrazers.cs
+++ b/MudSharpCore/NPC/AI/Groups/GroupTypes/NeutralHerdGrazers.cs
@@ -1,9 +1,10 @@
-﻿using MudSharp.Celestial;
+using MudSharp.Celestial;
 using MudSharp.Character.Heritage;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Movement;
 using System.Globalization;
+using MoreLinq;
 
 namespace MudSharp.NPC.AI.Groups.GroupTypes;
 
@@ -161,7 +162,7 @@ public class NeutralHerdGrazers : HerdGrazers
         {
             if (fighter.Combat == null || fighter.CombatTarget == null)
             {
-                foreach (ICharacter threat in threats.Shuffle())
+                foreach (ICharacter threat in threats.Shuffle(Constants.Random))
                 {
                     if (!fighter.CanSee(threat))
                     {
@@ -189,7 +190,7 @@ public class NeutralHerdGrazers : HerdGrazers
         {
             if (fighter.Combat == null || fighter.CombatTarget == null)
             {
-                foreach (ICharacter threat in threats.Shuffle())
+                foreach (ICharacter threat in threats.Shuffle(Constants.Random))
                 {
                     if (!fighter.CanSee(threat))
                     {
@@ -236,7 +237,7 @@ public class NeutralHerdGrazers : HerdGrazers
     {
         NeutralHerdGrazerData data = (NeutralHerdGrazerData)group.Data;
         if (data.LastAdultDeath.HasValue &&
-            DateTime.UtcNow - data.LastAdultDeath.Value < TimeSpan.FromMinutes(10))
+            RuntimeClock.UtcNow - data.LastAdultDeath.Value < TimeSpan.FromMinutes(10))
         {
             return true;
         }
@@ -414,7 +415,7 @@ public class NeutralHerdGrazers : HerdGrazers
         {
             foreach (ICell location in threats.Select(x => x.Location).Distinct())
             {
-                data.KnownThreatLocations[location] = DateTime.UtcNow;
+                data.KnownThreatLocations[location] = RuntimeClock.UtcNow;
                 group.Changed = true;
             }
         }

--- a/MudSharpCore/NPC/AI/Groups/GroupTypes/PredatorGroupBase.cs
+++ b/MudSharpCore/NPC/AI/Groups/GroupTypes/PredatorGroupBase.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Body.Needs;
+using MudSharp.Body.Needs;
 using MudSharp.Body.Position;
 using MudSharp.Celestial;
 using MudSharp.Character.Heritage;
@@ -551,7 +551,7 @@ public abstract class PredatorGroupBase : GroupAIType
     {
         foreach (KeyValuePair<ICell, DateTime> location in data.KnownThreatLocations.ToList())
         {
-            if (DateTime.UtcNow - location.Value > TimeSpan.FromHours(12))
+            if (RuntimeClock.UtcNow - location.Value > TimeSpan.FromHours(12))
             {
                 data.KnownThreatLocations.Remove(location.Key);
                 group.Changed = true;
@@ -600,7 +600,7 @@ public abstract class PredatorGroupBase : GroupAIType
         {
             foreach (ICell location in threats.Select(x => x.Location).Distinct())
             {
-                data.KnownThreatLocations[location] = DateTime.UtcNow;
+                data.KnownThreatLocations[location] = RuntimeClock.UtcNow;
                 group.Changed = true;
             }
         }

--- a/MudSharpCore/NPC/AI/Groups/GroupTypes/WildlifeGroupAIType.cs
+++ b/MudSharpCore/NPC/AI/Groups/GroupTypes/WildlifeGroupAIType.cs
@@ -841,12 +841,12 @@ public sealed class WildlifeGroupAIType : GroupAIType, IGroupAIControlPolicy, IE
 		public void RecordForage(ICell cell)
 		{
 			_lastForageCellId = cell.Id;
-			_lastForageUtc = DateTime.UtcNow;
+			_lastForageUtc = RuntimeClock.UtcNow;
 		}
 
 		public bool WasRecentlyForaged(ICell cell)
 		{
-			return cell.Id == _lastForageCellId && DateTime.UtcNow - _lastForageUtc < TimeSpan.FromMinutes(5);
+			return cell.Id == _lastForageCellId && RuntimeClock.UtcNow - _lastForageUtc < TimeSpan.FromMinutes(5);
 		}
 
 		public override XElement SaveToXml()

--- a/MudSharpCore/NPC/AI/Groups/GroupTypes/WimpyHerdGrazers.cs
+++ b/MudSharpCore/NPC/AI/Groups/GroupTypes/WimpyHerdGrazers.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Celestial;
+using MudSharp.Celestial;
 using MudSharp.Character.Heritage;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
@@ -233,7 +233,7 @@ public class WimpyHerdGrazers : HerdGrazers
         {
             foreach (ICell location in threats.Select(x => x.Location).Distinct())
             {
-                data.KnownThreatLocations[location] = DateTime.UtcNow;
+                data.KnownThreatLocations[location] = RuntimeClock.UtcNow;
                 group.Changed = true;
             }
         }

--- a/MudSharpCore/NPC/AI/JudgeAI.cs
+++ b/MudSharpCore/NPC/AI/JudgeAI.cs
@@ -1,4 +1,4 @@
-﻿using MimeKit.IO.Filters;
+using MimeKit.IO.Filters;
 using MoreLinq;
 using MudSharp.Accounts;
 using MudSharp.Character.Name;
@@ -1239,7 +1239,7 @@ With each of the emotes, you can use the following tokens:
 
 	private bool DoTrialTickAwaitingLawyers(ICharacter enforcer, ICharacter defendant, OnTrial trialEffect, Gendering gender, string[] crimeNames)
 	{
-		if (DateTime.UtcNow - trialEffect.LastTrialAction < TrialPhaseDelay(trialEffect.Phase, trialEffect.Crimes.Count()))
+		if (RuntimeClock.UtcNow - trialEffect.LastTrialAction < TrialPhaseDelay(trialEffect.Phase, trialEffect.Crimes.Count()))
         {
             return false;
         }
@@ -1287,12 +1287,12 @@ With each of the emotes, you can use the following tokens:
 		if (TrialAdvocatesReady(defendant, trialEffect))
 		{
 			trialEffect.Phase = TrialPhase.Introduction;
-			trialEffect.LastTrialAction = DateTime.UtcNow;
+			trialEffect.LastTrialAction = RuntimeClock.UtcNow;
             return true;
         }
 
         // After 10 minutes, fire the lawyers that aren't there
-        if (DateTime.UtcNow - trialEffect.LastTrialAction > TimeSpan.FromMinutes(10))
+        if (RuntimeClock.UtcNow - trialEffect.LastTrialAction > TimeSpan.FromMinutes(10))
         {
 			var defender = trialEffect.Defender;
 			if (defender is not null &&
@@ -1314,7 +1314,7 @@ With each of the emotes, you can use the following tokens:
 
     private bool DoTrialTickSentencing(ICharacter enforcer, ICharacter defendant, OnTrial trialEffect, Gendering gender, string[] crimeNames)
     {
-        if (DateTime.UtcNow - trialEffect.LastTrialAction < TrialPhaseDelay(trialEffect.Phase, trialEffect.Crimes.Count()))
+        if (RuntimeClock.UtcNow - trialEffect.LastTrialAction < TrialPhaseDelay(trialEffect.Phase, trialEffect.Crimes.Count()))
         {
             return false;
         }
@@ -1440,13 +1440,13 @@ With each of the emotes, you can use the following tokens:
             defendant
         )));
 
-        trialEffect.LastTrialAction = DateTime.UtcNow;
+        trialEffect.LastTrialAction = RuntimeClock.UtcNow;
         return true;
     }
 
     private bool DoTrialTickVerdict(ICharacter enforcer, ICharacter defendant, OnTrial trialEffect, Gendering gender, string[] crimeNames)
     {
-        if (DateTime.UtcNow - trialEffect.LastTrialAction < TrialPhaseDelay(trialEffect.Phase, trialEffect.Crimes.Count()))
+        if (RuntimeClock.UtcNow - trialEffect.LastTrialAction < TrialPhaseDelay(trialEffect.Phase, trialEffect.Crimes.Count()))
         {
             return false;
         }
@@ -1456,7 +1456,7 @@ With each of the emotes, you can use the following tokens:
         {
             trialEffect.ResetCrimeQueue();
             trialEffect.Phase = TrialPhase.Sentencing;
-            trialEffect.LastTrialAction = DateTime.UtcNow;
+            trialEffect.LastTrialAction = RuntimeClock.UtcNow;
             return true;
         }
 
@@ -1580,7 +1580,7 @@ With each of the emotes, you can use the following tokens:
                 defendant
             )));
 
-            trialEffect.LastTrialAction = DateTime.UtcNow;
+            trialEffect.LastTrialAction = RuntimeClock.UtcNow;
             return true;
         }
 
@@ -1603,13 +1603,13 @@ With each of the emotes, you can use the following tokens:
             defendant
         )));
         trialEffect.Punishments[verdictCrime] = verdictCrime.Law.PunishmentStrategy.GetResult(defendant, verdictCrime, severity);
-        trialEffect.LastTrialAction = DateTime.UtcNow;
+        trialEffect.LastTrialAction = RuntimeClock.UtcNow;
         return true;
     }
 
     private bool DoTrialTickClosingArguments(ICharacter enforcer, ICharacter defendant, OnTrial trialEffect, Gendering gender, string[] crimeNames)
     {
-        if (DateTime.UtcNow - trialEffect.LastTrialAction < TrialPhaseDelay(trialEffect.Phase, trialEffect.Crimes.Count()))
+        if (RuntimeClock.UtcNow - trialEffect.LastTrialAction < TrialPhaseDelay(trialEffect.Phase, trialEffect.Crimes.Count()))
         {
             return false;
         }
@@ -1630,7 +1630,7 @@ With each of the emotes, you can use the following tokens:
             defendant
         )));
         trialEffect.Phase = TrialPhase.Verdict;
-        trialEffect.LastTrialAction = DateTime.UtcNow;
+        trialEffect.LastTrialAction = RuntimeClock.UtcNow;
         trialEffect.ResetCrimeQueue();
         return true;
     }
@@ -1639,7 +1639,7 @@ With each of the emotes, you can use the following tokens:
 	{
 		if (!trialEffect.CasesFinishedArguing() && !TrialAdvocatesReady(defendant, trialEffect))
 		{
-			if (DateTime.UtcNow - trialEffect.LastTrialAction > TimeSpan.FromMinutes(10))
+			if (RuntimeClock.UtcNow - trialEffect.LastTrialAction > TimeSpan.FromMinutes(10))
 			{
 				RecoverMissingTrialAdvocates(defendant, trialEffect);
 			}
@@ -1647,7 +1647,7 @@ With each of the emotes, you can use the following tokens:
 			return false;
 		}
 
-		if (!trialEffect.CasesFinishedArguing() && DateTime.UtcNow - trialEffect.LastTrialAction < TrialPhaseDelay(trialEffect.Phase, trialEffect.Crimes.Count()))
+		if (!trialEffect.CasesFinishedArguing() && RuntimeClock.UtcNow - trialEffect.LastTrialAction < TrialPhaseDelay(trialEffect.Phase, trialEffect.Crimes.Count()))
 		{
 			return false;
         }
@@ -1668,7 +1668,7 @@ With each of the emotes, you can use the following tokens:
             defendant
         )));
         trialEffect.Phase = TrialPhase.ClosingArguments;
-        trialEffect.LastTrialAction = DateTime.UtcNow;
+        trialEffect.LastTrialAction = RuntimeClock.UtcNow;
         return true;
     }
 
@@ -1714,7 +1714,7 @@ With each of the emotes, you can use the following tokens:
 
     private bool DoTrialTickPlea(ICharacter enforcer, ICharacter defendant, OnTrial trialEffect, Gendering gender, string[] crimeNames)
     {
-        if (DateTime.UtcNow - trialEffect.LastTrialAction < TrialPhaseDelay(trialEffect.Phase, trialEffect.Crimes.Count()))
+        if (RuntimeClock.UtcNow - trialEffect.LastTrialAction < TrialPhaseDelay(trialEffect.Phase, trialEffect.Crimes.Count()))
         {
             return false;
         }
@@ -1741,7 +1741,7 @@ With each of the emotes, you can use the following tokens:
                 defendant
             )));
             trialEffect.Pleas[pleaEffect.Crime] = true;
-            trialEffect.LastTrialAction = DateTime.UtcNow;
+            trialEffect.LastTrialAction = RuntimeClock.UtcNow;
             defendant.RemoveEffect(pleaEffect);
             return true;
         }
@@ -1765,7 +1765,7 @@ With each of the emotes, you can use the following tokens:
                 defendant
             )));
             trialEffect.Phase = TrialPhase.Case;
-            trialEffect.LastTrialAction = DateTime.UtcNow;
+            trialEffect.LastTrialAction = RuntimeClock.UtcNow;
             return true;
         }
 
@@ -1790,13 +1790,13 @@ With each of the emotes, you can use the following tokens:
 
         defendant.AddEffect(new ConsideringPlea(defendant, trialEffect.LegalAuthority, pleaCrime));
         defendant.OutputHandler.Send("\nYou can #1plead guilty#0 to plead guilty or #2plead innocent#0 to plead innocent.\nIf you do not enter a plea you will be pleading guilty by default.".SubstituteANSIColour());
-        trialEffect.LastTrialAction = DateTime.UtcNow;
+        trialEffect.LastTrialAction = RuntimeClock.UtcNow;
         return true;
     }
 
     private bool DoTrialTickCharges(ICharacter enforcer, ICharacter defendant, OnTrial trialEffect, Gendering gender, string[] crimeNames)
     {
-        if (DateTime.UtcNow - trialEffect.LastTrialAction < TrialPhaseDelay(trialEffect.Phase, trialEffect.Crimes.Count()))
+        if (RuntimeClock.UtcNow - trialEffect.LastTrialAction < TrialPhaseDelay(trialEffect.Phase, trialEffect.Crimes.Count()))
         {
             return false;
         }
@@ -1819,7 +1819,7 @@ With each of the emotes, you can use the following tokens:
         )));
         trialEffect.Phase = TrialPhase.Plea;
         trialEffect.ResetCrimeQueue();
-        trialEffect.LastTrialAction = DateTime.UtcNow;
+        trialEffect.LastTrialAction = RuntimeClock.UtcNow;
         return true;
     }
 
@@ -1841,7 +1841,7 @@ With each of the emotes, you can use the following tokens:
             defendant
         )));
         trialEffect.Phase = TrialPhase.Charges;
-        trialEffect.LastTrialAction = DateTime.UtcNow;
+        trialEffect.LastTrialAction = RuntimeClock.UtcNow;
         return true;
     }
 

--- a/MudSharpCore/NPC/AI/TrackingAggressorAI.cs
+++ b/MudSharpCore/NPC/AI/TrackingAggressorAI.cs
@@ -10,6 +10,7 @@ using MudSharp.GameItems.Inventory;
 using MudSharp.GameItems.Inventory.Plans;
 using MudSharp.Models;
 using MudSharp.NPC.AI.Strategies;
+using MoreLinq;
 
 namespace MudSharp.NPC.AI;
 
@@ -225,7 +226,7 @@ public class TrackingAggressorAI : PathingAIWithProgTargetsBase
             return false;
         }
 
-        foreach (ICharacter tch in ch.Location.CharactersInSpatialVicinity(ch, false).Except(ch).Shuffle())
+        foreach (ICharacter tch in ch.Location.CharactersInSpatialVicinity(ch, false).Except(ch).Shuffle(Constants.Random))
         {
             if (CheckForAttack(ch, tch))
             {

--- a/MudSharpCore/NPC/AI/WildAnimalHerdAI.cs
+++ b/MudSharpCore/NPC/AI/WildAnimalHerdAI.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable annotations
+#nullable enable annotations
 
 using MudSharp.Body.Needs;
 using MudSharp.Body.Position;
@@ -1394,7 +1394,7 @@ public class WildAnimalHerdAI : PathingAIBase
     private bool MinuteTickForHerd(ICharacter alpha, WildAnimalHerdPriority priority, WildAnimalHerdState state,
         List<(INPC Animal, WildAnimalHerdRole Role)> herd, WildAnimalHerdEffect effect)
     {
-        if (DateTime.UtcNow - effect.LastAlphaMinuteTick < TimeSpan.FromSeconds(30))
+        if (RuntimeClock.UtcNow - effect.LastAlphaMinuteTick < TimeSpan.FromSeconds(30))
         {
             return false;
         }
@@ -1407,28 +1407,28 @@ public class WildAnimalHerdAI : PathingAIBase
         switch (effect.State)
         {
             case WildAnimalHerdState.Alert:
-                if (DateTime.UtcNow - effect.LastStateChange > TimeSpan.FromMinutes(5))
+                if (RuntimeClock.UtcNow - effect.LastStateChange > TimeSpan.FromMinutes(5))
                 {
                     effect.State--;
                 }
 
                 break;
             case WildAnimalHerdState.Spooked:
-                if (DateTime.UtcNow - effect.LastStateChange > TimeSpan.FromMinutes(20))
+                if (RuntimeClock.UtcNow - effect.LastStateChange > TimeSpan.FromMinutes(20))
                 {
                     effect.State--;
                 }
 
                 break;
             case WildAnimalHerdState.Desperate:
-                if (DateTime.UtcNow - effect.LastStateChange > TimeSpan.FromMinutes(120))
+                if (RuntimeClock.UtcNow - effect.LastStateChange > TimeSpan.FromMinutes(120))
                 {
                     effect.State--;
                 }
 
                 break;
             case WildAnimalHerdState.None:
-                if (DateTime.UtcNow - effect.LastStateChange > TimeSpan.FromHours(24))
+                if (RuntimeClock.UtcNow - effect.LastStateChange > TimeSpan.FromHours(24))
                 {
                     effect.AvoidedLocations.Clear();
                 }
@@ -1717,7 +1717,7 @@ public class WildAnimalHerdAI : PathingAIBase
             return false;
         }
 
-        if (effect.EntryReactionCooldown > DateTime.UtcNow)
+        if (effect.EntryReactionCooldown > RuntimeClock.UtcNow)
         {
             return false;
         }
@@ -1738,7 +1738,7 @@ public class WildAnimalHerdAI : PathingAIBase
         if (EscalateThreat(character, herd, stressors, effect.State))
         {
             effect.State = (WildAnimalHerdState)((int)effect.State + 1);
-            effect.EntryReactionCooldown = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+            effect.EntryReactionCooldown = RuntimeClock.UtcNow + TimeSpan.FromSeconds(10);
         }
 
         _stateReactionDictionary[effect.State]?.DoReaction(character,

--- a/MudSharpCore/NPC/NPC.cs
+++ b/MudSharpCore/NPC/NPC.cs
@@ -252,6 +252,12 @@ public class NPC : Character.Character, INPC
         _npcID = item.Item2.Id;
     }
 
+    internal void InitialiseCombatSimulationIdentity(long characterId, long bodyId, long instanceId, long npcId)
+    {
+        base.InitialiseCombatSimulationIdentity(characterId, bodyId, instanceId);
+        _npcID = npcId;
+    }
+
     protected override ICharacterCombatSettings ResolveCombatSettingsAfterInitialisation()
     {
         return MudSharp.Combat.CharacterCombatSettingsResolver.ResolveFallback(this, Template);

--- a/MudSharpCore/RPG/Checks/BranchCheck.cs
+++ b/MudSharpCore/RPG/Checks/BranchCheck.cs
@@ -49,11 +49,13 @@ public class BranchCheck : FrameworkItem, ICheck
         }
 
         TraitExpression expr = IncreasedBranchChance.IncreasedCapExpression;
-        expr.Formula.Parameters["attempts"] = effect.GetAttemptsForSkill(sd);
-        expr.Formula.Parameters["base"] = TargetNumberExpression.Evaluate(checkee, trait) * merits;
-
         effect.UseSkill(sd);
-        return expr.EvaluateWith(checkee, values: customParameters);
+        return expr.EvaluateWith(checkee, values:
+        [
+            ("attempts", effect.GetAttemptsForSkill(sd)),
+            ("base", TargetNumberExpression.Evaluate(checkee, trait) * merits),
+            ..customParameters
+        ]);
     }
 
     public CheckOutcome Check(IPerceivableHaveTraits checkee, Difficulty difficulty, IPerceivable target = null,

--- a/MudSharpCore/RPG/Checks/Check.cs
+++ b/MudSharpCore/RPG/Checks/Check.cs
@@ -118,7 +118,7 @@ public class StandardCheck : FrameworkItem, ICheck
             abject = true;
         }
 
-        if (trait != null && !TargetNumberExpression.Formula.Parameters.Any(x => x.Key.EqualTo("variable")))
+        if (trait != null && !TargetNumberExpression.Formula.ParameterNames.Any(x => x.EqualTo("variable")))
         {
             trait = null;
         }

--- a/MudSharpCore/RPG/Law/AutomaticCrimeExtensions.cs
+++ b/MudSharpCore/RPG/Law/AutomaticCrimeExtensions.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Construction;
+using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Economy.Property;
 using MudSharp.Effects.Concrete;
@@ -96,7 +96,7 @@ public static class AutomaticCrimeExtensions
 			return;
 		}
 
-		var now = DateTime.UtcNow;
+		var now = RuntimeClock.UtcNow;
 		var minimumSeverity = MinimumMurderWoundSeverity(victim.Gameworld);
 		var attributionWindow = MurderWoundAttributionWindow(victim.Gameworld);
 		var includeFriendlyWounds = IncludeFriendlyMurderWounds(victim.Gameworld);

--- a/MudSharpCore/RPG/Law/Crime.cs
+++ b/MudSharpCore/RPG/Law/Crime.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Accounts;
+using MudSharp.Accounts;
 using MudSharp.Character.Name;
 using MudSharp.Commands.Trees;
 using MudSharp.Construction;
@@ -33,7 +33,7 @@ public class Crime : LateInitialisingItem, ICrime
         _criminal = criminal;
         VictimId = victim is null ? null : CharacterInstanceIdentityComparer.IdentityId(victim);
         TimeOfCrime = resolvedCrimeLocation.DateTime();
-        RealTimeOfCrime = DateTime.UtcNow;
+        RealTimeOfCrime = RuntimeClock.UtcNow;
         CrimeLocation = resolvedCrimeLocation;
         _witnessIds.AddRange(witnesses.Select(CharacterInstanceIdentityComparer.IdentityId));
         Law = law;

--- a/MudSharpCore/RPG/Law/LegalAuthority.cs
+++ b/MudSharpCore/RPG/Law/LegalAuthority.cs
@@ -1,4 +1,4 @@
-﻿using MoreLinq.Extensions;
+using MoreLinq.Extensions;
 using MudSharp.Character.Name;
 using MudSharp.Construction;
 using MudSharp.Database;
@@ -669,6 +669,11 @@ public partial class LegalAuthority : SaveableItem, ILegalAuthority
         IGameItem item, string additionalInformation, IEnumerable<ICharacter> explicitWitnesses, bool notifyVictim,
         ICell crimeLocation)
     {
+		if (RuntimeSideEffectContext.IsCrimeCreationSuppressed)
+		{
+			return Enumerable.Empty<ICrime>();
+		}
+
         if (criminal.IsAdministrator())
         {
             return Enumerable.Empty<ICrime>();
@@ -696,7 +701,7 @@ public partial class LegalAuthority : SaveableItem, ILegalAuthority
             var criminalIdentityId = CharacterInstanceIdentityComparer.IdentityId(criminal);
             if (ShouldSuppressAutomaticRepeatCrime(law,
                     _unknownCrimesLookup[criminalIdentityId].Concat(_knownCrimesLookup[criminalIdentityId]), victim,
-                    item, location, DateTime.UtcNow))
+                    item, location, RuntimeClock.UtcNow))
             {
                 continue;
             }

--- a/MudSharpCore/RPG/Law/Patrol.cs
+++ b/MudSharpCore/RPG/Law/Patrol.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Construction;
+using MudSharp.Construction;
 using MudSharp.Database;
 using MudSharp.Effects.Concrete;
 using MudSharp.Framework.Save;
@@ -22,8 +22,8 @@ public class Patrol : SaveableItem, IPatrol
             ? new CorpseRecoveryPatrolStrategy(Gameworld)
             : route.PatrolStrategy;
         PatrolPhase = PatrolPhase.Preperation;
-        PatrolStartTime = DateTime.UtcNow;
-        LastArrivedTime = DateTime.UtcNow;
+        PatrolStartTime = RuntimeClock.UtcNow;
+        LastArrivedTime = RuntimeClock.UtcNow;
         PatrolLeader = leader;
         ActiveCorpseRecoveryReport = corpseRecoveryReport;
         TargetCrime = targetCrime;
@@ -70,8 +70,8 @@ public class Patrol : SaveableItem, IPatrol
         PatrolRoute = authority.PatrolRoutes.First(x => x.Id == patrol.PatrolRouteId);
         _id = patrol.Id;
         PatrolPhase = (PatrolPhase)patrol.PatrolPhase;
-        PatrolStartTime = DateTime.UtcNow;
-        LastArrivedTime = DateTime.UtcNow;
+        PatrolStartTime = RuntimeClock.UtcNow;
+        LastArrivedTime = RuntimeClock.UtcNow;
         LastMajorNode = Gameworld.Cells.Get(patrol.LastMajorNodeId ?? 0);
         NextMajorNode = Gameworld.Cells.Get(patrol.NextMajorNodeId ?? 0);
         _members.AddRange(patrol.PatrolMembers

--- a/MudSharpCore/RPG/Law/PatrolStrategies/CorpseRecoveryPatrolStrategy.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/CorpseRecoveryPatrolStrategy.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Construction.Boundary;
+using MudSharp.Construction.Boundary;
 using MudSharp.Economy.Estates;
 using MudSharp.Effects.Concrete;
 using MudSharp.GameItems;
@@ -71,7 +71,7 @@ public class CorpseRecoveryPatrolStrategy : PatrolStrategyBase
         if (HasReachedPatrolDestination(patrol.PatrolLeader, report.Corpse))
         {
             patrol.PatrolPhase = PatrolPhase.Patrol;
-            patrol.LastArrivedTime = DateTime.UtcNow;
+            patrol.LastArrivedTime = RuntimeClock.UtcNow;
             return;
         }
 
@@ -98,7 +98,7 @@ public class CorpseRecoveryPatrolStrategy : PatrolStrategyBase
             return;
         }
 
-        if (DateTime.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
+        if (RuntimeClock.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
         {
             report.MarkFailed();
             patrol.ActiveCorpseRecoveryReport = null;

--- a/MudSharpCore/RPG/Law/PatrolStrategies/CrimeTargetedPatrolStrategyBase.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/CrimeTargetedPatrolStrategyBase.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Construction;
+using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Effects.Concrete;
 using MudSharp.Movement;
@@ -258,7 +258,7 @@ public abstract class CrimeTargetedPatrolStrategyBase : ArmedPatrolStrategy, ICr
 			return;
 		}
 
-		if (DateTime.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
+		if (RuntimeClock.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
 		{
 			patrol.CompletePatrol();
 		}
@@ -269,7 +269,7 @@ public abstract class CrimeTargetedPatrolStrategyBase : ArmedPatrolStrategy, ICr
 		if (patrol.LastMajorNode != node)
 		{
 			patrol.LastMajorNode = node;
-			patrol.LastArrivedTime = DateTime.UtcNow;
+			patrol.LastArrivedTime = RuntimeClock.UtcNow;
 		}
 	}
 

--- a/MudSharpCore/RPG/Law/PatrolStrategies/DoorDutiesPatrolStrategy.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/DoorDutiesPatrolStrategy.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Construction;
+using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Effects.Concrete;
 using System.Globalization;
@@ -211,7 +211,7 @@ Normal uses the assigned DoorguardAI's existing will-open rules, such as clan-br
 			HasKeysForCells(patrol.PatrolLeader, dutyCells))
 		{
 			patrol.PatrolPhase = PatrolPhase.Patrol;
-			patrol.LastArrivedTime = DateTime.UtcNow;
+			patrol.LastArrivedTime = RuntimeClock.UtcNow;
 			patrol.LastMajorNode = patrol.LegalAuthority.MarshallingLocation;
 			patrol.NextMajorNode = dutyLocation;
 			EnableDoorGuardMode(patrol);
@@ -243,7 +243,7 @@ Normal uses the assigned DoorguardAI's existing will-open rules, such as clan-br
 
 		if (patrol.PatrolMembers.Any(x => x.Location != patrol.LegalAuthority.PreparingLocation))
 		{
-			if (DateTime.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
+			if (RuntimeClock.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
 			{
 				AbortDoorDuty(patrol);
 			}
@@ -253,7 +253,7 @@ Normal uses the assigned DoorguardAI's existing will-open rules, such as clan-br
 
 		if (!HasKeysForCells(patrol.PatrolLeader, dutyCells))
 		{
-			if (DateTime.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
+			if (RuntimeClock.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
 			{
 				AbortDoorDuty(patrol);
 			}
@@ -261,14 +261,14 @@ Normal uses the assigned DoorguardAI's existing will-open rules, such as clan-br
 			return;
 		}
 
-		if (DateTime.UtcNow - patrol.LastArrivedTime <= TimeSpan.FromMinutes(1))
+		if (RuntimeClock.UtcNow - patrol.LastArrivedTime <= TimeSpan.FromMinutes(1))
 		{
 			return;
 		}
 
 		FormParty(patrol);
 		patrol.PatrolPhase = PatrolPhase.Deployment;
-		patrol.LastArrivedTime = DateTime.UtcNow;
+		patrol.LastArrivedTime = RuntimeClock.UtcNow;
 		patrol.LastMajorNode = patrol.PatrolLeader.Location;
 		patrol.NextMajorNode = dutyLocation;
 	}
@@ -292,7 +292,7 @@ Normal uses the assigned DoorguardAI's existing will-open rules, such as clan-br
 			EnableDoorGuardMode(patrol);
 		}
 
-		if (DateTime.UtcNow - patrol.LastArrivedTime >= patrol.PatrolRoute.LingerTimeMajorNode)
+		if (RuntimeClock.UtcNow - patrol.LastArrivedTime >= patrol.PatrolRoute.LingerTimeMajorNode)
 		{
 			CompleteDoorDuty(patrol);
 			return;
@@ -322,7 +322,7 @@ Normal uses the assigned DoorguardAI's existing will-open rules, such as clan-br
 					PathSearch.IgnorePresenceOfDoors).ToList();
 				if (path.Count == 0)
 				{
-					if (DateTime.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
+					if (RuntimeClock.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
 					{
 						AbortDoorDuty(patrol);
 						return;

--- a/MudSharpCore/RPG/Law/PatrolStrategies/ExecutionPatrolStrategy.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/ExecutionPatrolStrategy.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Body;
+using MudSharp.Body;
 using MudSharp.Combat;
 using MudSharp.Combat.Moves;
 using MudSharp.Construction;
@@ -48,7 +48,7 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 	private ICharacter _condemned;
 	private long _condemnedId;
 	private ExecutionPatrolStage _stage = ExecutionPatrolStage.SelectingTarget;
-	private DateTime _stageBegan = DateTime.UtcNow;
+	private DateTime _stageBegan = RuntimeClock.UtcNow;
 	private DateTime _lastAction = DateTime.MinValue;
 	private int _scriptIndex;
 	private int _executionAttempts;
@@ -341,7 +341,7 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 	private void SetStage(ExecutionPatrolStage stage)
 	{
 		_stage = stage;
-		_stageBegan = DateTime.UtcNow;
+		_stageBegan = RuntimeClock.UtcNow;
 		_lastAction = DateTime.MinValue;
 	}
 
@@ -420,7 +420,7 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 
 		if (!MoveCharacterTo(patrol.PatrolLeader, equipment, 25))
 		{
-			if (DateTime.UtcNow - _stageBegan > TimeSpan.FromMinutes(3))
+			if (RuntimeClock.UtcNow - _stageBegan > TimeSpan.FromMinutes(3))
 			{
 				AbortExecution(patrol);
 			}
@@ -440,7 +440,7 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 
 		if (patrol.PatrolMembers.Any(x => !HasReachedPatrolDestination(x, equipment)))
 		{
-			if (DateTime.UtcNow - _stageBegan > TimeSpan.FromMinutes(3))
+			if (RuntimeClock.UtcNow - _stageBegan > TimeSpan.FromMinutes(3))
 			{
 				AbortExecution(patrol);
 			}
@@ -450,7 +450,7 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 
 		if (!EquipmentReady(patrol))
 		{
-			if (DateTime.UtcNow - _stageBegan > TimeSpan.FromMinutes(3))
+			if (RuntimeClock.UtcNow - _stageBegan > TimeSpan.FromMinutes(3))
 			{
 				AbortExecution(patrol);
 			}
@@ -460,7 +460,7 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 
 		FormParty(patrol);
 		patrol.PatrolPhase = PatrolPhase.Deployment;
-		patrol.LastArrivedTime = DateTime.UtcNow;
+		patrol.LastArrivedTime = RuntimeClock.UtcNow;
 		patrol.LastMajorNode = equipment;
 		SetStage(ExecutionPatrolStage.RetrievingPrisoner);
 	}
@@ -576,7 +576,7 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 	{
 		if (!MoveLeaderToCharacter(patrol, _condemned))
 		{
-			if (DateTime.UtcNow - _stageBegan > TimeSpan.FromMinutes(3))
+			if (RuntimeClock.UtcNow - _stageBegan > TimeSpan.FromMinutes(3))
 			{
 				AbortExecution(patrol);
 			}
@@ -609,7 +609,7 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 			return;
 		}
 
-		if (DateTime.UtcNow - _stageBegan < TimeSpan.FromSeconds(ComplianceWindowSeconds))
+		if (RuntimeClock.UtcNow - _stageBegan < TimeSpan.FromSeconds(ComplianceWindowSeconds))
 		{
 			return;
 		}
@@ -789,7 +789,7 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 
 		if (!MoveCharacterTo(patrol.PatrolLeader, executionLocation))
 		{
-			if (DateTime.UtcNow - _stageBegan > TimeSpan.FromMinutes(3))
+			if (RuntimeClock.UtcNow - _stageBegan > TimeSpan.FromMinutes(3))
 			{
 				AbortExecution(patrol);
 			}
@@ -969,11 +969,11 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 		{
 			DoEmote(patrol.PatrolLeader, LastWordsEmote, _condemned);
 			_lastWordsEmoteSent = true;
-			_lastAction = DateTime.UtcNow;
+			_lastAction = RuntimeClock.UtcNow;
 			return;
 		}
 
-		if (DateTime.UtcNow - _lastAction < TimeSpan.FromSeconds(LastWordsSeconds))
+		if (RuntimeClock.UtcNow - _lastAction < TimeSpan.FromSeconds(LastWordsSeconds))
 		{
 			return;
 		}
@@ -995,13 +995,13 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 		}
 
 		if (_lastAction != DateTime.MinValue &&
-		    DateTime.UtcNow - _lastAction < TimeSpan.FromSeconds(ScriptDelaySeconds))
+		    RuntimeClock.UtcNow - _lastAction < TimeSpan.FromSeconds(ScriptDelaySeconds))
 		{
 			return;
 		}
 
 		DoEmote(patrol.PatrolLeader, _executionScript[_scriptIndex++], _condemned);
-		_lastAction = DateTime.UtcNow;
+		_lastAction = RuntimeClock.UtcNow;
 	}
 
 	private void HandleKilling(IPatrol patrol)
@@ -1027,7 +1027,7 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 
 		if (!attempted)
 		{
-			if (DateTime.UtcNow - _stageBegan > TimeSpan.FromMinutes(3))
+			if (RuntimeClock.UtcNow - _stageBegan > TimeSpan.FromMinutes(3))
 			{
 				AbortExecution(patrol);
 			}
@@ -1053,7 +1053,7 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 			return;
 		}
 
-		if (DateTime.UtcNow - _stageBegan >= TimeSpan.FromSeconds(DeathConfirmationSeconds))
+		if (RuntimeClock.UtcNow - _stageBegan >= TimeSpan.FromSeconds(DeathConfirmationSeconds))
 		{
 			SetStage(ExecutionPatrolStage.Killing);
 		}
@@ -1241,7 +1241,7 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 		_condemned = null;
 		_condemnedId = 0;
 		_stage = ExecutionPatrolStage.SelectingTarget;
-		_stageBegan = DateTime.UtcNow;
+		_stageBegan = RuntimeClock.UtcNow;
 		_lastAction = DateTime.MinValue;
 		_scriptIndex = 0;
 		_executionAttempts = 0;

--- a/MudSharpCore/RPG/Law/PatrolStrategies/InvestigationPatrolStrategy.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/InvestigationPatrolStrategy.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Construction;
+using MudSharp.Construction;
 using System.Globalization;
 
 namespace MudSharp.RPG.Law.PatrolStrategies;
@@ -60,7 +60,7 @@ public class InvestigationPatrolStrategy : CrimeTargetedPatrolStrategyBase
 	protected override void HandleArrivedAtTargetNode(IPatrol patrol, ICell node)
 	{
 		base.HandleArrivedAtTargetNode(patrol, node);
-		if (DateTime.UtcNow - patrol.LastArrivedTime < SceneSearchTime)
+		if (RuntimeClock.UtcNow - patrol.LastArrivedTime < SceneSearchTime)
 		{
 			return;
 		}

--- a/MudSharpCore/RPG/Law/PatrolStrategies/JudgePatrolStrategy.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/JudgePatrolStrategy.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Commands.Trees;
+using MudSharp.Commands.Trees;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Effects.Concrete;
@@ -21,7 +21,7 @@ public class JudgePatrolStrategy : PatrolStrategyBase
         if (patrol.PatrolMembers.All(x => x.Location == patrol.LegalAuthority.CourtLocation))
         {
             patrol.PatrolPhase = PatrolPhase.Patrol;
-            patrol.LastArrivedTime = DateTime.UtcNow;
+            patrol.LastArrivedTime = RuntimeClock.UtcNow;
             patrol.LastMajorNode = patrol.LegalAuthority.CourtLocation;
             patrol.NextMajorNode = patrol.LegalAuthority.CourtLocation;
             return;
@@ -42,7 +42,7 @@ public class JudgePatrolStrategy : PatrolStrategyBase
                   .CharactersInImmediateVicinity(patrol.PatrolLeader)
                   .All(x => !x.EffectsOfType<OnTrial>(y => y.LegalAuthority == patrol.LegalAuthority).Any()))
         {
-            if (DateTime.UtcNow - patrol.LastArrivedTime >= patrol.PatrolRoute.LingerTimeMajorNode)
+            if (RuntimeClock.UtcNow - patrol.LastArrivedTime >= patrol.PatrolRoute.LingerTimeMajorNode)
             {
                 patrol.CompletePatrol();
                 return;

--- a/MudSharpCore/RPG/Law/PatrolStrategies/PatrolStrategyBase.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/PatrolStrategyBase.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character.Name;
+using MudSharp.Character.Name;
 using MudSharp.Combat;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
@@ -338,7 +338,7 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
                     PathSearch.IgnorePresenceOfDoors).ToList();
                 if (path.Count == 0)
                 {
-                    if (DateTime.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
+                    if (RuntimeClock.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
                     {
                         // Abort patrol
                         patrol.AbortPatrol();
@@ -426,7 +426,7 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
         if (patrol.PatrolLeader.Location == patrol.LegalAuthority.MarshallingLocation)
         {
             patrol.PatrolPhase = PatrolPhase.Patrol;
-            patrol.LastArrivedTime = DateTime.UtcNow;
+            patrol.LastArrivedTime = RuntimeClock.UtcNow;
             patrol.LastMajorNode = patrol.LegalAuthority.MarshallingLocation;
             return;
         }
@@ -461,7 +461,7 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
 				return;
 			}
 
-			if (DateTime.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
+			if (RuntimeClock.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
 			{
 				patrol.AbortPatrol();
 			}
@@ -865,11 +865,11 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
             DoPreparationRoomAction(member);
         }
 
-        if (DateTime.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(1))
+        if (RuntimeClock.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(1))
         {
             FormParty(patrol);
             patrol.PatrolPhase = PatrolPhase.Deployment;
-            patrol.LastArrivedTime = DateTime.UtcNow;
+            patrol.LastArrivedTime = RuntimeClock.UtcNow;
             patrol.LastMajorNode = patrol.PatrolLeader.Location;
             patrol.NextMajorNode = patrol.PatrolRoute.PatrolNodes.First();
         }

--- a/MudSharpCore/RPG/Law/PatrolStrategies/ProsectutorPatrolStrategy.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/ProsectutorPatrolStrategy.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Construction.Boundary;
+using MudSharp.Construction.Boundary;
 using MudSharp.Construction;
 using MudSharp.Effects.Concrete;
 
@@ -18,7 +18,7 @@ public class ProsectutorPatrolStrategy : PatrolStrategyBase
         if (patrol.PatrolMembers.All(x => x.Location == patrol.LegalAuthority.CourtLocation))
         {
             patrol.PatrolPhase = PatrolPhase.Patrol;
-            patrol.LastArrivedTime = DateTime.UtcNow;
+            patrol.LastArrivedTime = RuntimeClock.UtcNow;
             patrol.LastMajorNode = patrol.LegalAuthority.CourtLocation;
             patrol.NextMajorNode = patrol.LegalAuthority.CourtLocation;
             return;
@@ -39,7 +39,7 @@ public class ProsectutorPatrolStrategy : PatrolStrategyBase
                   .CharactersInImmediateVicinity(patrol.PatrolLeader)
                   .All(x => !x.EffectsOfType<OnTrial>(y => y.LegalAuthority == patrol.LegalAuthority).Any()))
         {
-            if (DateTime.UtcNow - patrol.LastArrivedTime >= patrol.PatrolRoute.LingerTimeMajorNode)
+            if (RuntimeClock.UtcNow - patrol.LastArrivedTime >= patrol.PatrolRoute.LingerTimeMajorNode)
             {
                 patrol.CompletePatrol();
                 return;
@@ -72,7 +72,7 @@ public class ProsectutorPatrolStrategy : PatrolStrategyBase
                     PathSearch.IgnorePresenceOfDoors).ToList();
                 if (path.Count == 0)
                 {
-                    if (DateTime.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
+                    if (RuntimeClock.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
                     {
                         // Abort patrol
                         patrol.AbortPatrol();

--- a/MudSharpCore/RPG/Law/PatrolStrategies/ReactivePatrolStrategy.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/ReactivePatrolStrategy.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Construction;
+using MudSharp.Construction;
 using MudSharp.TimeAndDate;
 using System.Globalization;
 
@@ -48,7 +48,7 @@ public class ReactivePatrolStrategy : CrimeTargetedPatrolStrategyBase
 		       crime.CrimeLocation is not null &&
 		       crime.Law.CrimeType.IsViolentCrime() &&
 		       crime.Law.EnforcementStrategy > EnforcementStrategy.NoActiveEnforcement &&
-		       DateTime.UtcNow - crime.RealTimeOfCrime <= dispatchWindow;
+		       RuntimeClock.UtcNow - crime.RealTimeOfCrime <= dispatchWindow;
 	}
 
 	protected override bool TargetCrimeStillValid(IPatrol patrol)
@@ -61,14 +61,14 @@ public class ReactivePatrolStrategy : CrimeTargetedPatrolStrategyBase
 	{
 		base.HandleArrivedAtTargetNode(patrol, node);
 
-		if (DateTime.UtcNow - patrol.PatrolStartTime >= MaximumDuration ||
+		if (RuntimeClock.UtcNow - patrol.PatrolStartTime >= MaximumDuration ||
 		    !patrol.PatrolRoute.TimeOfDays.Contains(patrol.PatrolLeader.Location.CurrentTimeOfDay))
 		{
 			patrol.CompletePatrol();
 			return;
 		}
 
-		if (DateTime.UtcNow - patrol.LastArrivedTime < patrol.PatrolRoute.LingerTimeMajorNode)
+		if (RuntimeClock.UtcNow - patrol.LastArrivedTime < patrol.PatrolRoute.LingerTimeMajorNode)
 		{
 			return;
 		}

--- a/MudSharpCore/RPG/Law/PatrolStrategies/RouteStrategyBase.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/RouteStrategyBase.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character.Name;
+using MudSharp.Character.Name;
 using MudSharp.Combat;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
@@ -28,7 +28,7 @@ public abstract class RouteStrategyBase : PatrolStrategyBase
         if (patrol.PatrolLeader.Location == patrol.NextMajorNode)
         {
             patrol.LastMajorNode = patrol.NextMajorNode;
-            patrol.LastArrivedTime = DateTime.UtcNow;
+            patrol.LastArrivedTime = RuntimeClock.UtcNow;
             if (patrol.NextMajorNode == patrol.PatrolRoute.PatrolNodes.Last())
             {
                 patrol.NextMajorNode = patrol.PatrolRoute.PatrolNodes.First();
@@ -41,13 +41,13 @@ public abstract class RouteStrategyBase : PatrolStrategyBase
         }
 
         if (patrol.NextMajorNode is null &&
-            DateTime.UtcNow - patrol.LastArrivedTime >= patrol.PatrolRoute.LingerTimeMajorNode)
+            RuntimeClock.UtcNow - patrol.LastArrivedTime >= patrol.PatrolRoute.LingerTimeMajorNode)
         {
             patrol.CompletePatrol();
             return;
         }
 
-        if (DateTime.UtcNow - patrol.LastArrivedTime >= patrol.PatrolRoute.LingerTimeMajorNode)
+        if (RuntimeClock.UtcNow - patrol.LastArrivedTime >= patrol.PatrolRoute.LingerTimeMajorNode)
         {
             FollowingPath effect = patrol.PatrolLeader.CombinedEffectsOfType<FollowingPath>().FirstOrDefault();
             if (effect != null)
@@ -69,7 +69,7 @@ public abstract class RouteStrategyBase : PatrolStrategyBase
 				return;
 			}
 
-			if (DateTime.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
+			if (RuntimeClock.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
 			{
 				patrol.AbortPatrol();
 			}

--- a/MudSharpCore/RPG/Law/PatrolStrategies/SheriffPatrolStrategy.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/SheriffPatrolStrategy.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Construction;
+using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Effects.Concrete;
 using MudSharp.TimeAndDate;
@@ -19,7 +19,7 @@ public class SheriffPatrolStrategy : PatrolStrategyBase
         if (patrol.PatrolMembers.All(x => x.Location == patrol.LegalAuthority.CourtLocation))
         {
             patrol.PatrolPhase = PatrolPhase.Patrol;
-            patrol.LastArrivedTime = DateTime.UtcNow;
+            patrol.LastArrivedTime = RuntimeClock.UtcNow;
             patrol.LastMajorNode = patrol.LegalAuthority.CourtLocation;
             patrol.NextMajorNode = patrol.LegalAuthority.CourtLocation;
             return;
@@ -88,7 +88,7 @@ public class SheriffPatrolStrategy : PatrolStrategyBase
         trialCandidate.Location.Leave(trialCandidate);
         trialCandidate.RoomLayer = RoomLayer.GroundLevel;
         authority.CourtLocation.Enter(trialCandidate);
-        trialCandidate.AddEffect(new OnTrial(trialCandidate, authority, DateTime.UtcNow, crimes));
+        trialCandidate.AddEffect(new OnTrial(trialCandidate, authority, RuntimeClock.UtcNow, crimes));
         trialCandidate.Body.Look(true);
         trialCandidate.OutputHandler.Handle(new EmoteOutput(
             new Emote(Gameworld.GetStaticString("FetchCriminalForTrialEmoteCourt"), trialCandidate, trialCandidate),
@@ -107,7 +107,7 @@ public class SheriffPatrolStrategy : PatrolStrategyBase
                   .CharactersInImmediateVicinity(patrol.PatrolLeader)
                   .All(x => !x.EffectsOfType<OnTrial>(y => y.LegalAuthority == patrol.LegalAuthority).Any()))
         {
-            if (DateTime.UtcNow - patrol.LastArrivedTime >= patrol.PatrolRoute.LingerTimeMajorNode)
+            if (RuntimeClock.UtcNow - patrol.LastArrivedTime >= patrol.PatrolRoute.LingerTimeMajorNode)
             {
                 patrol.CompletePatrol();
                 return;
@@ -139,7 +139,7 @@ public class SheriffPatrolStrategy : PatrolStrategyBase
                     PathSearch.IgnorePresenceOfDoors).ToList();
                 if (path.Count == 0)
                 {
-                    if (DateTime.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
+                    if (RuntimeClock.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
                     {
                         // Abort patrol
                         patrol.AbortPatrol();

--- a/MudSharpCore/RPG/Law/PatrolStrategies/StationEnforcerPatrolStrategy.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/StationEnforcerPatrolStrategy.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Construction;
+using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Effects.Concrete;
 
@@ -19,7 +19,7 @@ public class StationEnforcerPatrolStrategy : PatrolStrategyBase
         if (patrol.PatrolMembers.All(x => x.Location == patrol.PatrolRoute.PatrolNodes.First()))
         {
             patrol.PatrolPhase = PatrolPhase.Patrol;
-            patrol.LastArrivedTime = DateTime.UtcNow;
+            patrol.LastArrivedTime = RuntimeClock.UtcNow;
             patrol.LastMajorNode = patrol.LegalAuthority.MarshallingLocation;
             patrol.NextMajorNode = patrol.PatrolRoute.PatrolNodes.First();
             return;
@@ -35,7 +35,7 @@ public class StationEnforcerPatrolStrategy : PatrolStrategyBase
             return;
         }
 
-        if (DateTime.UtcNow - patrol.LastArrivedTime >= patrol.PatrolRoute.LingerTimeMajorNode)
+        if (RuntimeClock.UtcNow - patrol.LastArrivedTime >= patrol.PatrolRoute.LingerTimeMajorNode)
         {
             patrol.CompletePatrol();
             return;
@@ -66,7 +66,7 @@ public class StationEnforcerPatrolStrategy : PatrolStrategyBase
                     PathSearch.IgnorePresenceOfDoors).ToList();
                 if (path.Count == 0)
                 {
-                    if (DateTime.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
+                    if (RuntimeClock.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
                     {
                         // Abort patrol
                         patrol.AbortPatrol();

--- a/MudSharpCore/RPG/Merits/CharacterMerits/OrganHitChanceReductionMerit.cs
+++ b/MudSharpCore/RPG/Merits/CharacterMerits/OrganHitChanceReductionMerit.cs
@@ -207,8 +207,7 @@ public class OrganHitChanceReductionMerit : CharacterMeritBase, IOrganHitReducti
             return false;
         }
 
-        HitChanceExpression.Parameters["chance"] = organInfo.Value.HitChance;
-        if (RandomUtilities.Random(0, 100) <= (double)HitChanceExpression.Evaluate())
+        if (RandomUtilities.Random(0, 100) <= HitChanceExpression.EvaluateDoubleWith(("chance", organInfo.Value.HitChance)))
         {
             return true;
         }

--- a/MudSharpCore/Work/Crafts/Craft.cs
+++ b/MudSharpCore/Work/Crafts/Craft.cs
@@ -451,10 +451,10 @@ public class Craft : Framework.Revision.EditableItem, ICraft
         }
 
         Outcome outcome = component.QualityCheckOutcome;
-        QualityFormula?.Formula.Parameters["outcome"] = (int)outcome;
 
         ItemQuality outcomeQuality = (ItemQuality)Math.Min((int)ItemQuality.Legendary,
-            Math.Max(Convert.ToInt32(QualityFormula?.Evaluate(character, CheckTrait) ?? 0), (int)ItemQuality.Terrible));
+            Math.Max(Convert.ToInt32(QualityFormula?.EvaluateWith(character, CheckTrait,
+                values: [("outcome", (int)outcome)]) ?? 0), (int)ItemQuality.Terrible));
         ItemQuality netToolQuality = component.UsedToolQualities.Values.GetNetQuality();
         ItemQuality netInputQuality = component.ConsumedInputs
                                        .Select(x => (x.Value.Data.InputQuality, x.Key.InputQualityWeight))


### PR DESCRIPTION
## Summary

- Adds the founder-facing impdebug combatsim workflow for staged one-on-one and group combat simulations.
- Runs combat, heartbeat, effect, health, and time-dependent work on an isolated virtual clock with seeded deterministic randomness.
- Adds outcomes, bounded transcripts, batches, execution fingerprints, and paged random/state/materialisation traces.
- Suppresses crime creation, ordinary save-queue work, and EF SaveChanges calls in the simulation; production runs require explicit confirmation and warn about direct Dapper or external-hook side effects.
- Documents the runtime and persistence boundary.

## Validation

- MudSharpCore Debug build succeeded with only the two existing nullable warnings.
- MudSharpCore tests: 2,470/2,470; focused simulation/scheduler tests: 31/31.
- ExpressionEngine tests: 23/23.
- FutureMUDLibrary tests: 433/433.
- Live LabMUD validation on labmud_dbo covered templates 20/21/22, robot templates 1/60/72/76, group combat, and five identical-seed replay runs with matching fingerprints.
- git diff --check passed.

## Notes

- No EF migration is required because this is a runtime isolation change without model or schema changes.
- Direct SQL/Dapper and external service calls from authored hooks remain outside the transactional safety boundary and are reported to the operator.