### PR TITLE
Release Engine 2.7.0, Seeder 3.2.0 and MudClient 1.3.2

### DIFF
--- a/DatabaseSeeder/BlankDatabaseSnapshot.manifest.json
+++ b/DatabaseSeeder/BlankDatabaseSnapshot.manifest.json
@@ -1,5 +1,5 @@
 {
-  "ProductVersion": "3.1.0.0",
+  "ProductVersion": "3.2.0.0",
   "LatestMigrationId": "20260825022721_AddRacePainToleranceMultiplier",
   "GeneratedUtc": "2026-08-25T05:22:25.3377148Z"
 }

--- a/DatabaseSeeder/DatabaseSeeder.csproj
+++ b/DatabaseSeeder/DatabaseSeeder.csproj
@@ -4,9 +4,9 @@
 	<OutputType>Exe</OutputType>
 	<TargetFramework>net10.0</TargetFramework>
 	<Nullable>enable</Nullable>
-	<Version>3.1.0</Version>
-	<AssemblyVersion>3.1.0</AssemblyVersion>
-	<FileVersion>3.1.0</FileVersion>
+	<Version>3.2.0</Version>
+	<AssemblyVersion>3.2.0</AssemblyVersion>
+	<FileVersion>3.2.0</FileVersion>
   </PropertyGroup>
 
 	<PropertyGroup>

--- a/FutureMUD.Web/Content/PatchNotes/2026-08-25-database-seeder-3-2-0.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-08-25-database-seeder-3-2-0.md
@@ -1,0 +1,25 @@
+---
+title: Database Seeder 3.2.0
+summary: Expands ready-to-run restaurant, wildlife, trap and combat starting content, with a current blank database snapshot.
+date: 2026-08-25
+tags: seeder, release, upgrade, content
+---
+**Upgrade note:** Database Seeder 3.2.0 targets .NET 10. Install the .NET 10 runtime before using the framework-dependent download.
+
+## A More Complete Living-World Catalogue
+
+The stock animal catalogue now provides practical wildlife and managed-group foundations: habitat-aware animals, coordinated social groups, shelters, deterministic race recommendations and durable ecology metadata. Builders can begin with useful wild and managed examples rather than constructing every behavioural profile from scratch.
+
+Animal, mythical and supernatural catalogues now share a reviewed combat foundation. Stock creatures receive consistent physical attributes, pain tolerance, armour, bodypart weights, natural attacks and signature actions appropriate to their role. Rerunning the owned stock package reconciles those maintained fields without overwriting builder-created content.
+
+## Playable Sites And Physical Hazards
+
+Restaurant-supporting seed content now accompanies the Engine's staffed dine-in and takeaway workflows, giving new worlds practical starting definitions for food preparation and service.
+
+The seeder also includes the complete physical trap foundation: templates, triggers, ordered payloads, component dependencies and spent-item handling for mechanical, magical and natural hazards. This makes the Engine's regular `traptemplate` and `trap` workflow usable from a new installation without hand-assembling its prerequisites.
+
+## Installation And Maintenance
+
+The bundled blank database snapshot is current through `20260825022721_AddRacePainToleranceMultiplier`, allowing a clean installation to begin from the maintained schema baseline. It remains guarded by migration validation, so the installer falls back safely to normal migrations whenever a snapshot is not current.
+
+Stock package dependencies, idempotent reconciliation and clearer prerequisite diagnostics continue to keep the catalogue suitable both for new worlds and for maintainers adding supported content to an existing world.

--- a/FutureMUD.Web/Content/PatchNotes/2026-08-25-engine-2-7-0.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-08-25-engine-2-7-0.md
@@ -1,0 +1,31 @@
+---
+title: FutureMUD Engine 2.7.0
+summary: Adds restaurant table service, wildlife and animal-combat foundations, plus deterministic accelerated combat simulation.
+date: 2026-08-25
+tags: engine, release, upgrade, builders, simulation
+---
+**Upgrade note:** Apply the normal database upgrades before starting Engine 2.7.0. This release keeps the .NET 10 and MySQL 8.0 requirements and the Windows x64, Linux x64 and Linux ARM64 package set.
+
+## Restaurants As Social Play Spaces
+
+Restaurants are now specialised permanent shops with menus, dine-in table sessions, takeaway orders and bill settlement. Hosts can choose and configure real preparation paths for opened, crafted, plated and packed food; designated tables receive physical dishes and serviceware rather than only a text receipt.
+
+Builders can put their existing employee definitions to work as chefs and servers. These NPCs use the ordinary crafting and item-operation paths, visibly prepare and deliver food, and clear finished serviceware. Restaurant settings also support authorable chef and server emotes, participant consent for shared tables, and the existing legal consequences for leaving without settling a bill.
+
+## Living Wildlife And More Expressive Combat
+
+Animal AI now supports durable wildlife profiles, habitat and activity choices, threat and sense policies, shelter ownership, and coordinating groups such as herds, packs, flocks, schools, pods, colonies and swarms. Founder diagnostics make it practical to inspect the resulting behaviour and group state in a live world.
+
+Mounted combat adds deliberate charge, skirmish and hit-and-run tactics with weapon tiers. Animal, mythical and supernatural stock combatants have been brought onto a consistent balance model: their physical profiles, armour, pain tolerance, natural attacks and signature abilities now give builders a dependable starting point while respecting custom records.
+
+## Accelerated Combat Simulation
+
+Founders can use `impdebug combatsim` to stage individual or group combat in an isolated, accelerated simulation. A seeded virtual clock and deterministic random source make runs repeatable; transcripts, outcomes, batches and execution fingerprints make results inspectable rather than opaque.
+
+The simulator isolates ordinary saves, crime creation and scheduled world work, and explicitly reports external or direct-data side effects that cannot be contained. It is therefore useful for testing combat templates and balance without turning a diagnostic run into a live-world event.
+
+## Reliability And Presentation
+
+This release also improves restaurant service timing, aquatic animal behaviour, breathable-gas handling, combat-simulation participant loading and a number of player-facing combat messages. The result is clearer output and more reliable runtime behaviour across the newly expanded systems.
+
+Use [/downloads](/downloads) for release archives and checksums, [/getting-started](/getting-started) for installation requirements, and [/docs/commands](/docs/commands) for the published Engine reference.

--- a/FutureMUD.Web/Content/PatchNotes/2026-08-25-mudclient-1-3-2.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-08-25-mudclient-1-3-2.md
@@ -1,0 +1,19 @@
+---
+title: FutureMUD Web MUD Client 1.3.2
+summary: Hardens client deployment ownership, connection cleanup and trusted browser identity forwarding.
+date: 2026-08-25
+tags: mudclient, release, security, upgrade
+---
+**Upgrade note:** Web MUD Client 1.3.2 remains self-contained for Windows x64, Linux x64 and Linux ARM64. Upgrade the FutureMUD Engine before enabling trusted browser identity forwarding; the matching Engine release understands the PROXY header.
+
+## Safer Edge Deployment
+
+Linux deployment and update ownership are now hardened so that release files, verification tools and the unprivileged proxy service retain their intended separation. The updater continues to verify the signed update manifest and archive checksum before activation, preserves rollback releases, and leaves operator-owned configuration in its durable location.
+
+## Reliable Connections And Shared Engine Protections
+
+The proxy now closes detached asynchronous account connections through the transport lifecycle and more consistently forwards the browser's client address to a trusted FutureMUD Engine. This keeps the Engine's established bans, registration controls and flood protections as the one source of truth for Telnet and WebSocket players.
+
+Continue to keep the proxy bound privately, use HTTPS/WSS publicly, require the exact public `AllowedOrigins`, and list only the proxy's trusted address on the third line of `Connection.config`.
+
+Use [/downloads](/downloads) for release archives and checksums. Package-local deployment instructions remain the source of truth for installation and rollback commands.

--- a/MudClient/DEPLOYMENT.md
+++ b/MudClient/DEPLOYMENT.md
@@ -33,12 +33,12 @@ Linux additionally requires systemd, bash, curl, unzip, and Caddy v2 managed by 
 
 MudClient 1.2.0 is the first release with a safe upgrade layout. Its release files are immutable under `releases/<version>`; on Linux they remain root-owned and are not writable by the `mudclient` proxy account because root invokes the updater and verification tools from the active release. `current`, `web`, and `proxy` stay at stable paths so an upgrade does not alter Caddy, DNS, TLS, firewall, MUD, or database configuration. Operator settings are moved to `/etc/mudclient` on Linux and `%ProgramData%\FutureMUD\MudClient` on Windows.
 
-To migrate an existing 1.0.1 or 1.1.0 Linux installation, download and extract the 1.3.1 archive once, then run the installer with the original archive:
+To migrate an existing 1.0.1 or 1.1.0 Linux installation, download and extract the 1.3.2 archive once, then run the installer with the original archive:
 
 ~~~bash
-unzip mudclient-1.3.1-linux-x64.zip -d /tmp/mudclient-1.3.1
-sudo bash /tmp/mudclient-1.3.1/mudclient-1.3.1-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.3.1-linux-x64.zip" --migrate
+unzip mudclient-1.3.2-linux-x64.zip -d /tmp/mudclient-1.3.2
+sudo bash /tmp/mudclient-1.3.2/mudclient-1.3.2-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.3.2-linux-x64.zip" --migrate
 ~~~
 
 The command keeps the old release as a rollback target, copies proxy and browser settings to durable locations, and retains the existing Caddy configuration. It briefly restarts only the private proxy, so connected browser sessions disconnect and can reconnect; the MUD itself is not restarted.
@@ -51,14 +51,14 @@ sudo /opt/mudclient/current/deploy/linux/update-mudclient.sh
 
 Use `--check` to inspect the signed latest manifest without changing files, or `--rollback` to activate the previous local release. The updater verifies an Ed25519-signed manifest and archive SHA-256 before staging, preserves two prior releases, and restores the prior release if the proxy health check fails.
 
-On Windows, extract the 1.3.1 archive once and run this from an elevated PowerShell window:
+On Windows, extract the 1.3.2 archive once and run this from an elevated PowerShell window:
 
 ~~~powershell
-& 'C:\staging\mudclient-1.3.1-win-x64\deploy\windows\Install-MudClient.ps1' `
-  -ArchivePath 'C:\Users\Administrator\Downloads\mudclient-1.3.1-win-x64.zip' -Migrate
+& 'C:\staging\mudclient-1.3.2-win-x64\deploy\windows\Install-MudClient.ps1' `
+  -ArchivePath 'C:\Users\Administrator\Downloads\mudclient-1.3.2-win-x64.zip' -Migrate
 ~~~
 
-Version 1.3.1 can resume an interrupted 1.2.0-1.2.4 migration. It stops the legacy proxy scheduled task and any remaining proxy process before moving the old directories, completes a partially moved legacy `proxy`/`web` pair, reuses the preserved legacy release, and replaces an inactive staged copy before retrying. It also supplies the required .NET Windows Service lifetime for the native `MudClientProxy` service. If activation fails, the legacy task is restored to its previous running state, rollback warnings are reported separately, and the original activation error remains visible.
+Version 1.3.2 retains the resilient 1.2.0-1.2.4 migration path. It stops the legacy proxy scheduled task and any remaining proxy process before moving the old directories, completes a partially moved legacy `proxy`/`web` pair, reuses the preserved legacy release, and replaces an inactive staged copy before retrying. It also supplies the required .NET Windows Service lifetime for the native `MudClientProxy` service. If activation fails, the legacy task is restored to its previous running state, rollback warnings are reported separately, and the original activation error remains visible.
 
 If a failed earlier migration left stale `current`, `web`, or `proxy` links, stop the proxy and remove only those reparse points before retrying. This does not remove ordinary configuration directories:
 
@@ -87,16 +87,16 @@ Later Windows updates use:
 After verifying the website's published SHA-256 checksum, extract the downloaded package to `/opt/mudclient` and run the installer from that directory:
 
 ~~~bash
-unzip mudclient-1.3.1-linux-x64.zip -d /tmp/mudclient-package
-sudo bash /tmp/mudclient-package/mudclient-1.3.1-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.3.1-linux-x64.zip" --domain play.example.com
+unzip mudclient-1.3.2-linux-x64.zip -d /tmp/mudclient-package
+sudo bash /tmp/mudclient-package/mudclient-1.3.2-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.3.2-linux-x64.zip" --domain play.example.com
 ~~~
 
 The script creates the unprivileged proxy service, writes the exact trusted public origin, adds an isolated Caddy site fragment, validates Caddy before reload, and checks the private health endpoint. The selected domain must already resolve to the host. To connect to a MUD on a private network rather than the same machine:
 
 ~~~bash
-sudo bash /tmp/mudclient-package/mudclient-1.3.1-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.3.1-linux-x64.zip" --domain play.example.com --mud-host 10.0.0.20 --mud-port 4000
+sudo bash /tmp/mudclient-package/mudclient-1.3.2-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.3.2-linux-x64.zip" --domain play.example.com --mud-host 10.0.0.20 --mud-port 4000
 ~~~
 
 Use `CADDY_CONFIG` and `CADDY_FRAGMENTS_DIR` for nonstandard Caddyfile locations. The installer saves `.before-mudclient-install` backups of the files it changes; review those and take a normal deployment backup before upgrading an existing installation.
@@ -112,7 +112,7 @@ dotnet workload install wasm-tools
 ```
 
 ```powershell
-.\scripts\Publish-ProductPackage.ps1 -RuntimeIdentifier win-x64 -Version 1.3.1
+.\scripts\Publish-ProductPackage.ps1 -RuntimeIdentifier win-x64 -Version 1.3.2
 ```
 
 ```bash

--- a/MudClient/Deployment/Windows_AWS_Web_Client_Guide.md
+++ b/MudClient/Deployment/Windows_AWS_Web_Client_Guide.md
@@ -1,6 +1,6 @@
 # Windows and AWS Web Client Setup Guide
 
-This is a deliberately plain-English guide for installing FutureMUD Web MUD Client 1.3.1 on a Windows server hosted in AWS. It adds a small HTTPS website alongside an existing FutureMUD game, without changing the game itself or any other applications on the server.
+This is a deliberately plain-English guide for installing FutureMUD Web MUD Client 1.3.2 on a Windows server hosted in AWS. It adds a small HTTPS website alongside an existing FutureMUD game, without changing the game itself or any other applications on the server.
 
 The names and addresses below are examples. Before using a command, replace `play.example.com` with your own player-facing hostname. Do not put a live server's IP address, AWS instance ID, administrator account name, or credentials in a public guide or repository.
 
@@ -64,7 +64,7 @@ Name them clearly, for example `Web MUD Client HTTP` and `Web MUD Client HTTPS`.
 Open an **Administrator PowerShell** window on the Windows server and run the following. It creates a new, dedicated folder and does not overwrite the game installation.
 
 ```powershell
-$version = '1.3.1'
+$version = '1.3.2'
 $archive = "$env:USERPROFILE\Downloads\mudclient-$version-win-x64.zip"
 $staging = "C:\MudClient-$version"
 
@@ -89,7 +89,7 @@ C:\MudClient\web\wwwroot\index.html
 C:\MudClient\deploy\windows\Caddyfile
 ```
 
-For an existing 1.0.1 or 1.1.0 installation, use the same command with `-Migrate`. It preserves the old release and existing Caddyfile, moves proxy/browser settings to `%ProgramData%\FutureMUD\MudClient`, and replaces only the old proxy task with a correctly hosted native Windows Service. Version 1.3.1 stops the old proxy task and any remaining proxy process before moving its directory, resumes a partially completed 1.2.0-1.2.4 migration, restores the old task if activation fails, and reports the original activation error even if a rollback step has its own problem.
+For an existing 1.0.1 or 1.1.0 installation, use the same command with `-Migrate`. It preserves the old release and existing Caddyfile, moves proxy/browser settings to `%ProgramData%\FutureMUD\MudClient`, and replaces only the old proxy task with a correctly hosted native Windows Service. Version 1.3.2 retains the guarded legacy migration path: it stops the old proxy task and any remaining proxy process before moving its directory, resumes a partially completed 1.2.0-1.2.4 migration, restores the old task if activation fails, and reports the original activation error even if a rollback step has its own problem.
 
 After that one-time migration, an Administrator updates the client with one command:
 

--- a/MudClient/MudClientBlazor/MudClientBlazor.csproj
+++ b/MudClient/MudClientBlazor/MudClientBlazor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/MudClient/MudClientDeployment/MudClientDeployment.csproj
+++ b/MudClient/MudClientDeployment/MudClientDeployment.csproj
@@ -5,7 +5,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<Version>1.3.1</Version>
+		<Version>1.3.2</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj
+++ b/MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.3.1</Version>
+		<Version>1.3.2</Version>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/MudSharpCore/MudSharpCore.csproj
+++ b/MudSharpCore/MudSharpCore.csproj
@@ -10,9 +10,9 @@
 	<Product>FutureMUD</Product>
 	<ApplicationIcon>FM Logo.ico</ApplicationIcon>
 	<AssemblyName>MudSharp</AssemblyName>
-	<Version>2.6.0</Version>
-	<AssemblyVersion>2.6.0</AssemblyVersion>
-	<FileVersion>2.6.0</FileVersion>
+	<Version>2.7.0</Version>
+	<AssemblyVersion>2.7.0</AssemblyVersion>
+	<FileVersion>2.7.0</FileVersion>
   </PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
## Release preparation

- FutureMUD Engine 2.7.0: restaurant table service, wildlife and combat foundations, and accelerated deterministic combat simulation.
- Database Seeder 3.2.0: ready-to-run restaurant, wildlife, trap and combat stock content; the bundled snapshot manifest now identifies the released product version and current migration baseline.
- FutureMUD Web MUD Client 1.3.2: hardened deployment ownership, connection cleanup and trusted browser identity forwarding, with versioned deployment instructions.
- Adds narrative public patch notes for all three products.

## Validation

- `dotnet test "MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj" -c Release --no-build --no-restore -m:1` — 2,488 passed.
- `dotnet test "DatabaseSeeder Unit Tests/DatabaseSeeder Unit Tests.csproj" -c Release --no-build --no-restore -m:1` — 715 passed.
- `dotnet test "MudClient/MudClientTests/MudClientTests.csproj" -c Release --no-restore -m:1` — 136 passed.
- `dotnet test "FutureMUD.Web.Tests/FutureMUD.Web.Tests.csproj" -c Release --no-restore -m:1` — 51 passed.
- Engine documentation export populated commands, FutureProg functions/types, collection extensions and item components.
- Representative Engine and Seeder Windows x64 packages and a self-contained MudClient Windows x64 package were built and inspected; the client package contains its verifier, proxy, and Windows/Linux deployment wrappers.
- `git diff --check` passed.