### PR TITLE
Fix Terrain Planner Windows upgrade activation

### DIFF
--- a/FutureMUD.Web/Content/PatchNotes/2026-08-27-terrain-planner-2-0-3.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-08-27-terrain-planner-2-0-3.md
@@ -1,0 +1,12 @@
+---
+title: FutureMUD Terrain Planner & Engine API 2.0.3
+summary: Makes Windows in-place upgrades safe and diagnoses service-command failures clearly.
+date: 2026-08-27
+tags: terrainplanner, release, deployment, bugfix
+---
+
+Terrain Planner & Engine API 2.0.3 corrects two Windows upgrade issues found during first hosted deployment. The installer now replaces only its `current` release junction, without prompting to recursively remove the release it points to.
+
+It also configures the existing Windows Service through argument-safe process invocation, preserving the quoted executable command line. If Windows rejects a service configuration, the installer now reports the `sc.exe` exit code and diagnostic output instead of returning a generic failure.
+
+The deployment guide now explains the one-off bootstrap installation needed by early 2.0 releases. After 2.0.3 is installed, the signed updater can perform subsequent upgrades normally.

--- a/TerrainPlanner/DEPLOYMENT.md
+++ b/TerrainPlanner/DEPLOYMENT.md
@@ -78,6 +78,12 @@ Use `linux-arm64` on ARM64 hosts. Windows:
 
 The updater downloads `update-manifest.json`, its Ed25519 signature, and the named archive from futuremud.com. The bundled verifier checks the signature, product/version/runtime identity, size, and SHA-256 before the normal health-checked installer activates it. It automatically reuses the Caddy paths from the Web MUD Client scheduled task; if that task cannot be discovered, pass the same `-CaddyExecutable` and `-Caddyfile` arguments shown above.
 
+### Bootstrap an early 2.0 installation
+
+If your existing installation is 2.0.0 or 2.0.1, install 2.0.3 once using the normal archive-install method above instead of its bundled updater. Those releases used a retired archive route. If a 2.0.2 Windows installation stopped while configuring the service, also use the archive-install method once. This retains the existing shared configuration, MySQL password, service, and Caddy configuration. From 2.0.3 onwards, use the updater command in the preceding section.
+
+During an upgrade, the installer replaces only the `current` release junction. It never recursively deletes the release that junction points to. If Windows reports that the planner service cannot be configured, the installer now includes the exact `sc.exe` output in the error so the failure can be diagnosed safely.
+
 ## Verification
 
 ```bash

--- a/TerrainPlanner/TerrainPlanner.Server/TerrainPlanner.Server.csproj
+++ b/TerrainPlanner/TerrainPlanner.Server/TerrainPlanner.Server.csproj
@@ -4,9 +4,9 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>2.0.2</Version>
-		<AssemblyVersion>2.0.2</AssemblyVersion>
-		<FileVersion>2.0.2</FileVersion>
+		<Version>2.0.3</Version>
+		<AssemblyVersion>2.0.3</AssemblyVersion>
+		<FileVersion>2.0.3</FileVersion>
 		<BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
 		<AssemblyName>TerrainPlanner</AssemblyName>
 		<RootNamespace>TerrainPlanner.Server</RootNamespace>

--- a/TerrainPlanner/TerrainPlanner.Tests/DeploymentContractTests.cs
+++ b/TerrainPlanner/TerrainPlanner.Tests/DeploymentContractTests.cs
@@ -67,6 +67,21 @@ public class DeploymentContractTests
 		Assert.IsFalse(updater.Contains("$latestBase/$archiveName", StringComparison.Ordinal));
 	}
 
+	[TestMethod]
+	public void WindowsInstallerReplacesOnlyJunctionsAndUsesArgumentSafeServiceConfiguration()
+	{
+		var installer = File.ReadAllText(Path.Combine(RepositoryRoot, "TerrainPlanner", "deploy", "windows",
+			"Install-TerrainPlanner.ps1"));
+
+		Assert.IsTrue(installer.Contains("[IO.Directory]::Delete($Path)", StringComparison.Ordinal));
+		Assert.IsTrue(installer.Contains("Refusing to remove '$Path' because it is not a release junction.", StringComparison.Ordinal));
+		Assert.IsTrue(installer.Contains("$startInfo.ArgumentList.Add($argument)", StringComparison.Ordinal));
+		Assert.IsTrue(installer.Contains("'binPath=', $serviceCommand, 'start=', 'auto'", StringComparison.Ordinal));
+		Assert.IsTrue(installer.Contains("New-Item -ItemType Junction -Path $currentPath -Target $previousTarget", StringComparison.Ordinal));
+		Assert.IsTrue(installer.Contains("Terrain Planner activation failed; the previous release was restored.", StringComparison.Ordinal));
+		Assert.IsFalse(installer.Contains("sc.exe config FutureMUDTerrainPlanner binPath=", StringComparison.Ordinal));
+	}
+
 	private static string FindRepositoryRoot()
 	{
 		var directory = new DirectoryInfo(AppContext.BaseDirectory);

--- a/TerrainPlanner/deploy/windows/Install-TerrainPlanner.ps1
+++ b/TerrainPlanner/deploy/windows/Install-TerrainPlanner.ps1
@@ -7,13 +7,61 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+
+function Remove-CurrentReleaseJunction {
+	param([Parameter(Mandatory = $true)][string]$Path)
+
+	if (-not (Test-Path -LiteralPath $Path)) { return }
+	$item = Get-Item -LiteralPath $Path -Force
+	if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne [IO.FileAttributes]::ReparsePoint) {
+		throw "Refusing to remove '$Path' because it is not a release junction."
+	}
+
+	# Directory.Delete removes the junction itself; it does not recurse into or remove its target release.
+	[IO.Directory]::Delete($Path)
+}
+
+function Invoke-ServiceControl {
+	param(
+		[Parameter(Mandatory = $true)][string[]]$Arguments,
+		[Parameter(Mandatory = $true)][string]$FailureMessage
+	)
+
+	$startInfo = [Diagnostics.ProcessStartInfo]::new()
+	$startInfo.FileName = Join-Path $env:SystemRoot 'System32\sc.exe'
+	$startInfo.UseShellExecute = $false
+	$startInfo.RedirectStandardOutput = $true
+	$startInfo.RedirectStandardError = $true
+	foreach ($argument in $Arguments) {
+		[void]$startInfo.ArgumentList.Add($argument)
+	}
+
+	$process = [Diagnostics.Process]::new()
+	$process.StartInfo = $startInfo
+	[void]$process.Start()
+	$standardOutput = $process.StandardOutput.ReadToEnd()
+	$standardError = $process.StandardError.ReadToEnd()
+	$process.WaitForExit()
+	if ($process.ExitCode -ne 0) {
+		$detail = ($standardOutput, $standardError | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) -join [Environment]::NewLine
+		throw "$FailureMessage sc.exe exited with code $($process.ExitCode). $detail"
+	}
+}
+
 $packageRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 $version = (Get-Content -LiteralPath (Join-Path $packageRoot 'version.txt') -Raw).Trim()
 $releaseRoot = Join-Path $InstallRoot "releases\$version"
 $sharedRoot = Join-Path $InstallRoot 'shared'
 $configPath = Join-Path $sharedRoot 'appsettings.Production.json'
 $currentPath = Join-Path $InstallRoot 'current'
-$previousTarget = if (Test-Path -LiteralPath $currentPath) { (Get-Item -LiteralPath $currentPath).Target } else { $null }
+$previousTarget = $null
+if (Test-Path -LiteralPath $currentPath) {
+	$currentItem = Get-Item -LiteralPath $currentPath -Force
+	if (($currentItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne [IO.FileAttributes]::ReparsePoint) {
+		throw "Refusing to replace '$currentPath' because it is not a release junction."
+	}
+	$previousTarget = $currentItem.Target
+}
 
 New-Item -ItemType Directory -Force -Path (Join-Path $InstallRoot 'releases'), $sharedRoot, (Join-Path $sharedRoot 'keys') | Out-Null
 if (-not (Test-Path -LiteralPath $configPath)) {
@@ -26,49 +74,62 @@ if (Test-Path -LiteralPath $releaseRoot) { throw "Release $version is already in
 New-Item -ItemType Directory -Path $releaseRoot | Out-Null
 Copy-Item -LiteralPath (Join-Path $packageRoot 'app'), (Join-Path $packageRoot 'tools'), (Join-Path $packageRoot 'deploy'), (Join-Path $packageRoot 'DEPLOYMENT.md') -Destination $releaseRoot -Recurse -Force
 Copy-Item -LiteralPath $configPath -Destination (Join-Path $releaseRoot 'app\appsettings.Production.json') -Force
-if (Test-Path -LiteralPath $currentPath) { Remove-Item -LiteralPath $currentPath -Force }
+Remove-CurrentReleaseJunction -Path $currentPath
 New-Item -ItemType Junction -Path $currentPath -Target $releaseRoot | Out-Null
 
 $exe = Join-Path $currentPath 'app\TerrainPlanner.exe'
 $serviceCommand = "`"$exe`" --windows-service"
-if (-not [Diagnostics.EventLog]::SourceExists('FutureMUD Terrain Planner')) {
-	New-EventLog -LogName Application -Source 'FutureMUD Terrain Planner'
-}
-
 $existingService = Get-Service FutureMUDTerrainPlanner -ErrorAction SilentlyContinue
 $serviceWasCreated = $false
-if ($existingService) {
-	Stop-Service FutureMUDTerrainPlanner -ErrorAction SilentlyContinue
-	sc.exe config FutureMUDTerrainPlanner binPath= $serviceCommand start= auto | Out-Null
-	if ($LASTEXITCODE -ne 0) { throw 'Could not update the Terrain Planner service command.' }
-} else {
-	New-Service -Name FutureMUDTerrainPlanner -BinaryPathName $serviceCommand -StartupType Automatic -DisplayName 'FutureMUD Terrain Planner and Engine API'
-	$serviceWasCreated = $true
-}
+try {
+	if (-not [Diagnostics.EventLog]::SourceExists('FutureMUD Terrain Planner')) {
+		New-EventLog -LogName Application -Source 'FutureMUD Terrain Planner'
+	}
 
-# LocalService is a low-privilege built-in service account. The unrestricted service SID below gives only this service
-# access to its durable configuration and data-protection keys.
-sc.exe --% config FutureMUDTerrainPlanner obj= "NT AUTHORITY\LocalService" password= ""
-if ($LASTEXITCODE -ne 0) { throw 'Could not configure the Terrain Planner service account.' }
-sc.exe --% sidtype FutureMUDTerrainPlanner unrestricted
-if ($LASTEXITCODE -ne 0) { throw 'Could not enable the Terrain Planner service SID.' }
-& icacls.exe $sharedRoot /inheritance:r /grant:r 'Administrators:(OI)(CI)F' 'SYSTEM:(OI)(CI)F' 'NT SERVICE\FutureMUDTerrainPlanner:(OI)(CI)M' | Out-Null
-if ($LASTEXITCODE -ne 0) { throw 'Could not protect the Terrain Planner shared data directory.' }
-sc.exe failure FutureMUDTerrainPlanner reset= 86400 actions= restart/5000/restart/15000/none/0 | Out-Null
-if ($LASTEXITCODE -ne 0) { throw 'Could not configure Terrain Planner service recovery.' }
-Start-Service FutureMUDTerrainPlanner
+	if ($existingService) {
+		Stop-Service FutureMUDTerrainPlanner -ErrorAction SilentlyContinue
+		Invoke-ServiceControl -Arguments @('config', 'FutureMUDTerrainPlanner', 'binPath=', $serviceCommand, 'start=', 'auto') -FailureMessage 'Could not update the Terrain Planner service command.'
+	} else {
+		New-Service -Name FutureMUDTerrainPlanner -BinaryPathName $serviceCommand -StartupType Automatic -DisplayName 'FutureMUD Terrain Planner and Engine API'
+		$serviceWasCreated = $true
+	}
 
-$healthy = $false
-for ($attempt = 0; $attempt -lt 30; $attempt++) {
-	try { Invoke-RestMethod http://127.0.0.1:5010/health/ready | Out-Null; $healthy = $true; break } catch { Start-Sleep -Seconds 1 }
-}
-if (-not $healthy) {
+	# LocalService is a low-privilege built-in service account. The unrestricted service SID below gives only this service
+	# access to its durable configuration and data-protection keys.
+	sc.exe --% config FutureMUDTerrainPlanner obj= "NT AUTHORITY\LocalService" password= ""
+	if ($LASTEXITCODE -ne 0) { throw 'Could not configure the Terrain Planner service account.' }
+	sc.exe --% sidtype FutureMUDTerrainPlanner unrestricted
+	if ($LASTEXITCODE -ne 0) { throw 'Could not enable the Terrain Planner service SID.' }
+	& icacls.exe $sharedRoot /inheritance:r /grant:r 'Administrators:(OI)(CI)F' 'SYSTEM:(OI)(CI)F' 'NT SERVICE\FutureMUDTerrainPlanner:(OI)(CI)M' | Out-Null
+	if ($LASTEXITCODE -ne 0) { throw 'Could not protect the Terrain Planner shared data directory.' }
+	sc.exe failure FutureMUDTerrainPlanner reset= 86400 actions= restart/5000/restart/15000/none/0 | Out-Null
+	if ($LASTEXITCODE -ne 0) { throw 'Could not configure Terrain Planner service recovery.' }
+	Start-Service FutureMUDTerrainPlanner
+
+	$healthy = $false
+	for ($attempt = 0; $attempt -lt 30; $attempt++) {
+		try { Invoke-RestMethod http://127.0.0.1:5010/health/ready | Out-Null; $healthy = $true; break } catch { Start-Sleep -Seconds 1 }
+	}
+	if (-not $healthy) { throw 'The new release did not become ready within 30 seconds.' }
+} catch {
+	$activationError = $_
 	Stop-Service FutureMUDTerrainPlanner -ErrorAction SilentlyContinue
-	Remove-Item -LiteralPath $currentPath -Force
-	if ($previousTarget) { New-Item -ItemType Junction -Path $currentPath -Target $previousTarget | Out-Null; Start-Service FutureMUDTerrainPlanner }
-	if ($serviceWasCreated) { sc.exe delete FutureMUDTerrainPlanner | Out-Null }
-	Remove-Item -LiteralPath $releaseRoot -Recurse -Force
-	throw 'Health check failed; the previous release was restored.'
+	try {
+		Remove-CurrentReleaseJunction -Path $currentPath
+		if ($previousTarget) {
+			New-Item -ItemType Junction -Path $currentPath -Target $previousTarget | Out-Null
+		}
+		if ($serviceWasCreated) {
+			sc.exe delete FutureMUDTerrainPlanner | Out-Null
+		} elseif ($previousTarget) {
+			Start-Service FutureMUDTerrainPlanner
+		}
+		Remove-Item -LiteralPath $releaseRoot -Recurse -Force
+	} catch {
+		throw "Terrain Planner activation failed and rollback also failed. Activation error: $($activationError.Exception.Message) Rollback error: $($_.Exception.Message)"
+	}
+
+	throw "Terrain Planner activation failed; the previous release was restored. $($activationError.Exception.Message)"
 }
 Get-ChildItem (Join-Path $InstallRoot 'releases') -Directory | Sort-Object LastWriteTimeUtc -Descending | Select-Object -Skip 3 | Remove-Item -Recurse -Force
 & (Join-Path $packageRoot 'deploy\windows\Install-CaddySite.ps1') -Hostname $Hostname -CaddyExecutable $CaddyExecutable -Caddyfile $Caddyfile


### PR DESCRIPTION
## Summary\n- make Windows service command updates argument-safe and retain sc.exe diagnostics\n- replace only verified current release junctions and roll back the whole activation sequence\n- document the early 2.0 bootstrap path and publish 2.0.3 release notes\n\n## Validation\n- dotnet test TerrainPlanner\\TerrainPlanner.Tests\\TerrainPlanner.Tests.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 (32 passed)\n- PowerShell parser validation for Install-TerrainPlanner.ps1\n- self-contained win-x64 package smoke test, including archive layout and 2.0.3 version