### PR TITLE
Fix Terrain Planner updater archive download

### DIFF
--- a/FutureMUD.Web/Content/PatchNotes/2026-08-26-terrain-planner-2-0-2.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-08-26-terrain-planner-2-0-2.md
@@ -1,0 +1,10 @@
+---
+title: FutureMUD Terrain Planner & Engine API 2.0.2
+summary: Corrects the Windows updater's signed archive download route.
+date: 2026-08-26
+tags: terrainplanner, release, deployment, bugfix
+---
+
+Terrain Planner & Engine API 2.0.2 corrects the Windows updater's archive URL. The updater now retrieves the signed manifest from the stable `latest` endpoint and downloads its named archive from the matching immutable version endpoint before verifying its signature and SHA-256 checksum.
+
+This makes in-place upgrades from 2.0.0 and 2.0.1 work with the public FutureMUD download service while retaining the same health-checked activation and rollback safeguards.

--- a/TerrainPlanner/TerrainPlanner.Server/TerrainPlanner.Server.csproj
+++ b/TerrainPlanner/TerrainPlanner.Server/TerrainPlanner.Server.csproj
@@ -4,9 +4,9 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>2.0.1</Version>
-		<AssemblyVersion>2.0.1</AssemblyVersion>
-		<FileVersion>2.0.1</FileVersion>
+		<Version>2.0.2</Version>
+		<AssemblyVersion>2.0.2</AssemblyVersion>
+		<FileVersion>2.0.2</FileVersion>
 		<BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
 		<AssemblyName>TerrainPlanner</AssemblyName>
 		<RootNamespace>TerrainPlanner.Server</RootNamespace>

--- a/TerrainPlanner/TerrainPlanner.Tests/DeploymentContractTests.cs
+++ b/TerrainPlanner/TerrainPlanner.Tests/DeploymentContractTests.cs
@@ -56,6 +56,17 @@ public class DeploymentContractTests
 		Assert.IsTrue(windows.Contains("Caddy already contains a site block", StringComparison.Ordinal));
 	}
 
+	[TestMethod]
+	public void WindowsUpdaterDownloadsTheVersionedArchiveEndpoint()
+	{
+		var updater = File.ReadAllText(Path.Combine(RepositoryRoot, "TerrainPlanner", "deploy", "windows",
+			"Update-TerrainPlanner.ps1"));
+
+		Assert.IsTrue(updater.Contains("$latestBase/update-manifest.json", StringComparison.Ordinal));
+		Assert.IsTrue(updater.Contains("downloads/terrainplanner/$($manifest.version)/$archiveName", StringComparison.Ordinal));
+		Assert.IsFalse(updater.Contains("$latestBase/$archiveName", StringComparison.Ordinal));
+	}
+
 	private static string FindRepositoryRoot()
 	{
 		var directory = new DirectoryInfo(AppContext.BaseDirectory);

--- a/TerrainPlanner/deploy/windows/Update-TerrainPlanner.ps1
+++ b/TerrainPlanner/deploy/windows/Update-TerrainPlanner.ps1
@@ -11,13 +11,14 @@ $ErrorActionPreference = 'Stop'
 $work = Join-Path ([IO.Path]::GetTempPath()) ("terrainplanner-update-" + [guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Path $work | Out-Null
 try {
-	$base = 'https://futuremud.com/downloads/terrainplanner/latest'
-	Invoke-WebRequest "$base/update-manifest.json" -OutFile (Join-Path $work 'update-manifest.json')
-	Invoke-WebRequest "$base/update-manifest.sig" -OutFile (Join-Path $work 'update-manifest.sig')
+	$latestBase = 'https://futuremud.com/downloads/terrainplanner/latest'
+	Invoke-WebRequest "$latestBase/update-manifest.json" -OutFile (Join-Path $work 'update-manifest.json')
+	Invoke-WebRequest "$latestBase/update-manifest.sig" -OutFile (Join-Path $work 'update-manifest.sig')
 	$manifest = Get-Content (Join-Path $work 'update-manifest.json') -Raw | ConvertFrom-Json
 	$archiveName = "terrainplanner-$($manifest.version)-$RuntimeIdentifier.zip"
 	$archive = Join-Path $work $archiveName
-	Invoke-WebRequest "$base/$archiveName" -OutFile $archive
+	$archiveUri = "https://futuremud.com/downloads/terrainplanner/$($manifest.version)/$archiveName"
+	Invoke-WebRequest $archiveUri -OutFile $archive
 	$verifier = Join-Path $InstallRoot 'current\tools\TerrainPlanner.Deployment.exe'
 	& $verifier verify --manifest (Join-Path $work 'update-manifest.json') --signature (Join-Path $work 'update-manifest.sig') --archive $archive --runtime $RuntimeIdentifier
 	if ($LASTEXITCODE -ne 0) { throw 'Signed update verification failed.' }


### PR DESCRIPTION
## Summary\n- download the signed manifest from the stable latest endpoint and its archive from the matching immutable version endpoint\n- add a deployment contract test that prevents a regression to the nonexistent latest archive route\n- release as Terrain Planner 2.0.2 with patch notes\n\n## Validation\n- dotnet build TerrainPlanner/TerrainPlanner.Server/TerrainPlanner.Server.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510\n- dotnet test TerrainPlanner/TerrainPlanner.Tests/TerrainPlanner.Tests.csproj -c Debug --no-build --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 (31 passed)\n- PowerShell parser validation for Update-TerrainPlanner.ps1\n- public 2.0.1 immutable archive endpoint and checksum-header check for all three runtimes