### PR TITLE
Expand combat simulation staging and participant starts

### DIFF
--- a/Design Documents/Combat/Accelerated_Combat_Simulation.md
+++ b/Design Documents/Combat/Accelerated_Combat_Simulation.md
@@ -4,7 +4,7 @@
 
 The accelerated combat simulator is a founder diagnostic for testing ordinary combat strategies without waiting for wall-clock combat delays. It supports two or more named teams and accepts both loaded characters and current NPC templates. The simulator uses the real combat move, health, effect, item and heartbeat code; it is not a separate statistical combat model.
 
-The workflow is staged under `impdebug combatsim`. A founder selects a scene, adds combatants to teams, reviews preflight warnings, and then runs the staged scenario. The completed session retains a summary and a bounded transcript until it is replaced or cleared. The same staged scenario can also be run as a bounded batch across a deterministic sequence of seeds to compare aggregate outcomes.
+The workflow is staged under `impdebug combatsim`. A founder selects one or more cells, adds combatants to teams and starting positions, reviews preflight warnings, and then runs the staged scenario. The completed session retains a summary and a bounded transcript until it is replaced or cleared. The same staged scenario can also be run as a bounded batch across a deterministic sequence of seeds to compare aggregate outcomes.
 
 ## Runtime model
 
@@ -14,11 +14,13 @@ Gameplay code that needs current UTC uses the ambient `RuntimeClock.UtcNow`. Out
 
 The simulation starts a private heartbeat at one virtual-second intervals. After its snapshot or template-load data is applied, each materialised participant completes the body-login lifecycle inside that private scope. This calculates organ function and subscribes stamina, bleeding, healing, drug, breathing, biological and other heartbeat processes to the private manager without firing the broader character-entered-game hooks. Combat recovery schedules and expiring effects share the virtual clock. Execution stops when no more than one active team remains, no schedule remains, the configured virtual-time, fired-event or wall-clock guard is reached, or no combat-relevant participant state changes for 30 virtual seconds and 1,000 fired schedules. The latter is reported as a stalemate with an actionable no-input warning rather than consuming the whole event budget.
 
-Team combat uses `SimpleMeleeCombat` with a simulation-only target policy. When an actor needs a target, the policy chooses an engageable, able member of another team. This preserves the normal move selection and response pipeline while allowing fights larger than one-on-one.
+Team combat uses `SimpleMeleeCombat` with a simulation-only target policy. Every staged combatant joins the same combat immediately; when an actor needs a target, the policy chooses an engageable, able member of another team. Starting in the same combat does not imply immediate melee range: normal AI, combat settings, movement, ranged, flight and position choices determine what happens after combat starts. This preserves the normal move selection and response pipeline while allowing fights larger than one-on-one and across several staged cells.
 
 ## Scene and combatant materialisation
 
-The scene is a transient negative-ID `Cell` that borrows the selected cell's room and overlay environment but owns its characters and items independently. It has no exits, so strategies that require actual room-to-room flight may reach a guard limit rather than successfully flee. Saved effects on the source cell are cloned when possible.
+Each staged source cell is represented by a transient negative-ID `Cell` that borrows that cell's room and overlay environment but owns its characters and items independently. Only exits whose two endpoints are both staged are copied into the transient map, so strategies can use normal movement and pathing within the selected area without escaping into the live world. Exits with installed doors are omitted with a preflight warning: sharing a live door would allow the simulator to mutate live state. Saved effects on each source cell are cloned when possible.
+
+Each combatant has an independent starting cell, layer and position state. They default to the first staged cell, `GroundLevel`, and `standing`; for example, a flying combatant can begin in the `sky` layer of a second staged outdoor cell with `state flying`. Preflight rejects a layer that the selected source cell does not provide.
 
 Loaded-character sources are never placed in combat. The simulator creates a non-player transient character with the source's identity template, race, traits, descriptions, merits, blood, stamina, active and latent drug doses, position, combat settings, strategy, saved character/body effects, wounds, infections, and deep copies of worn, wielded and held inventory. Wounds are reconstructed through the target body's health strategy and then assigned their live damage, pain, shock, stun and bleeding values; infections retain their type, intensity, immunity, virulence, stage and wound/bodypart relationship. Special wound implementation state, lodged-item relationships, unsaved non-saving effects, clan/party/project state and arbitrary external relationships are not guaranteed to clone exactly.
 
@@ -38,11 +40,11 @@ Per-combatant terminal outcomes are:
 
 `Surrendered` remains part of the report contract, but the current automatic combat strategy pipeline has no general surrender transition to emit it. Fully manual combat, manual movement/position management, fully manual ranged or inventory management, zero automatic attack weighting, and NPC on-load progs are surfaced during preflight because they can stall or broaden a no-input simulation.
 
-The individual report includes run ID, seed, winning team, stop reason, virtual and wall-clock duration, fired-event count, participant state, blood and stamina ratios, wounds, terminal outcome, and a full versioned execution fingerprint. The current `v1` fingerprint is a SHA-256 digest over materialisation order, seeded random draws, private scheduler ticks, simulation output and the canonical terminal state. It excludes wall-clock duration, run IDs and transient object IDs. Transcript entries carry virtual timestamps and participant labels. The default limits are 30 virtual minutes, 100,000 fired schedules, 10,000 transcript entries, and 60 wall-clock seconds.
+The individual report includes run ID, seed, winning team, stop reason, virtual and wall-clock duration, fired-event count, participant state, blood and stamina ratios, wounds, terminal outcome, and a full versioned execution fingerprint. The current `v2` fingerprint is a SHA-256 digest over staged topology, materialisation order and start locations, seeded random draws, private scheduler ticks, simulation output and the canonical terminal state. It excludes wall-clock duration, run IDs and transient object IDs. Transcript entries carry virtual timestamps and participant labels. The default limits are 30 virtual minutes, 100,000 fired schedules, 10,000 transcript entries, and 60 wall-clock seconds.
 
 ## Batch tournaments
 
-`batch` reuses the currently staged scene and combatants for 1 to 100 sequential runs. It starts from the staged seed unless `seed` is supplied, and increases it by one unless `step` is supplied; a zero step is permitted when intentionally replaying the same seed. The batch validates that every generated seed remains a 32-bit integer. One UTC epoch is captured at the start of the batch and reused by every run, preventing real elapsed time between repetitions from changing absolute-time-sensitive gameplay decisions. Separate batch invocations intentionally capture new epochs.
+`batch` reuses the currently staged cells and combatants for 1 to 100 sequential runs. It starts from the staged seed unless `seed` is supplied, and increases it by one unless `step` is supplied; a zero step is permitted when intentionally replaying the same seed. The batch validates that every generated seed remains a 32-bit integer. One UTC epoch is captured at the start of the batch and reused by every run, preventing real elapsed time between repetitions from changing absolute-time-sensitive gameplay decisions. Separate batch invocations intentionally capture new epochs.
 
 Each run retains only its compact result, not its transcript, so a 100-run tournament cannot consume transcript memory. The aggregate report shows team wins and win rates, run-status counts, combatant-outcome counts, total, average and range virtual duration, and both summed simulation and whole-batch wall-clock duration. The final individual result remains available through `report`, but its batch transcript is intentionally empty. `batchreport` repeats the aggregate report; `batchreport runs [<start>] [<count>]` pages the per-run seed, status, winner, timing, event count and short trace fingerprint. `batchreport trace <run> <random|state|materialisation> [<start>] [<count>]` pages the captured diagnostic trace for one run, making the first divergence in an intentionally repeated seed inspectable without retaining full combat transcripts.
 
@@ -71,8 +73,11 @@ Simulation character death uses a reduced death path, so it does not post death-
 
 ```text
 impdebug combatsim new [<cell>]
-impdebug combatsim add character <loaded character> team <team>
-impdebug combatsim add template <NPC template> team <team> [count <number>]
+impdebug combatsim cell add <cell>
+impdebug combatsim cell remove <number>
+impdebug combatsim cell list
+impdebug combatsim add character <loaded character> team <team> [cell <number>] [layer <layer>] [state <position>]
+impdebug combatsim add template <NPC template> team <team> [cell <number>] [layer <layer>] [state <position>] [count <number>]
 impdebug combatsim remove <slot>
 impdebug combatsim set scene <cell>
 impdebug combatsim set seed <number>
@@ -90,4 +95,6 @@ impdebug combatsim transcript [<start>] [<count>]
 impdebug combatsim clear
 ```
 
-For comparable runs within one batch, keep the source state, active NPC-template revision and selected scene unchanged; use a zero seed step for an exact seeded replay. The seed controls the engine's shared random source, expression evaluation uses call-local parameter values rather than shared mutable dictionaries, and all runs share the batch epoch. Repeated runs should therefore have the same `v1` execution fingerprint unless authored or external code escapes those controlled services. Separate invocations use their own starting epoch. `report` repeats the summary; `transcript` defaults to the first 100 entries and accepts a one-based start plus a maximum count of 1,000.
+`new` creates staged cell 1; `set scene <cell>` replaces that first/default cell. `cell add <cell>` appends another cell and `cell remove <number>` removes an unused non-default staged cell. The `add` command takes its optional arguments in any order. `cell` is the one-based staged-cell number rather than a room lookup, which keeps multi-word cell names unambiguous. `ground`, `trees`, `sky`, `highair`, `water`, and the named `RoomLayer` values are accepted layers; `state` accepts normal position-state names such as `standing`, `sitting`, `prone`, and `flying`.
+
+For comparable runs within one batch, keep the source state, active NPC-template revision and staged cells unchanged; use a zero seed step for an exact seeded replay. The seed controls the engine's shared random source, expression evaluation uses call-local parameter values rather than shared mutable dictionaries, and all runs share the batch epoch. Repeated runs should therefore have the same `v2` execution fingerprint unless authored or external code escapes those controlled services. Separate invocations use their own starting epoch. `report` repeats the summary; `transcript` defaults to the first 100 entries and accepts a one-based start plus a maximum count of 1,000.

--- a/FutureMUDLibrary/Combat/Simulation/ICombatSimulation.cs
+++ b/FutureMUDLibrary/Combat/Simulation/ICombatSimulation.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using MudSharp.Body.Position;
 using MudSharp.Character;
 using MudSharp.Character.Name;
 using MudSharp.Construction;
@@ -46,7 +47,10 @@ public sealed record CombatSimulationParticipantRequest(
 	CombatSimulationSourceType SourceType,
 	ICharacter? Character,
 	INPCTemplate? NpcTemplate,
-	int Ordinal = 1)
+	int Ordinal = 1,
+	ICell? StartingCell = null,
+	RoomLayer StartingLayer = RoomLayer.GroundLevel,
+	IPositionState? StartingPosition = null)
 {
 	public string SourceDescription => SourceType switch
 	{
@@ -66,7 +70,8 @@ public sealed record CombatSimulationRequest(
 	int MaximumEvents,
 	int MaximumTranscriptEntries,
 	TimeSpan MaximumWallClockTime,
-	bool Force);
+	bool Force,
+	IReadOnlyList<ICell>? Cells = null);
 
 public sealed record CombatSimulationBatchRequest(
 	Guid BatchId,
@@ -80,7 +85,8 @@ public sealed record CombatSimulationBatchRequest(
 	int MaximumEvents,
 	TimeSpan MaximumWallClockTime,
 	TimeSpan MaximumBatchWallClockTime,
-	bool Force);
+	bool Force,
+	IReadOnlyList<ICell>? Cells = null);
 
 public sealed record CombatSimulationValidationMessage(bool IsError, string Message);
 

--- a/MudSharpCore Unit Tests/CombatSimulationTests.cs
+++ b/MudSharpCore Unit Tests/CombatSimulationTests.cs
@@ -9,6 +9,7 @@ using MudSharp.Character;
 using MudSharp.Combat;
 using MudSharp.Combat.Simulation;
 using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
 using MudSharp.Framework;
 using MudSharp.Framework.Scheduling;
 using MudSharp.NPC.Templates;
@@ -55,6 +56,81 @@ public class CombatSimulationTests
 		var messages = new CombatSimulationService().Validate(request);
 
 		Assert.IsTrue(messages.Any(x => x.IsError && x.Message.Contains("opposing teams")));
+	}
+
+	[TestMethod]
+	public void CombatSimulationCommand_SkyLayerAlias_MapsToInAir()
+	{
+		Assert.IsTrue(CombatSimulationCommand.TryParseRoomLayer("sky", out var layer));
+		Assert.AreEqual(RoomLayer.InAir, layer);
+	}
+
+	[TestMethod]
+	public void Validate_StagedCellsAllowCombatantsToStartInDifferentCells()
+	{
+		var request = CreateRequest("red", "blue");
+		var firstCell = new Mock<ICell>();
+		var secondCell = new Mock<ICell>();
+		var stagedRequest = request with
+		{
+			Scene = firstCell.Object,
+			Cells = [firstCell.Object, secondCell.Object],
+			Participants =
+			[
+				request.Participants[0] with { StartingCell = firstCell.Object },
+				request.Participants[1] with { StartingCell = secondCell.Object, StartingLayer = RoomLayer.InAir }
+			]
+		};
+
+		var messages = new CombatSimulationService().Validate(stagedRequest);
+
+		Assert.IsFalse(messages.Any(x => x.IsError));
+	}
+
+	[TestMethod]
+	public void Validate_CombatantOutsideStagedCells_ReturnsStructuralError()
+	{
+		var request = CreateRequest("red", "blue");
+		var scene = new Mock<ICell>();
+		var unlistedCell = new Mock<ICell>();
+		var stagedRequest = request with
+		{
+			Scene = scene.Object,
+			Cells = [scene.Object],
+			Participants =
+			[
+				request.Participants[0],
+				request.Participants[1] with { StartingCell = unlistedCell.Object }
+			]
+		};
+
+		var messages = new CombatSimulationService().Validate(stagedRequest);
+
+		Assert.IsTrue(messages.Any(x => x.IsError && x.Message.Contains("not staged")));
+	}
+
+	[TestMethod]
+	public void Validate_CombatantStartingLayerUnavailableInCell_ReturnsStructuralError()
+	{
+		var request = CreateRequest("red", "blue");
+		var terrain = new Mock<ITerrain>();
+		terrain.SetupGet(x => x.TerrainLayers).Returns([RoomLayer.GroundLevel]);
+		var scene = new Mock<ICell>();
+		scene.Setup(x => x.Terrain(It.IsAny<IPerceiver>())).Returns(terrain.Object);
+		var stagedRequest = request with
+		{
+			Scene = scene.Object,
+			Cells = [scene.Object],
+			Participants =
+			[
+				request.Participants[0],
+				request.Participants[1] with { StartingLayer = RoomLayer.InAir }
+			]
+		};
+
+		var messages = new CombatSimulationService().Validate(stagedRequest);
+
+		Assert.IsTrue(messages.Any(x => x.IsError && x.Message.Contains("not available")));
 	}
 
 	[TestMethod]
@@ -188,6 +264,25 @@ public class CombatSimulationTests
 	}
 
 	[TestMethod]
+	public void CombatSimulationExecutionFingerprint_DifferentStartingLayer_ProducesDifferentDigest()
+	{
+		var template = new Mock<INPCTemplate>();
+		template.SetupGet(x => x.Id).Returns(1L);
+		var groundParticipant = new CombatSimulationParticipantRequest(1, "red",
+			CombatSimulationSourceType.NpcTemplate, null, template.Object);
+		var airParticipant = groundParticipant with { StartingLayer = RoomLayer.InAir };
+		var ground = new CombatSimulationExecutionFingerprint(1234);
+		var air = new CombatSimulationExecutionFingerprint(1234);
+
+		ground.RecordMaterialisation(groundParticipant);
+		air.RecordMaterialisation(airParticipant);
+
+		Assert.AreNotEqual(
+			ground.Complete(CombatSimulationRunStatus.Completed, "red", TimeSpan.Zero, 0, []),
+			air.Complete(CombatSimulationRunStatus.Completed, "red", TimeSpan.Zero, 0, []));
+	}
+
+	[TestMethod]
 	public void Validate_ManualCombatSettings_ReportsNoInputRisks()
 	{
 		var settings = new Mock<ICharacterCombatSettings>();
@@ -217,6 +312,42 @@ public class CombatSimulationTests
 
 		Assert.AreEqual(-1L, simulationCell.Id);
 		Assert.AreEqual(42L, simulationCell.DatabaseLocationId);
+	}
+
+	[TestMethod]
+	public void TransientExit_CombatSimulationCopyPreservesMovementDirections()
+	{
+		var gameworld = new Mock<IFuturemud>();
+		var sourceOrigin = new Mock<ICell>();
+		var sourceDestination = new Mock<ICell>();
+		var simulationOrigin = new Mock<ICell>();
+		var simulationDestination = new Mock<ICell>();
+		simulationOrigin.SetupGet(x => x.Id).Returns(-1L);
+		simulationDestination.SetupGet(x => x.Id).Returns(-2L);
+		var sourceExit = new Mock<IExit>();
+		var sourceOriginExit = new Mock<ICellExit>();
+		var sourceDestinationExit = new Mock<ICellExit>();
+		sourceOriginExit.SetupGet(x => x.Opposite).Returns(sourceDestinationExit.Object);
+		sourceOriginExit.SetupGet(x => x.Destination).Returns(sourceDestination.Object);
+		sourceOriginExit.SetupGet(x => x.OutboundDirection).Returns(CardinalDirection.North);
+		sourceOriginExit.SetupGet(x => x.InboundDirection).Returns(CardinalDirection.South);
+		sourceDestinationExit.SetupGet(x => x.OutboundDirection).Returns(CardinalDirection.South);
+		sourceDestinationExit.SetupGet(x => x.InboundDirection).Returns(CardinalDirection.North);
+		sourceExit.Setup(x => x.CellExitFor(sourceOrigin.Object)).Returns(sourceOriginExit.Object);
+		sourceExit.SetupGet(x => x.BlockedLayers).Returns(Array.Empty<RoomLayer>());
+		sourceExit.SetupGet(x => x.TimeMultiplier).Returns(1.0);
+
+		var transientExit = new TransientExit(gameworld.Object, simulationOrigin.Object, simulationDestination.Object,
+			sourceExit.Object, sourceOrigin.Object, "combat-simulation:test");
+
+		var copiedOriginExit = transientExit.CellExitFor(simulationOrigin.Object);
+		var copiedDestinationExit = transientExit.CellExitFor(simulationDestination.Object);
+		Assert.IsNotNull(copiedOriginExit);
+		Assert.IsNotNull(copiedDestinationExit);
+		Assert.AreSame(simulationDestination.Object, copiedOriginExit!.Destination);
+		Assert.AreEqual(CardinalDirection.North, copiedOriginExit.OutboundDirection);
+		Assert.AreSame(simulationOrigin.Object, copiedDestinationExit!.Destination);
+		Assert.AreEqual(CardinalDirection.South, copiedDestinationExit.OutboundDirection);
 	}
 
 	[TestMethod]

--- a/MudSharpCore/Combat/Simulation/CombatSimulationCommand.cs
+++ b/MudSharpCore/Combat/Simulation/CombatSimulationCommand.cs
@@ -1,3 +1,5 @@
+using MudSharp.Body.Position;
+using MudSharp.Body.Position.PositionStates;
 using MudSharp.Character;
 using MudSharp.Character.Name;
 using MudSharp.Construction;
@@ -9,7 +11,13 @@ namespace MudSharp.Combat.Simulation;
 
 internal sealed class CombatSimulationCommandSession(ICell scene)
 {
-	public ICell Scene { get; set; } = scene;
+	public List<ICell> Cells { get; } = [scene];
+	public ICell Scene
+	{
+		get => Cells[0];
+		set => Cells[0] = value;
+	}
+
 	public List<CombatSimulationParticipantRequest> Participants { get; } = [];
 	public int Seed { get; set; } = Random.Shared.Next();
 	public TimeSpan MaximumVirtualTime { get; set; } = TimeSpan.FromMinutes(30);
@@ -23,15 +31,17 @@ internal sealed class CombatSimulationCommandSession(ICell scene)
 
 internal static class CombatSimulationCommand
 {
-	private const string HelpText = @"The #3impdebug combatsim#0 workflow stages and runs an accelerated combat using transient copies of loaded characters or NPC templates. Combat, effects and heartbeats use a private virtual-time scheduler while the normal game loop is blocked. EF SaveChanges calls and ordinary save-queue work are suppressed; generated actors, bodies, items and the transient scene are removed afterward. Direct Dapper writes and external effects from hooks or progs cannot be unwound.
+	private const string HelpText = @"The #3impdebug combatsim#0 workflow stages and runs an accelerated combat using transient copies of loaded characters or NPC templates across one or more staged cells. Combat, effects and heartbeats use a private virtual-time scheduler while the normal game loop is blocked. EF SaveChanges calls and ordinary save-queue work are suppressed; generated actors, bodies, items and transient cells are removed afterward. Direct Dapper writes and external effects from hooks or progs cannot be unwound.
 
 Review #3validate#0 before running. Any warning requires #3force#0. An unset or unrecognised #3FUTUREMUD_ENVIRONMENT#0 is treated as production, where every run also requires the exact #3confirm-production#0 argument. Batch runs do not retain transcripts and have a ten-minute aggregate wall-clock guard.
 
 The syntax is:
 
 	#3impdebug combatsim new [<cell>]#0
-	#3impdebug combatsim add character <loaded character> team <team>#0
-	#3impdebug combatsim add template <NPC template> team <team> [count <number>]#0
+	#3impdebug combatsim cell add <cell>#0
+	#3impdebug combatsim cell remove <number>#0
+	#3impdebug combatsim add character <loaded character> team <team> [cell <number>] [layer <layer>] [state <position>]#0
+	#3impdebug combatsim add template <NPC template> team <team> [cell <number>] [layer <layer>] [state <position>] [count <number>]#0
 	#3impdebug combatsim remove <slot>#0
 	#3impdebug combatsim set scene <cell>#0
 	#3impdebug combatsim set seed <number>#0
@@ -60,6 +70,9 @@ The syntax is:
 				return;
 			case "add":
 				Add(actor, command);
+				return;
+			case "cell":
+				Cell(actor, command);
 				return;
 			case "remove":
 				Remove(actor, command);
@@ -164,15 +177,10 @@ The syntax is:
 		}
 
 		var team = command.PopSpeech();
-		var count = 1;
-		if (!command.IsFinished)
+		if (!TryParseAddOptions(actor, command, session, out var count, out var startingCell, out var startingLayer,
+			    out var startingPosition))
 		{
-			if (!command.PopSpeech().EqualTo("count") || command.IsFinished ||
-			    !int.TryParse(command.PopSpeech(), out count) || count is < 1 or > 100 || !command.IsFinished)
-			{
-				actor.OutputHandler.Send("The optional count must be a whole number from 1 to 100.");
-				return;
-			}
+			return;
 		}
 
 		if (sourceType is "character" or "char")
@@ -191,9 +199,10 @@ The syntax is:
 			}
 
 			session.Participants.Add(new CombatSimulationParticipantRequest(
-				session.NextSlot++, team, CombatSimulationSourceType.Character, character, null));
+				session.NextSlot++, team, CombatSimulationSourceType.Character, character, null,
+				StartingCell: startingCell, StartingLayer: startingLayer, StartingPosition: startingPosition));
 			actor.OutputHandler.Send(
-				$"You add {character.PersonalName.GetName(NameStyle.SimpleFull).ColourName()} to team {team.ColourName()}.");
+				$"You add {character.PersonalName.GetName(NameStyle.SimpleFull).ColourName()} to team {team.ColourName()} {DescribeStartingLocation(session, startingCell, startingLayer, startingPosition)}.");
 			return;
 		}
 
@@ -207,11 +216,192 @@ The syntax is:
 		for (var i = 1; i <= count; i++)
 		{
 			session.Participants.Add(new CombatSimulationParticipantRequest(
-				session.NextSlot++, team, CombatSimulationSourceType.NpcTemplate, null, template, i));
+				session.NextSlot++, team, CombatSimulationSourceType.NpcTemplate, null, template, i,
+				startingCell, startingLayer, startingPosition));
 		}
 
 		actor.OutputHandler.Send(
-			$"You add {count.ToString("N0", actor).ColourValue()} instance{(count == 1 ? string.Empty : "s")} of {template.Name.ColourName()} to team {team.ColourName()}.");
+			$"You add {count.ToString("N0", actor).ColourValue()} instance{(count == 1 ? string.Empty : "s")} of {template.Name.ColourName()} to team {team.ColourName()} {DescribeStartingLocation(session, startingCell, startingLayer, startingPosition)}.");
+	}
+
+	private static bool TryParseAddOptions(
+		ICharacter actor,
+		StringStack command,
+		CombatSimulationCommandSession session,
+		out int count,
+		out ICell? startingCell,
+		out RoomLayer startingLayer,
+		out IPositionState? startingPosition)
+	{
+		count = 1;
+		startingCell = null;
+		startingLayer = RoomLayer.GroundLevel;
+		startingPosition = null;
+		var seen = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+		while (!command.IsFinished)
+		{
+			var option = command.PopSpeech().CollapseString().ToLowerInvariant();
+			if (!seen.Add(option))
+			{
+				actor.OutputHandler.Send($"You can only specify {option.ColourCommand()} once when adding a combatant.");
+				return false;
+			}
+
+			switch (option)
+			{
+				case "count":
+					if (command.IsFinished || !int.TryParse(command.PopSpeech(), out count) || count is < 1 or > 100)
+					{
+						actor.OutputHandler.Send("The count must be a whole number from 1 to 100.");
+						return false;
+					}
+
+					break;
+				case "cell":
+					if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var cellNumber) ||
+					    cellNumber is < 1 or > int.MaxValue || cellNumber > session.Cells.Count)
+					{
+						actor.OutputHandler.Send($"The cell must be a staged cell number from 1 to {session.Cells.Count:N0}.");
+						return false;
+					}
+
+					startingCell = session.Cells[cellNumber - 1];
+					break;
+				case "layer":
+					if (command.IsFinished || !TryParseRoomLayer(command.PopSpeech(), out startingLayer))
+					{
+						actor.OutputHandler.Send("Specify a valid layer, such as ground, trees, sky or highair.");
+						return false;
+					}
+
+					break;
+				case "state":
+				case "position":
+					startingPosition = command.IsFinished ? null : PositionState.GetState(command.PopSpeech());
+					if (startingPosition is null)
+					{
+						actor.OutputHandler.Send("Specify a valid starting position, such as standing, sitting, prone or flying.");
+						return false;
+					}
+
+					break;
+				default:
+					actor.OutputHandler.Send("The add options are cell, layer, state and count.");
+					return false;
+			}
+		}
+
+		return true;
+	}
+
+	private static void Cell(ICharacter actor, StringStack command)
+	{
+		var session = Session(actor);
+		if (session is null)
+		{
+			return;
+		}
+
+		var action = command.PopSpeech().CollapseString().ToLowerInvariant();
+		switch (action)
+		{
+			case "add":
+				var cell = actor.Gameworld.Cells.GetByIdOrName(command.SafeRemainingArgument);
+				if (cell is null)
+				{
+					actor.OutputHandler.Send("There is no such cell.");
+					return;
+				}
+
+				if (session.Cells.Any(x => ReferenceEquals(x, cell)))
+				{
+					actor.OutputHandler.Send("That cell is already staged for this combat simulation.");
+					return;
+				}
+
+				session.Cells.Add(cell);
+				actor.OutputHandler.Send($"You add cell #{session.Cells.Count:N0} {cell.GetFriendlyReference(actor).ColourName()} to the staged combat area.");
+				return;
+			case "remove":
+				if (!int.TryParse(command.SafeRemainingArgument, out var cellNumber) ||
+				    cellNumber is < 2 or > int.MaxValue || cellNumber > session.Cells.Count)
+				{
+					actor.OutputHandler.Send($"Specify a non-default staged cell number from 2 to {session.Cells.Count:N0}.");
+					return;
+				}
+
+				var removedCell = session.Cells[cellNumber - 1];
+				if (session.Participants.Any(x => ReferenceEquals(x.StartingCell, removedCell)))
+				{
+					actor.OutputHandler.Send("Remove or relocate combatants assigned to that cell before removing it.");
+					return;
+				}
+
+				session.Cells.RemoveAt(cellNumber - 1);
+				actor.OutputHandler.Send($"You remove staged cell #{cellNumber:N0}.");
+				return;
+			case "list":
+				ShowCells(actor, session);
+				return;
+			default:
+				actor.OutputHandler.Send("The cell syntax is impdebug combatsim cell add <cell>, cell remove <number>, or cell list.");
+				return;
+		}
+	}
+
+	internal static bool TryParseRoomLayer(string text, out RoomLayer layer)
+	{
+		if (Utilities.TryParseEnum(text, out layer))
+		{
+			return true;
+		}
+
+		switch (text.ToLowerInvariant().CollapseString())
+		{
+			case "ground":
+			case "groundlevel":
+				layer = RoomLayer.GroundLevel;
+				return true;
+			case "water":
+			case "underwater":
+				layer = RoomLayer.Underwater;
+				return true;
+			case "deepwater":
+			case "deepunderwater":
+				layer = RoomLayer.DeepUnderwater;
+				return true;
+			case "verydeepwater":
+			case "verydeepunderwater":
+				layer = RoomLayer.VeryDeepUnderwater;
+				return true;
+			case "trees":
+			case "intrees":
+				layer = RoomLayer.InTrees;
+				return true;
+			case "hightrees":
+			case "highintrees":
+				layer = RoomLayer.HighInTrees;
+				return true;
+			case "air":
+			case "sky":
+			case "inair":
+				layer = RoomLayer.InAir;
+				return true;
+			case "highair":
+			case "highsky":
+			case "highinair":
+				layer = RoomLayer.HighInAir;
+				return true;
+			case "roof":
+			case "rooftop":
+			case "rooftops":
+			case "onrooftops":
+				layer = RoomLayer.OnRooftops;
+				return true;
+			default:
+				layer = RoomLayer.GroundLevel;
+				return false;
+		}
 	}
 
 	private static void Remove(ICharacter actor, StringStack command)
@@ -254,7 +444,22 @@ The syntax is:
 					return;
 				}
 
+				if (session.Cells.Skip(1).Any(x => ReferenceEquals(x, scene)))
+				{
+					actor.OutputHandler.Send("That cell is already staged. Use its staged cell number when adding combatants.");
+					return;
+				}
+
+				var previousScene = session.Scene;
 				session.Scene = scene;
+				for (var i = 0; i < session.Participants.Count; i++)
+				{
+					if (ReferenceEquals(session.Participants[i].StartingCell, previousScene))
+					{
+						session.Participants[i] = session.Participants[i] with { StartingCell = scene };
+					}
+				}
+
 				actor.OutputHandler.Send($"The combat scene is now {scene.GetFriendlyReference(actor).ColourName()}.");
 				return;
 			case "seed":
@@ -301,7 +506,7 @@ The syntax is:
 				actor.OutputHandler.Send($"The transcript limit is now {entries.ToString("N0", actor).ColourValue()} entries.");
 				return;
 			default:
-				actor.OutputHandler.Send("You can set scene, seed, maxtime, maxevents or transcript.");
+				actor.OutputHandler.Send("You can set scene, seed, maxtime, maxevents or transcript. Use combatsim cell add/remove/list to manage the staged area.");
 				return;
 		}
 	}
@@ -317,10 +522,13 @@ The syntax is:
 		var sb = new StringBuilder();
 		sb.AppendLine("Accelerated Combat Simulation");
 		sb.AppendLine();
-		sb.AppendLine($"Scene: {session.Scene.GetFriendlyReference(actor).ColourName()}");
+		sb.AppendLine($"Default Cell: {session.Scene.GetFriendlyReference(actor).ColourName()}");
 		sb.AppendLine($"Seed: {session.Seed.ToString("N0", actor).ColourValue()}");
 		sb.AppendLine($"Limits: {session.MaximumVirtualTime.Describe(actor).ColourValue()} virtual time, {session.MaximumEvents.ToString("N0", actor).ColourValue()} events, {session.MaximumWallClockTime.Describe(actor).ColourValue()} wall time");
 		sb.AppendLine($"Transcript: {session.MaximumTranscriptEntries.ToString("N0", actor).ColourValue()} entries");
+		sb.AppendLine();
+		sb.AppendLine();
+		AppendCells(sb, actor, session);
 		sb.AppendLine();
 		var rows = session.Participants
 			.OrderBy(x => x.Slot)
@@ -329,12 +537,54 @@ The syntax is:
 				x.Slot.ToString("N0", actor),
 				x.Team,
 				x.SourceType.DescribeEnum(true),
-				x.SourceDescription
+				x.SourceDescription,
+				CellNumberFor(session, x).ToString("N0", actor),
+				x.StartingLayer.DescribeEnum(true),
+				(x.StartingPosition ?? PositionStanding.Instance).DefaultDescription()
 			});
 		sb.AppendLine(session.Participants.Count == 0
 			? "No combatants have been added."
-			: StringUtilities.GetTextTable(rows, ["Slot", "Team", "Type", "Source"], actor, Telnet.Green));
+			: StringUtilities.GetTextTable(rows, ["Slot", "Team", "Type", "Source", "Cell", "Layer", "State"], actor, Telnet.Green));
 		actor.OutputHandler.Send(sb.ToString());
+	}
+
+	private static void ShowCells(ICharacter actor, CombatSimulationCommandSession session)
+	{
+		var sb = new StringBuilder();
+		AppendCells(sb, actor, session);
+		actor.OutputHandler.Send(sb.ToString());
+	}
+
+	private static void AppendCells(StringBuilder sb, ICharacter actor, CombatSimulationCommandSession session)
+	{
+		var rows = session.Cells
+			.Select((cell, index) => new[]
+			{
+				(index + 1).ToString("N0", actor),
+				cell.GetFriendlyReference(actor)
+			});
+		sb.AppendLine(StringUtilities.GetTextTable(rows, ["Cell", "Staged Cell"], actor, Telnet.Green));
+	}
+
+	private static int CellNumberFor(CombatSimulationCommandSession session, CombatSimulationParticipantRequest participant)
+	{
+		if (participant.StartingCell is null)
+		{
+			return 1;
+		}
+
+		var index = session.Cells.FindIndex(x => ReferenceEquals(x, participant.StartingCell));
+		return index >= 0 ? index + 1 : 0;
+	}
+
+	private static string DescribeStartingLocation(
+		CombatSimulationCommandSession session,
+		ICell? startingCell,
+		RoomLayer startingLayer,
+		IPositionState? startingPosition)
+	{
+		var cell = startingCell is null ? 1 : session.Cells.FindIndex(x => ReferenceEquals(x, startingCell)) + 1;
+		return $"in cell #{cell:N0}, {startingLayer.LocativeDescription()} and {(startingPosition ?? PositionStanding.Instance).DefaultDescription()}";
 	}
 
 	private static CombatSimulationRequest BuildRequest(ICharacter actor, CombatSimulationCommandSession session, bool force)
@@ -342,7 +592,7 @@ The syntax is:
 		return new CombatSimulationRequest(
 			Guid.NewGuid(), actor, session.Scene, session.Participants.ToList(), session.Seed,
 			session.MaximumVirtualTime, session.MaximumEvents, session.MaximumTranscriptEntries,
-			session.MaximumWallClockTime, force);
+			session.MaximumWallClockTime, force, session.Cells.ToList());
 	}
 
 	private static CombatSimulationBatchRequest BuildBatchRequest(
@@ -365,7 +615,8 @@ The syntax is:
 			session.MaximumEvents,
 			session.MaximumWallClockTime,
 			TimeSpan.FromMinutes(10),
-			force);
+			force,
+			session.Cells.ToList());
 	}
 
 	private static void Validate(ICharacter actor)

--- a/MudSharpCore/Combat/Simulation/CombatSimulationExecutionFingerprint.cs
+++ b/MudSharpCore/Combat/Simulation/CombatSimulationExecutionFingerprint.cs
@@ -12,7 +12,7 @@ namespace MudSharp.Combat.Simulation;
 /// </summary>
 internal sealed class CombatSimulationExecutionFingerprint
 {
-	public const string Version = "v1";
+	public const string Version = "v2";
 	private const int TraceCheckpointInterval = 50;
 	private const int MaximumTraceCheckpoints = 200;
 	private const int MaximumRecentRandomOperations = 128;
@@ -64,13 +64,22 @@ internal sealed class CombatSimulationExecutionFingerprint
 			? participant.Character?.Id.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty
 			: participant.NpcTemplate?.Id.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty;
 		var ordinal = participant.Ordinal.ToString(System.Globalization.CultureInfo.InvariantCulture);
+		var startingCell = participant.StartingCell?.Id.ToString(System.Globalization.CultureInfo.InvariantCulture) ??
+			string.Empty;
+		var startingLayer = ((int)participant.StartingLayer).ToString(System.Globalization.CultureInfo.InvariantCulture);
+		var startingPosition = participant.StartingPosition?.Id.ToString(System.Globalization.CultureInfo.InvariantCulture) ??
+			string.Empty;
 		Record("materialise");
 		Record(slot);
 		Record(participant.Team);
 		Record(sourceType);
 		Record(source);
 		Record(ordinal);
-		RecordTrace(_materialisationHash, "materialise", slot, participant.Team, sourceType, source, ordinal);
+		Record(startingCell);
+		Record(startingLayer);
+		Record(startingPosition);
+		RecordTrace(_materialisationHash, "materialise", slot, participant.Team, sourceType, source, ordinal,
+			startingCell, startingLayer, startingPosition);
 		_materialisationOperations++;
 	}
 
@@ -90,6 +99,14 @@ internal sealed class CombatSimulationExecutionFingerprint
 				$"slot:{slotText} {category}:{ShortDigest(value)}"));
 		}
 
+		_materialisationOperations++;
+	}
+
+	public void RecordTopology(string description)
+	{
+		Record("topology");
+		Record(description);
+		RecordTrace(_materialisationHash, "topology", description);
 		_materialisationOperations++;
 	}
 

--- a/MudSharpCore/Combat/Simulation/CombatSimulationService.cs
+++ b/MudSharpCore/Combat/Simulation/CombatSimulationService.cs
@@ -1,8 +1,11 @@
 using System.Diagnostics;
 using System.Threading;
 using Microsoft.EntityFrameworkCore.Storage;
+using MudSharp.Body.Position;
+using MudSharp.Body.Position.PositionStates;
 using MudSharp.Character;
 using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
 using MudSharp.Database;
 using MudSharp.Effects.Interfaces;
 using MudSharp.Events;
@@ -43,12 +46,53 @@ public sealed class CombatSimulationService : ICombatSimulationService
 	private static int _simulationRunning;
 	private static long _nextTemporaryCellId = -1_000_000;
 
+	private static IReadOnlyList<ICell> StagedCells(CombatSimulationRequest request)
+	{
+		var cells = new List<ICell>();
+		if (request.Scene is not null)
+		{
+			cells.Add(request.Scene);
+		}
+
+		if (request.Cells is not null)
+		{
+			cells.AddRange(request.Cells.OfType<ICell>());
+		}
+
+		cells.AddRange(request.Participants
+			.Select(x => x.StartingCell)
+			.OfType<ICell>());
+		return cells.Distinct(ReferenceEqualityComparer.Instance).Cast<ICell>().ToList();
+	}
+
+	private static bool IsStagedCell(IReadOnlyList<ICell> cells, ICell cell)
+	{
+		return cells.Any(x => ReferenceEquals(x, cell));
+	}
+
 	public IReadOnlyList<CombatSimulationValidationMessage> Validate(CombatSimulationRequest request)
 	{
 		var messages = new List<CombatSimulationValidationMessage>();
 		if (request.Scene is null)
 		{
 			messages.Add(new CombatSimulationValidationMessage(true, "A combat scene is required."));
+		}
+		else if (request.Cells is not null && !IsStagedCell(request.Cells, request.Scene))
+		{
+			messages.Add(new CombatSimulationValidationMessage(true,
+				"The default combat cell must be included in the staged cells."));
+		}
+
+		if (request.Cells is not null && request.Cells.Count == 0)
+		{
+			messages.Add(new CombatSimulationValidationMessage(true,
+				"At least one staged combat cell is required."));
+		}
+
+		if (request.Cells is not null && request.Cells.Count != request.Cells.Distinct(ReferenceEqualityComparer.Instance).Count())
+		{
+			messages.Add(new CombatSimulationValidationMessage(true,
+				"Each staged combat cell may only be included once."));
 		}
 
 		if (request.Participants.Count < 2)
@@ -95,6 +139,28 @@ public sealed class CombatSimulationService : ICombatSimulationService
 
 		foreach (var participant in request.Participants)
 		{
+			var startingCell = participant.StartingCell ?? request.Scene;
+			if (startingCell is null)
+			{
+				messages.Add(new CombatSimulationValidationMessage(true,
+					$"Combatant slot {participant.Slot:N0} has no starting cell."));
+			}
+			else
+			{
+				if (request.Cells is not null && !IsStagedCell(request.Cells, startingCell))
+				{
+					messages.Add(new CombatSimulationValidationMessage(true,
+						$"Combatant slot {participant.Slot:N0} starts in a cell that is not staged for this simulation."));
+				}
+
+				var terrain = startingCell.Terrain(null);
+				if (terrain is not null && !terrain.TerrainLayers.Contains(participant.StartingLayer))
+				{
+					messages.Add(new CombatSimulationValidationMessage(true,
+						$"Combatant slot {participant.Slot:N0} starts on {participant.StartingLayer.DescribeEnum(true)}, which is not available in its selected cell."));
+				}
+			}
+
 			if (string.IsNullOrWhiteSpace(participant.Team))
 			{
 				messages.Add(new CombatSimulationValidationMessage(true,
@@ -189,7 +255,8 @@ public sealed class CombatSimulationService : ICombatSimulationService
 			request.MaximumEvents,
 			0,
 			request.MaximumWallClockTime,
-			request.Force)).ToList();
+			request.Force,
+			request.Cells)).ToList();
 
 		if (request.RunCount is < 1 or > 100)
 		{
@@ -256,7 +323,8 @@ public sealed class CombatSimulationService : ICombatSimulationService
 				request.MaximumEvents,
 				0,
 				perRunWallClock,
-				request.Force), batchEpoch, request.RunCount > 1 && request.SeedIncrement == 0));
+				request.Force,
+				request.Cells), batchEpoch, request.RunCount > 1 && request.SeedIncrement == 0));
 		}
 
 		return BuildBatchResult(request, results, validation, batchWallClock.Elapsed, errorMessage);
@@ -289,14 +357,15 @@ public sealed class CombatSimulationService : ICombatSimulationService
 
 		var wallClock = Stopwatch.StartNew();
 		var snapshots = new List<SourceSnapshot>();
-		XElement? sceneEffects = null;
+		var sourceCellEffects = new Dictionary<ICell, XElement?>(ReferenceEqualityComparer.Instance);
 		var originalActors = new HashSet<ICharacter>(ReferenceEqualityComparer.Instance);
 		var originalCachedActors = new HashSet<ICharacter>(ReferenceEqualityComparer.Instance);
 		var originalBodies = new HashSet<MudSharp.Body.IBody>(ReferenceEqualityComparer.Instance);
 		var originalItems = new HashSet<MudSharp.GameItems.IGameItem>(ReferenceEqualityComparer.Instance);
 		var cleanupSimulationArtifacts = false;
 		var runtimeParticipants = new List<RuntimeParticipant>();
-		Cell? simulationCell = null;
+		var simulationCells = new Dictionary<ICell, Cell>(ReferenceEqualityComparer.Instance);
+		var simulationExits = new List<IExit>();
 		CombatSimulationTranscript? transcript = null;
 		IDbContextTransaction? transaction = null;
 		IDisposable? databaseScope = null;
@@ -320,7 +389,10 @@ public sealed class CombatSimulationService : ICombatSimulationService
 				executionFingerprint);
 
 			snapshots = CaptureSourceSnapshots(request);
-			sceneEffects = request.Scene is Cell sourceCell ? sourceCell.SaveEffects() : null;
+			foreach (var sourceCell in StagedCells(request).OfType<Cell>())
+			{
+				sourceCellEffects[sourceCell] = sourceCell.SaveEffects();
+			}
 			originalActors.UnionWith(request.RequestedBy.Gameworld.Actors);
 			originalCachedActors.UnionWith(request.RequestedBy.Gameworld.CachedActors);
 			originalBodies.UnionWith(request.RequestedBy.Gameworld.Bodies);
@@ -333,18 +405,25 @@ public sealed class CombatSimulationService : ICombatSimulationService
 
 			transcript = new CombatSimulationTranscript(timeProvider, startedAt, request.MaximumTranscriptEntries,
 				executionFingerprint);
-			simulationCell = new Cell(request.Scene, Interlocked.Decrement(ref _nextTemporaryCellId));
-			request.RequestedBy.Gameworld.Add(simulationCell);
-			if (sceneEffects is not null)
+			foreach (var sourceCell in StagedCells(request))
 			{
-				TryRestoreEffects(() => simulationCell.RestoreCombatSimulationEffects(sceneEffects), validation,
-					"Some scene effects could not be cloned and were omitted.");
+				var simulationCell = new Cell(sourceCell, Interlocked.Decrement(ref _nextTemporaryCellId));
+				request.RequestedBy.Gameworld.Add(simulationCell);
+				simulationCells[sourceCell] = simulationCell;
+				if (sourceCellEffects.TryGetValue(sourceCell, out var sourceEffects) && sourceEffects is not null)
+				{
+					TryRestoreEffects(() => simulationCell.RestoreCombatSimulationEffects(sourceEffects), validation,
+						$"Some effects in {sourceCell.Name} could not be cloned and were omitted.");
+				}
 			}
+
+			CreateSimulationTopology(request, simulationCells, simulationExits, validation, executionFingerprint);
 
 			foreach (var snapshot in snapshots)
 			{
 				executionFingerprint.RecordMaterialisation(snapshot.Request);
-				var participant = MaterialiseParticipant(snapshot, simulationCell, transcript, validation,
+				var sourceCell = snapshot.Request.StartingCell ?? request.Scene;
+				var participant = MaterialiseParticipant(snapshot, simulationCells[sourceCell], transcript, validation,
 					executionFingerprint);
 				runtimeParticipants.Add(participant);
 			}
@@ -474,7 +553,7 @@ public sealed class CombatSimulationService : ICombatSimulationService
 			{
 				TryCleanup(
 					() => Cleanup(request.RequestedBy.Gameworld, originalActors, originalCachedActors, originalBodies,
-						originalItems, simulationCell), cleanupErrors);
+						originalItems, simulationExits, simulationCells.Values), cleanupErrors);
 			}
 
 			TryCleanup(() => transaction?.Rollback(), cleanupErrors);
@@ -552,6 +631,51 @@ public sealed class CombatSimulationService : ICombatSimulationService
 		}).ToList();
 	}
 
+	private static void CreateSimulationTopology(
+		CombatSimulationRequest request,
+		IReadOnlyDictionary<ICell, Cell> simulationCells,
+		ICollection<IExit> simulationExits,
+		ICollection<CombatSimulationValidationMessage> validation,
+		CombatSimulationExecutionFingerprint executionFingerprint)
+	{
+		var seenSourceExits = new HashSet<IExit>(ReferenceEqualityComparer.Instance);
+		foreach (var sourceCell in StagedCells(request))
+		{
+			foreach (var sourceCellExit in request.RequestedBy.Gameworld.ExitManager.GetExitsFor(sourceCell))
+			{
+				var sourceExit = sourceCellExit.Exit;
+				if (!seenSourceExits.Add(sourceExit) || !simulationCells.TryGetValue(sourceCellExit.Destination, out var destination))
+				{
+					continue;
+				}
+
+				if (sourceExit.Door is not null)
+				{
+					validation.Add(new CombatSimulationValidationMessage(false,
+						$"The staged exit from {sourceCell.Name} to {sourceCellExit.Destination.Name} has a door and was omitted so the simulation cannot mutate live door state."));
+					continue;
+				}
+
+				var transientExit = new TransientExit(
+					request.RequestedBy.Gameworld,
+					simulationCells[sourceCell],
+					destination,
+					sourceExit,
+					sourceCell,
+					$"combat-simulation:{request.RunId:D}:{sourceExit.Id:N0}");
+				request.RequestedBy.Gameworld.ExitManager.RegisterTransientExit(transientExit);
+				simulationExits.Add(transientExit);
+				executionFingerprint.RecordTopology(
+					$"exit:{sourceCell.Id}:{sourceCellExit.Destination.Id}:{sourceExit.Id}:{sourceCellExit.OutboundDirection}");
+			}
+		}
+
+		foreach (var sourceCell in StagedCells(request).OrderBy(x => x.Id))
+		{
+			executionFingerprint.RecordTopology($"cell:{sourceCell.Id}");
+		}
+	}
+
 	private static RuntimeParticipant MaterialiseParticipant(
 		SourceSnapshot snapshot,
 		Cell simulationCell,
@@ -572,7 +696,7 @@ public sealed class CombatSimulationService : ICombatSimulationService
 			var clone = new CombatSimulationCharacter(source.Gameworld, template);
 			character = clone;
 			source.Gameworld.Add(clone, true);
-			simulationCell.Enter(clone, noSave: true, roomLayer: source.RoomLayer);
+			simulationCell.Enter(clone, noSave: true, roomLayer: snapshot.Request.StartingLayer);
 			clone.CopyCombatSimulationStateFrom(source);
 			((BodyImplementation)clone.Body).CopyCombatSimulationBiologyFrom(source.Body);
 			CharacterInstanceService.CloneInventory(source, clone, out var inventoryResult);
@@ -602,7 +726,7 @@ public sealed class CombatSimulationService : ICombatSimulationService
 			materialisedNpc = npc;
 			character = npc;
 			npcTemplate.Gameworld.Add(npc, true);
-			simulationCell.Enter(npc, noSave: true, roomLayer: npc.RoomLayer);
+			simulationCell.Enter(npc, noSave: true, roomLayer: snapshot.Request.StartingLayer);
 			foreach (var warning in npcTemplate.ApplyTemplateLoadAdditions(npc, false))
 			{
 				validation.Add(new CombatSimulationValidationMessage(false,
@@ -611,6 +735,10 @@ public sealed class CombatSimulationService : ICombatSimulationService
 
 			npcTemplate.OnLoadProg?.Execute(npc);
 		}
+
+		character.PositionState = snapshot.Request.StartingPosition ?? PositionStanding.Instance;
+		character.PositionModifier = PositionModifier.None;
+		character.PositionTarget = null;
 
 		var name = character.PersonalName.GetName(Character.Name.NameStyle.SimpleFull);
 		character.Register(new CombatSimulationOutputHandler(transcript,
@@ -640,7 +768,10 @@ public sealed class CombatSimulationService : ICombatSimulationService
 			$"gender:{(int)character.Gender.Enum}",
 			$"height:{character.Height.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}",
 			$"weight:{character.Weight.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}",
-			$"stamina:{character.CurrentStamina.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}"
+			$"stamina:{character.CurrentStamina.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}",
+			$"location:{(character.Location as Cell)?.DatabaseLocationId ?? character.Location.Id}",
+			$"layer:{(int)character.RoomLayer}",
+			$"position:{character.PositionState.Id}"
 		]);
 		fingerprint.RecordMaterialisationRuntimeState(slot, "attributes", template.SelectedAttributes
 			.OrderBy(x => x.Definition.Id)
@@ -932,8 +1063,14 @@ public sealed class CombatSimulationService : ICombatSimulationService
 		ISet<ICharacter> originalCachedActors,
 		ISet<MudSharp.Body.IBody> originalBodies,
 		ISet<MudSharp.GameItems.IGameItem> originalItems,
-		Cell? simulationCell)
+		IEnumerable<IExit> simulationExits,
+		IEnumerable<Cell> simulationCells)
 	{
+		foreach (var simulationExit in simulationExits)
+		{
+			gameworld.ExitManager.UnregisterTransientExit(simulationExit);
+		}
+
 		foreach (var actor in gameworld.Actors.Where(x => !originalActors.Contains(x)).ToList())
 		{
 			DetachActor(actor);
@@ -961,7 +1098,7 @@ public sealed class CombatSimulationService : ICombatSimulationService
 			gameworld.Destroy(body);
 		}
 
-		if (simulationCell is not null)
+		foreach (var simulationCell in simulationCells)
 		{
 			gameworld.Destroy(simulationCell);
 		}

--- a/MudSharpCore/Construction/Boundary/TransientExit.cs
+++ b/MudSharpCore/Construction/Boundary/TransientExit.cs
@@ -49,6 +49,84 @@ public class TransientExit : PerceivedItem, ITransientExit, IMagicPortalExit
 			outboundDescription, inboundTarget, inboundDescription, outboundTarget);
 	}
 
+	/// <summary>
+	/// Creates an isolated copy of one existing exit between two transient cells. The copied exit deliberately
+	/// has no door reference, so a combat simulation can never open, close or otherwise mutate a live door.
+	/// </summary>
+	internal TransientExit(
+		IFuturemud gameworld,
+		ICell origin,
+		ICell destination,
+		IExit sourceExit,
+		ICell sourceOrigin,
+		string stableKey)
+	{
+		var sourceOriginExit = sourceExit.CellExitFor(sourceOrigin) ??
+		                       throw new ArgumentException("The source exit does not leave the supplied source cell.",
+			                       nameof(sourceOrigin));
+		var sourceDestinationExit = sourceOriginExit.Opposite ??
+		                            throw new ArgumentException("The source exit has no opposite side.", nameof(sourceExit));
+		Gameworld = gameworld;
+		_id = Interlocked.Decrement(ref _nextId);
+		IdInitialised = true;
+		_name = $"transient portal {Math.Abs(_id):N0}";
+		_cells.Add(origin);
+		_cells.Add(destination);
+		TimeMultiplier = sourceExit.TimeMultiplier;
+		MaximumSizeToEnter = sourceExit.MaximumSizeToEnter;
+		MaximumSizeToEnterUpright = sourceExit.MaximumSizeToEnterUpright;
+		AcceptsDoor = sourceExit.AcceptsDoor;
+		DoorSize = sourceExit.DoorSize;
+		IsClimbExit = sourceExit.IsClimbExit;
+		ClimbDifficulty = sourceExit.ClimbDifficulty;
+		foreach (var blockedLayer in sourceExit.BlockedLayers)
+		{
+			_blockedLayers.Add(blockedLayer);
+		}
+
+		FallCell = ReferenceEquals(sourceExit.FallCell, sourceOrigin)
+			? origin
+			: ReferenceEquals(sourceExit.FallCell, sourceOriginExit.Destination)
+				? destination
+				: null;
+		Caster = null;
+		Spell = null;
+		SourceEffect = null;
+		StableKey = stableKey;
+		Source = origin;
+		Destination = destination;
+		Verb = sourceOriginExit is INonCardinalCellExit nonCardinalOrigin
+			? nonCardinalOrigin.Verb
+			: sourceOriginExit.OutboundDirection.Describe().ToLowerInvariant();
+		OutboundKeyword = sourceOriginExit is INonCardinalCellExit nonCardinalOutbound
+			? nonCardinalOutbound.PrimaryKeyword
+			: sourceOriginExit.OutboundDirection.Describe().ToLowerInvariant();
+		InboundKeyword = sourceDestinationExit is INonCardinalCellExit nonCardinalInbound
+			? nonCardinalInbound.PrimaryKeyword
+			: sourceDestinationExit.OutboundDirection.Describe().ToLowerInvariant();
+
+		if (sourceOriginExit is INonCardinalCellExit sourceNonCardinalOrigin &&
+		    sourceDestinationExit is INonCardinalCellExit sourceNonCardinalDestination)
+		{
+			_cellExits[0] = new NonCardinalCellExit(this, origin, destination,
+				sourceNonCardinalOrigin.Verb, sourceNonCardinalOrigin.PrimaryKeyword,
+				sourceNonCardinalOrigin.Keywords, sourceNonCardinalOrigin.OutboundDescription,
+				sourceNonCardinalOrigin.OutboundTarget, sourceNonCardinalOrigin.InboundDescription,
+				sourceNonCardinalOrigin.InboundTarget);
+			_cellExits[1] = new NonCardinalCellExit(this, destination, origin,
+				sourceNonCardinalDestination.Verb, sourceNonCardinalDestination.PrimaryKeyword,
+				sourceNonCardinalDestination.Keywords, sourceNonCardinalDestination.OutboundDescription,
+				sourceNonCardinalDestination.OutboundTarget, sourceNonCardinalDestination.InboundDescription,
+				sourceNonCardinalDestination.InboundTarget);
+			return;
+		}
+
+		_cellExits[0] = new CellExit(this, origin, destination, sourceOriginExit.OutboundDirection,
+			sourceOriginExit.InboundDirection);
+		_cellExits[1] = new CellExit(this, destination, origin, sourceDestinationExit.OutboundDirection,
+			sourceDestinationExit.InboundDirection);
+	}
+
 	private static IEnumerable<string> KeywordsFor(string target, string keyword)
 	{
 		return target

--- a/MudSharpCore/Construction/Cell.cs
+++ b/MudSharpCore/Construction/Cell.cs
@@ -368,9 +368,7 @@ public partial class Cell : Location, IDisposable, ICell
         return lowest;
     }
 
-    public IEnumerable<ICell> Surrounds => _isCombatSimulationCell
-        ? Enumerable.Empty<ICell>()
-        : Gameworld.ExitManager.GetExitsFor(this).Select(x => x.Destination);
+	public IEnumerable<ICell> Surrounds => Gameworld.ExitManager.GetExitsFor(this).Select(x => x.Destination);
 
     public override string Name => CurrentOverlay.CellName;
 


### PR DESCRIPTION
## Summary

- Extend `impdebug combatsim` to stage combatants across multiple transient cells with configurable inter-cell links.
- Allow each participant to specify a cell, layer, and starting position/state, while preserving defaults of cell 1, ground level, and standing.
- Keep all staged participants in the same combat and leave movement/engagement outcomes to their configured AI and combat settings.
- Update execution fingerprinting, documentation, and regression coverage for the expanded staging model.

## Validation

- `dotnet build MudSharpCore/MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- Focused combat simulation tests: 28/28 passed.
- MudSharpCore unit tests: 2478/2478 passed.
- `git diff --check origin/master...HEAD`

The build reports only the existing nullable-annotation warnings in `CombatMoveBase.cs` and `PerceiverItem.cs`.