### PR TITLE
Terrain Planner 2.0.4 Windows PowerShell upgrade repair

### DIFF
--- a/FutureMUD.Web/Content/PatchNotes/2026-08-27-terrain-planner-2-0-4.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-08-27-terrain-planner-2-0-4.md
@@ -1,0 +1,12 @@
+---
+title: FutureMUD Terrain Planner & Engine API 2.0.4
+summary: Repairs Windows PowerShell 5.1 upgrades and makes junction rollback reliable.
+date: 2026-08-27
+tags: terrainplanner, release, deployment, bugfix
+---
+
+Terrain Planner & Engine API 2.0.4 corrects a Windows PowerShell 5.1 compatibility issue in the 2.0.3 installer. Upgrades no longer use the newer process argument API that is unavailable in the PowerShell version included with supported Windows Server installations.
+
+The installer now retains the stable service executable path during upgrades—the service always runs from the `current` junction—so an in-place release only switches that junction, restarts the existing service, and checks readiness. Its rollback logic also converts Windows PowerShell's junction-target array to the single target path before rebuilding the prior link.
+
+For one last time, installations from any earlier 2.0.x build should use the archive-install procedure in the deployment guide. Once 2.0.4 is healthy, the signed updater handles later releases normally.

--- a/TerrainPlanner/DEPLOYMENT.md
+++ b/TerrainPlanner/DEPLOYMENT.md
@@ -25,8 +25,8 @@ FLUSH PRIVILEGES;
 Extract the archive. It creates one directory named for the runtime package; change into that directory, then run:
 
 ```bash
-unzip terrainplanner-2.0.1-linux-x64.zip
-cd terrainplanner-2.0.1-linux-x64
+unzip terrainplanner-2.0.4-linux-x64.zip
+cd terrainplanner-2.0.4-linux-x64
 sudo bash deploy/linux/install-terrainplanner.sh planner.example.com
 ```
 
@@ -44,10 +44,10 @@ The installer creates the unprivileged `terrainplanner` account, installs a hard
 Open an elevated PowerShell prompt. The archive extracts to an outer download directory which contains the actual runtime package directory; change into the inner directory before running the installer:
 
 ```powershell
-$archive = 'C:\Install\terrainplanner-2.0.1-win-x64.zip'
-$extractRoot = 'C:\Install\terrainplanner-2.0.1'
+$archive = 'C:\Install\terrainplanner-2.0.4-win-x64.zip'
+$extractRoot = 'C:\Install\terrainplanner-2.0.4'
 Expand-Archive -LiteralPath $archive -DestinationPath $extractRoot -Force
-Set-Location "$extractRoot\terrainplanner-2.0.1-win-x64"
+Set-Location "$extractRoot\terrainplanner-2.0.4-win-x64"
 .\deploy\windows\Install-TerrainPlanner.ps1 -Hostname planner.example.com
 ```
 
@@ -80,9 +80,9 @@ The updater downloads `update-manifest.json`, its Ed25519 signature, and the nam
 
 ### Bootstrap an early 2.0 installation
 
-If your existing installation is 2.0.0 or 2.0.1, install 2.0.3 once using the normal archive-install method above instead of its bundled updater. Those releases used a retired archive route. If a 2.0.2 Windows installation stopped while configuring the service, also use the archive-install method once. This retains the existing shared configuration, MySQL password, service, and Caddy configuration. From 2.0.3 onwards, use the updater command in the preceding section.
+If your existing installation is 2.0.0 through 2.0.3, install 2.0.4 once using the normal archive-install method above instead of its bundled updater. Versions 2.0.0 and 2.0.1 used a retired archive route. Version 2.0.2 could stop while configuring the service, and the 2.0.3 Windows installer used an API that is unavailable in Windows PowerShell 5.1. This retains the existing shared configuration, MySQL password, service, and Caddy configuration. From 2.0.4 onwards, use the updater command in the preceding section.
 
-During an upgrade, the installer replaces only the `current` release junction. It never recursively deletes the release that junction points to. If Windows reports that the planner service cannot be configured, the installer now includes the exact `sc.exe` output in the error so the failure can be diagnosed safely.
+During an upgrade, the installer replaces only the `current` release junction. It never recursively deletes the release that junction points to. The service executable always points at that stable junction, so upgrades restart the existing service without rewriting its command line.
 
 ## Verification
 

--- a/TerrainPlanner/TerrainPlanner.Server/TerrainPlanner.Server.csproj
+++ b/TerrainPlanner/TerrainPlanner.Server/TerrainPlanner.Server.csproj
@@ -4,9 +4,9 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>2.0.3</Version>
-		<AssemblyVersion>2.0.3</AssemblyVersion>
-		<FileVersion>2.0.3</FileVersion>
+		<Version>2.0.4</Version>
+		<AssemblyVersion>2.0.4</AssemblyVersion>
+		<FileVersion>2.0.4</FileVersion>
 		<BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
 		<AssemblyName>TerrainPlanner</AssemblyName>
 		<RootNamespace>TerrainPlanner.Server</RootNamespace>

--- a/TerrainPlanner/TerrainPlanner.Tests/DeploymentContractTests.cs
+++ b/TerrainPlanner/TerrainPlanner.Tests/DeploymentContractTests.cs
@@ -68,17 +68,22 @@ public class DeploymentContractTests
 	}
 
 	[TestMethod]
-	public void WindowsInstallerReplacesOnlyJunctionsAndUsesArgumentSafeServiceConfiguration()
+	public void WindowsInstallerUsesPowerShellFiveCompatibleJunctionRollbackAndStableServiceCommand()
 	{
 		var installer = File.ReadAllText(Path.Combine(RepositoryRoot, "TerrainPlanner", "deploy", "windows",
 			"Install-TerrainPlanner.ps1"));
 
 		Assert.IsTrue(installer.Contains("[IO.Directory]::Delete($Path)", StringComparison.Ordinal));
 		Assert.IsTrue(installer.Contains("Refusing to remove '$Path' because it is not a release junction.", StringComparison.Ordinal));
-		Assert.IsTrue(installer.Contains("$startInfo.ArgumentList.Add($argument)", StringComparison.Ordinal));
-		Assert.IsTrue(installer.Contains("'binPath=', $serviceCommand, 'start=', 'auto'", StringComparison.Ordinal));
+		Assert.IsTrue(installer.Contains("$targets = @($item.Target)", StringComparison.Ordinal));
+		Assert.IsTrue(installer.Contains("return [string]$targets[0]", StringComparison.Ordinal));
 		Assert.IsTrue(installer.Contains("New-Item -ItemType Junction -Path $currentPath -Target $previousTarget", StringComparison.Ordinal));
+		Assert.IsTrue(installer.Contains("if ($existingService.Status -ne 'Stopped')", StringComparison.Ordinal));
+		Assert.IsTrue(installer.Contains("New-Service -Name FutureMUDTerrainPlanner -BinaryPathName $serviceCommand", StringComparison.Ordinal));
 		Assert.IsTrue(installer.Contains("Terrain Planner activation failed; the previous release was restored.", StringComparison.Ordinal));
+		Assert.IsFalse(installer.Contains("ArgumentList", StringComparison.Ordinal));
+		Assert.IsFalse(installer.Contains("Invoke-ServiceControl", StringComparison.Ordinal));
+		Assert.IsFalse(installer.Contains("$previousTarget = $currentItem.Target", StringComparison.Ordinal));
 		Assert.IsFalse(installer.Contains("sc.exe config FutureMUDTerrainPlanner binPath=", StringComparison.Ordinal));
 	}
 

--- a/TerrainPlanner/deploy/windows/Install-TerrainPlanner.ps1
+++ b/TerrainPlanner/deploy/windows/Install-TerrainPlanner.ps1
@@ -21,31 +21,22 @@ function Remove-CurrentReleaseJunction {
 	[IO.Directory]::Delete($Path)
 }
 
-function Invoke-ServiceControl {
-	param(
-		[Parameter(Mandatory = $true)][string[]]$Arguments,
-		[Parameter(Mandatory = $true)][string]$FailureMessage
-	)
+function Get-ReleaseJunctionTarget {
+	param([Parameter(Mandatory = $true)][string]$Path)
 
-	$startInfo = [Diagnostics.ProcessStartInfo]::new()
-	$startInfo.FileName = Join-Path $env:SystemRoot 'System32\sc.exe'
-	$startInfo.UseShellExecute = $false
-	$startInfo.RedirectStandardOutput = $true
-	$startInfo.RedirectStandardError = $true
-	foreach ($argument in $Arguments) {
-		[void]$startInfo.ArgumentList.Add($argument)
+	if (-not (Test-Path -LiteralPath $Path)) { return $null }
+	$item = Get-Item -LiteralPath $Path -Force
+	if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne [IO.FileAttributes]::ReparsePoint) {
+		throw "Refusing to replace '$Path' because it is not a release junction."
 	}
 
-	$process = [Diagnostics.Process]::new()
-	$process.StartInfo = $startInfo
-	[void]$process.Start()
-	$standardOutput = $process.StandardOutput.ReadToEnd()
-	$standardError = $process.StandardError.ReadToEnd()
-	$process.WaitForExit()
-	if ($process.ExitCode -ne 0) {
-		$detail = ($standardOutput, $standardError | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) -join [Environment]::NewLine
-		throw "$FailureMessage sc.exe exited with code $($process.ExitCode). $detail"
+	# Windows PowerShell returns DirectoryInfo.Target as a one-element string array for a junction.
+	$targets = @($item.Target)
+	if ($targets.Count -ne 1 -or [string]::IsNullOrWhiteSpace([string]$targets[0])) {
+		throw "Could not determine the target for release junction '$Path'."
 	}
+
+	return [string]$targets[0]
 }
 
 $packageRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
@@ -54,14 +45,7 @@ $releaseRoot = Join-Path $InstallRoot "releases\$version"
 $sharedRoot = Join-Path $InstallRoot 'shared'
 $configPath = Join-Path $sharedRoot 'appsettings.Production.json'
 $currentPath = Join-Path $InstallRoot 'current'
-$previousTarget = $null
-if (Test-Path -LiteralPath $currentPath) {
-	$currentItem = Get-Item -LiteralPath $currentPath -Force
-	if (($currentItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne [IO.FileAttributes]::ReparsePoint) {
-		throw "Refusing to replace '$currentPath' because it is not a release junction."
-	}
-	$previousTarget = $currentItem.Target
-}
+$previousTarget = Get-ReleaseJunctionTarget -Path $currentPath
 
 New-Item -ItemType Directory -Force -Path (Join-Path $InstallRoot 'releases'), $sharedRoot, (Join-Path $sharedRoot 'keys') | Out-Null
 if (-not (Test-Path -LiteralPath $configPath)) {
@@ -74,21 +58,22 @@ if (Test-Path -LiteralPath $releaseRoot) { throw "Release $version is already in
 New-Item -ItemType Directory -Path $releaseRoot | Out-Null
 Copy-Item -LiteralPath (Join-Path $packageRoot 'app'), (Join-Path $packageRoot 'tools'), (Join-Path $packageRoot 'deploy'), (Join-Path $packageRoot 'DEPLOYMENT.md') -Destination $releaseRoot -Recurse -Force
 Copy-Item -LiteralPath $configPath -Destination (Join-Path $releaseRoot 'app\appsettings.Production.json') -Force
-Remove-CurrentReleaseJunction -Path $currentPath
-New-Item -ItemType Junction -Path $currentPath -Target $releaseRoot | Out-Null
-
-$exe = Join-Path $currentPath 'app\TerrainPlanner.exe'
-$serviceCommand = "`"$exe`" --windows-service"
 $existingService = Get-Service FutureMUDTerrainPlanner -ErrorAction SilentlyContinue
 $serviceWasCreated = $false
 try {
+	Remove-CurrentReleaseJunction -Path $currentPath
+	New-Item -ItemType Junction -Path $currentPath -Target $releaseRoot | Out-Null
+
+	$exe = Join-Path $currentPath 'app\TerrainPlanner.exe'
+	$serviceCommand = "`"$exe`" --windows-service"
 	if (-not [Diagnostics.EventLog]::SourceExists('FutureMUD Terrain Planner')) {
 		New-EventLog -LogName Application -Source 'FutureMUD Terrain Planner'
 	}
 
 	if ($existingService) {
-		Stop-Service FutureMUDTerrainPlanner -ErrorAction SilentlyContinue
-		Invoke-ServiceControl -Arguments @('config', 'FutureMUDTerrainPlanner', 'binPath=', $serviceCommand, 'start=', 'auto') -FailureMessage 'Could not update the Terrain Planner service command.'
+		if ($existingService.Status -ne 'Stopped') {
+			Stop-Service FutureMUDTerrainPlanner -ErrorAction Stop
+		}
 	} else {
 		New-Service -Name FutureMUDTerrainPlanner -BinaryPathName $serviceCommand -StartupType Automatic -DisplayName 'FutureMUD Terrain Planner and Engine API'
 		$serviceWasCreated = $true


### PR DESCRIPTION
## Summary
- removes the unnecessary Windows service command-line rewrite during upgrades
- normalises Windows PowerShell junction targets before rollback
- updates the bootstrap deployment guidance and adds 2.0.4 patch notes

## Validation
- Terrain Planner unit tests: 32 passed
- Windows PowerShell 5.1 parser and real junction-target probe
- self-contained win-x64 package smoke check