### PR TITLE
Fix Terrain Planner release manifest validation

### DIFF
--- a/.github/workflows/publish-products.yml
+++ b/.github/workflows/publish-products.yml
@@ -117,6 +117,21 @@ jobs:
               SingleFile = $true
               IncludeNativeLibrariesForSelfExtract = $true
             }
+            terrainapi = [pscustomobject]@{
+              TagPrefix = 'terrainapi-v'
+              ProjectPath = ''
+              TestProjects = [string[]]@()
+              Runtimes = [string[]]@('win-x64', 'linux-x64')
+              ArchiveName = 'terrainapi-{version}-{runtime}.zip'
+              DocumentationCatalogue = $false
+              PackageKind = 'single-file'
+              WebProjectPath = ''
+              PackageScriptPath = ''
+              FrameworkDependent = $true
+              SingleFile = $true
+              IncludeNativeLibrariesForSelfExtract = $true
+              Retired = $true
+            }
             mudclient = [pscustomobject]@{
               TagPrefix = 'mudclient-v'
               ProjectPath = 'MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj'
@@ -132,7 +147,7 @@ jobs:
               IncludeNativeLibrariesForSelfExtract = $true
             }
           }
-          $allowedIds = [string[]]@('engine', 'seeder', 'discordbot', 'terrainplanner', 'mudclient')
+          $allowedIds = [string[]]@('engine', 'seeder', 'discordbot', 'terrainplanner', 'terrainapi', 'mudclient')
 
           $tagMatch = [regex]::Match(
             $env:RELEASE_TAG,
@@ -188,6 +203,7 @@ jobs:
                  [bool]$candidate.frameworkDependent -ne $allowed.FrameworkDependent -or
                  [bool]$candidate.singleFile -ne $allowed.SingleFile -or
                  [bool]$candidate.includeNativeLibrariesForSelfExtract -ne $allowed.IncludeNativeLibrariesForSelfExtract -or
+                 [bool]$candidate.retired -ne [bool]$allowed.Retired -or
                 [bool]$candidate.documentationCatalogue -ne $allowed.DocumentationCatalogue) {
               throw "Product '$id' does not match the workflow allowlist."
             }

--- a/FutureMUD.Web.Tests/ReleasePackagingManifestTests.cs
+++ b/FutureMUD.Web.Tests/ReleasePackagingManifestTests.cs
@@ -43,4 +43,32 @@ public class ReleasePackagingManifestTests
 		Assert.AreEqual("TerrainPlanner/scripts/Publish-ProductPackage.ps1", terrainPlanner.PackageScriptPath);
 		Assert.IsTrue(manifest.Products.Single(product => product.Id == "terrainapi").Retired);
 	}
+
+	[TestMethod]
+	public void PublishWorkflow_AllowsRetiredTerrainApiManifestEntryWithoutPublishingIt()
+	{
+		var repositoryRoot = LocateRepositoryRoot();
+		var workflow = File.ReadAllText(Path.Combine(repositoryRoot.FullName, ".github", "workflows", "publish-products.yml"));
+
+		StringAssert.Contains(
+			workflow,
+			"$allowedIds = [string[]]@('engine', 'seeder', 'discordbot', 'terrainplanner', 'terrainapi', 'mudclient')");
+		StringAssert.Contains(workflow, "terrainapi = [pscustomobject]@{");
+		StringAssert.Contains(workflow, "Retired = $true");
+		var publishingTagRegex = workflow
+			.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+			.Single(line => line.Contains(@"\A(?<product>", StringComparison.Ordinal));
+		Assert.IsFalse(publishingTagRegex.Contains("terrainapi", StringComparison.Ordinal));
+	}
+
+	private static DirectoryInfo LocateRepositoryRoot()
+	{
+		var directory = new DirectoryInfo(AppContext.BaseDirectory);
+		while (directory is not null && !Directory.Exists(Path.Combine(directory.FullName, ".github")))
+		{
+			directory = directory.Parent;
+		}
+
+		return directory ?? throw new DirectoryNotFoundException("Could not locate the FutureMUD repository root.");
+	}
 }


### PR DESCRIPTION
## Summary
- retain retired `terrainapi` as an explicitly allowlisted historical manifest entry
- keep it excluded from release tag triggers and the publishable product regex
- add a regression test covering the retired-entry/publishing boundary

## Failure addressed
`terrainplanner-v2.0.0` workflow run 32959206509 failed in `prepare` because the six-entry product manifest was compared with a five-entry strict allowlist. No package or production mutation occurred.

## Validation
- `FutureMUD.Web.Tests`: 54 passed, 0 failed
- `git diff --check`

The immutable release tag remains on merge commit `3d480dc17fd0618c717b851896458179937fffe3`. After this recovery merges, the existing tag will be replayed via the normal workflow-dispatch input; it will not be moved or recreated.