### PR TITLE
Fix seeded combat ward messages and pushback display

### DIFF
--- a/DatabaseSeeder Unit Tests/CombatSeederWardMessageTests.cs
+++ b/DatabaseSeeder Unit Tests/CombatSeederWardMessageTests.cs
@@ -1,0 +1,52 @@
+#nullable enable
+
+using DatabaseSeeder.Seeders;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Combat;
+using MudSharp.Database;
+using System;
+using System.Linq;
+using DatabaseCombatMessage = MudSharp.Models.CombatMessage;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class CombatSeederWardMessageTests
+{
+	[TestMethod]
+	public void EnsureWardCombatMessages_ExistingCombatMessages_AddsAndRetainsOneFallbackForEachWardStage()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		context.CombatMessages.Add(new DatabaseCombatMessage
+		{
+			Type = (int)BuiltInCombatMoveType.Dodge,
+			Message = "#1 %1|dodge|dodges",
+			FailureMessage = "#1 %1|fail|fails to dodge",
+			Chance = 1.0,
+			Priority = 1
+		});
+		context.SaveChanges();
+
+		Assert.AreEqual(2, CombatSeeder.EnsureWardCombatMessages(context, SeedCombatMessageStyle.Compact));
+		Assert.AreEqual(0, CombatSeeder.EnsureWardCombatMessages(context, SeedCombatMessageStyle.Compact));
+
+		DatabaseCombatMessage wardDefense = context.CombatMessages.Single(x =>
+			x.Type == (int)BuiltInCombatMoveType.WardDefense);
+		DatabaseCombatMessage wardCounter = context.CombatMessages.Single(x =>
+			x.Type == (int)BuiltInCombatMoveType.WardCounter);
+
+		Assert.AreEqual(", but #1 %1|attempt|attempts to keep $0 at bay", wardDefense.Message);
+		Assert.AreEqual(", and #1 %1|fail|fails to hold $0 at bay", wardCounter.Message);
+		Assert.AreEqual(", but #1 %1|hold|holds $0 at bay", wardCounter.FailureMessage);
+		Assert.AreEqual(3, context.CombatMessages.Count());
+	}
+
+	private static FuturemudDatabaseContext BuildContext()
+	{
+		DbContextOptions<FuturemudDatabaseContext> options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.Options;
+		return new FuturemudDatabaseContext(options);
+	}
+}

--- a/DatabaseSeeder/Seeders/CombatSeeder.Checks.cs
+++ b/DatabaseSeeder/Seeders/CombatSeeder.Checks.cs
@@ -28,6 +28,8 @@ public partial class CombatSeeder
         {
             SeedUnarmedCombatMessage(context, questionAnswers);
         }
+
+        EnsureWardCombatMessages(context, CombatSeederMessageStyleHelper.Parse(questionAnswers["messagestyle"]));
 		EnsureMountedCombatMessages(context);
 
         // Seed Combat Strategies

--- a/DatabaseSeeder/Seeders/CombatSeeder.UnarmedAndDefence.cs
+++ b/DatabaseSeeder/Seeders/CombatSeeder.UnarmedAndDefence.cs
@@ -729,6 +729,51 @@ public partial class CombatSeeder
         #endregion
     }
 
+	internal static int EnsureWardCombatMessages(FuturemudDatabaseContext context, SeedCombatMessageStyle messageStyle)
+	{
+		var changes = 0;
+		var definitions = new (BuiltInCombatMoveType Type, string Message, string Failure)[]
+		{
+			(BuiltInCombatMoveType.WardDefense,
+				CombatSeederMessageStyleHelper.BuildDefenseSuccess(messageStyle,
+					"#1 %1|attempt|attempts to keep $0 at bay"),
+				CombatSeederMessageStyleHelper.BuildDefenseSuccess(messageStyle,
+					"#1 %1|attempt|attempts to keep $0 at bay")),
+			(BuiltInCombatMoveType.WardCounter,
+				$"{CombatSeederMessageStyleHelper.FailurePrefix(messageStyle)}#1 %1|fail|fails to hold $0 at bay",
+				CombatSeederMessageStyleHelper.BuildDefenseSuccess(messageStyle,
+					"#1 %1|hold|holds $0 at bay"))
+		};
+
+		foreach (var definition in definitions)
+		{
+			if (context.CombatMessages.Any(x =>
+				x.Type == (int)definition.Type &&
+				x.Outcome == null &&
+				x.Verb == null &&
+				x.ProgId == null &&
+				x.AuxiliaryProgId == null &&
+				!x.CombatMessagesWeaponAttacks.Any() &&
+				!x.CombatMessagesCombatActions.Any()))
+			{
+				continue;
+			}
+
+			context.CombatMessages.Add(new CombatMessage
+			{
+				Message = definition.Message,
+				FailureMessage = definition.Failure,
+				Type = (int)definition.Type,
+				Chance = 1.0,
+				Priority = 1
+			});
+			changes++;
+		}
+
+		context.SaveChanges();
+		return changes;
+	}
+
 	private static void EnsureMountedCombatMessages(FuturemudDatabaseContext context)
 	{
 		var definitions = new (BuiltInCombatMoveType Type, string Message, string Failure)[]

--- a/DatabaseSeeder/Seeders/CombatSeeder.cs
+++ b/DatabaseSeeder/Seeders/CombatSeeder.cs
@@ -265,6 +265,8 @@ You can choose #3Compact#f, #3Sentences#f or #3Sparse#f",
 			count++;
 		}
 
+		count += EnsureWardCombatMessages(context, CombatSeederMessageStyleHelper.Parse(answers["messagestyle"]));
+
 		return new CombatSeederModuleResult("foundations", count);
 	}
 

--- a/Design Documents/Combat/Combat_Strategy_Runtime.md
+++ b/Design Documents/Combat/Combat_Strategy_Runtime.md
@@ -61,7 +61,7 @@ holder weak without being an absolute substitute for the standard strategy's hel
 
 `RangeBaseStrategy` handles ranged defenses, receive-charge opportunities, and ranged-natural defenses. It delegates magic power attack defense to `StandardMeleeStrategy` so ranged-mode combatants still use ordinary ward/block/parry/dodge coverage against magic. Ranged strategies normally rely on the melee-range setter to switch them to their preferred melee strategy once melee range is established.
 
-`WardStrategy` extends melee defense by trying a ward defense before falling back to standard defense. Wards are available against start-clinch, weapon attacks, and magic attack powers when the defender is not ward-beaten, has stamina, the assailant is upright, and the defender has a usable warding weapon or unarmed ward attack.
+`WardStrategy` extends melee defense by trying a ward defense before falling back to standard defense. Wards are available against start-clinch, weapon attacks, and magic attack powers when the defender is not ward-beaten, has stamina, the assailant is upright, and the defender has a usable warding weapon or unarmed ward attack. The Combat Seeder supplies unfiltered `WardDefense` and `WardCounter` fallback messages; attack-specific messages remain eligible only for their linked attack.
 
 ## Shared Attack Behaviour
 

--- a/MudSharpCore Unit Tests/GameModuleNaturalAttackTests.cs
+++ b/MudSharpCore Unit Tests/GameModuleNaturalAttackTests.cs
@@ -1,0 +1,16 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Combat;
+using MudSharp.Commands.Modules;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class GameModuleNaturalAttackTests
+{
+	[TestMethod]
+	public void NaturalAttackTypesForDisplay_IncludesPushbackUnarmed()
+	{
+		CollectionAssert.Contains(GameModule.NaturalAttackTypesForDisplay,
+			BuiltInCombatMoveType.PushbackUnarmed);
+	}
+}

--- a/MudSharpCore/Commands/Modules/GameModule.cs
+++ b/MudSharpCore/Commands/Modules/GameModule.cs
@@ -37,6 +37,29 @@ internal class GameModule : Module<ICharacter>
     public static GameModule Instance { get; } = new();
     public override int CommandsDisplayOrder => 0;
 
+    internal static readonly BuiltInCombatMoveType[] NaturalAttackTypesForDisplay =
+    [
+        BuiltInCombatMoveType.NaturalWeaponAttack,
+        BuiltInCombatMoveType.StaggeringBlowUnarmed,
+        BuiltInCombatMoveType.DownedAttackUnarmed,
+        BuiltInCombatMoveType.UnbalancingBlowUnarmed,
+        BuiltInCombatMoveType.PushbackUnarmed,
+        BuiltInCombatMoveType.ScreechAttack,
+        BuiltInCombatMoveType.WardFreeUnarmedAttack,
+        BuiltInCombatMoveType.ClinchUnarmedAttack,
+        BuiltInCombatMoveType.UnarmedSmashItem,
+        BuiltInCombatMoveType.EnvenomingAttack,
+        BuiltInCombatMoveType.EnvenomingAttackClinch,
+        BuiltInCombatMoveType.UnbalancingBlowClinch,
+        BuiltInCombatMoveType.StaggeringBlowClinch,
+        BuiltInCombatMoveType.SwoopAttackUnarmed,
+        BuiltInCombatMoveType.RangedNaturalAttack,
+        BuiltInCombatMoveType.BreathWeaponAttack,
+        BuiltInCombatMoveType.SpitNaturalAttack,
+        BuiltInCombatMoveType.ExplosiveNaturalAttack,
+        BuiltInCombatMoveType.BuffetingNaturalAttack
+    ];
+
     [PlayerCommand("SkillLevels", "skilllevels")]
     [HelpInfo("skilllevels", @"The #3skilllevels#0 command lists the named skill or attribute's descriptive level bands in order. Administrators can inspect any defined trait; other characters can inspect only their own traits.
 
@@ -286,25 +309,8 @@ For a full list of combat flags, see #3SHOW COMBATFLAGS#0", AutoHelp.HelpArg)]
         {
             sb.AppendLine($"You are currently able to use the following unarmed attacks:\n");
             sb.AppendLine(StringUtilities.GetTextTable(
-                from attack in actor.Race.UsableNaturalWeaponAttacks(actor, null, true, BuiltInCombatMoveType.NaturalWeaponAttack,
-                    BuiltInCombatMoveType.StaggeringBlowUnarmed,
-                    BuiltInCombatMoveType.DownedAttackUnarmed,
-                    BuiltInCombatMoveType.UnbalancingBlowUnarmed,
-                    BuiltInCombatMoveType.ScreechAttack,
-                    BuiltInCombatMoveType.WardFreeUnarmedAttack,
-                    BuiltInCombatMoveType.ClinchUnarmedAttack,
-                    BuiltInCombatMoveType.UnarmedSmashItem,
-                    BuiltInCombatMoveType.EnvenomingAttack,
-                    BuiltInCombatMoveType.EnvenomingAttackClinch,
-                    BuiltInCombatMoveType.UnbalancingBlowClinch,
-                    BuiltInCombatMoveType.StaggeringBlowClinch,
-                    BuiltInCombatMoveType.SwoopAttackUnarmed,
-                    BuiltInCombatMoveType.RangedNaturalAttack,
-                    BuiltInCombatMoveType.BreathWeaponAttack,
-                    BuiltInCombatMoveType.SpitNaturalAttack,
-                    BuiltInCombatMoveType.ExplosiveNaturalAttack,
-                    BuiltInCombatMoveType.BuffetingNaturalAttack
-                ).Select(x => x.Attack).Distinct()
+                from attack in actor.Race.UsableNaturalWeaponAttacks(actor, null, true,
+                    NaturalAttackTypesForDisplay).Select(x => x.Attack).Distinct()
                 select new List<string>
                 {
                     attack.Name,


### PR DESCRIPTION
## Summary

- Add idempotent WardDefense and WardCounter fallback messages to fresh and existing Combat Seeder paths.
- Include PushbackUnarmed in the player-facing natural attack list.
- Document the fallback and attack-specific message selection, with regression coverage.

## Validation

- DatabaseSeeder and MudSharpCore builds passed.
- DatabaseSeeder Unit Tests: 704 passed.
- MudSharpCore Unit Tests: 2,479 passed.