### PR TITLE
Terrain Planner 2.0.5 preserves existing Caddy sites

### DIFF
--- a/FutureMUD.Web/Content/PatchNotes/2026-08-27-terrain-planner-2-0-5.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-08-27-terrain-planner-2-0-5.md
@@ -1,0 +1,12 @@
+---
+title: FutureMUD Terrain Planner & Engine API 2.0.5
+summary: Preserves existing direct Caddy site definitions during Windows installation and upgrades.
+date: 2026-08-27
+tags: terrainplanner, release, deployment, bugfix
+---
+
+Terrain Planner & Engine API 2.0.5 corrects the Windows Caddy site detection used by the installer. When the Web MUD Client's main Caddyfile already contains a direct site block for the planner hostname, the installer now recognises it and preserves that configuration.
+
+This prevents a duplicate Terrain Planner site fragment from being added, avoiding Caddy's ambiguous site definition validation error. Existing successful service activation and the active Caddy configuration remain untouched.
+
+Installations on any earlier 2.0.x release should use the archive-install procedure once for 2.0.5. After that one-time update, use the signed in-place updater for future releases.

--- a/TerrainPlanner/DEPLOYMENT.md
+++ b/TerrainPlanner/DEPLOYMENT.md
@@ -25,8 +25,8 @@ FLUSH PRIVILEGES;
 Extract the archive. It creates one directory named for the runtime package; change into that directory, then run:
 
 ```bash
-unzip terrainplanner-2.0.4-linux-x64.zip
-cd terrainplanner-2.0.4-linux-x64
+unzip terrainplanner-2.0.5-linux-x64.zip
+cd terrainplanner-2.0.5-linux-x64
 sudo bash deploy/linux/install-terrainplanner.sh planner.example.com
 ```
 
@@ -44,10 +44,10 @@ The installer creates the unprivileged `terrainplanner` account, installs a hard
 Open an elevated PowerShell prompt. The archive extracts to an outer download directory which contains the actual runtime package directory; change into the inner directory before running the installer:
 
 ```powershell
-$archive = 'C:\Install\terrainplanner-2.0.4-win-x64.zip'
-$extractRoot = 'C:\Install\terrainplanner-2.0.4'
+$archive = 'C:\Install\terrainplanner-2.0.5-win-x64.zip'
+$extractRoot = 'C:\Install\terrainplanner-2.0.5'
 Expand-Archive -LiteralPath $archive -DestinationPath $extractRoot -Force
-Set-Location "$extractRoot\terrainplanner-2.0.4-win-x64"
+Set-Location "$extractRoot\terrainplanner-2.0.5-win-x64"
 .\deploy\windows\Install-TerrainPlanner.ps1 -Hostname planner.example.com
 ```
 
@@ -78,9 +78,11 @@ Use `linux-arm64` on ARM64 hosts. Windows:
 
 The updater downloads `update-manifest.json`, its Ed25519 signature, and the named archive from futuremud.com. The bundled verifier checks the signature, product/version/runtime identity, size, and SHA-256 before the normal health-checked installer activates it. It automatically reuses the Caddy paths from the Web MUD Client scheduled task; if that task cannot be discovered, pass the same `-CaddyExecutable` and `-Caddyfile` arguments shown above.
 
-### Bootstrap an early 2.0 installation
+### Bootstrap an earlier 2.0 installation
 
-If your existing installation is 2.0.0 through 2.0.3, install 2.0.4 once using the normal archive-install method above instead of its bundled updater. Versions 2.0.0 and 2.0.1 used a retired archive route. Version 2.0.2 could stop while configuring the service, and the 2.0.3 Windows installer used an API that is unavailable in Windows PowerShell 5.1. This retains the existing shared configuration, MySQL password, service, and Caddy configuration. From 2.0.4 onwards, use the updater command in the preceding section.
+If your existing installation is 2.0.0 through 2.0.4, install 2.0.5 once using the normal archive-install method above instead of its bundled updater. Versions 2.0.0 and 2.0.1 used a retired archive route. Version 2.0.2 could stop while configuring the service, 2.0.3 used an API that is unavailable in Windows PowerShell 5.1, and the 2.0.4 Windows Caddy check could add a duplicate site fragment when the hostname was already defined directly in the main Caddyfile. This retains the existing shared configuration, MySQL password, service, and Caddy configuration. From 2.0.5 onwards, use the updater command in the preceding section.
+
+If 2.0.4 reported ambiguous site definition but https://planner.example.com/health/ready responds, the planner service is already healthy: Caddy restored its previous configuration after declining the duplicate fragment. Install 2.0.5 once using the archive method. It detects and preserves the existing direct Caddy site block.
 
 During an upgrade, the installer replaces only the `current` release junction. It never recursively deletes the release that junction points to. The service executable always points at that stable junction, so upgrades restart the existing service without rewriting its command line.
 

--- a/TerrainPlanner/TerrainPlanner.Server/TerrainPlanner.Server.csproj
+++ b/TerrainPlanner/TerrainPlanner.Server/TerrainPlanner.Server.csproj
@@ -4,9 +4,9 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>2.0.4</Version>
-		<AssemblyVersion>2.0.4</AssemblyVersion>
-		<FileVersion>2.0.4</FileVersion>
+		<Version>2.0.5</Version>
+		<AssemblyVersion>2.0.5</AssemblyVersion>
+		<FileVersion>2.0.5</FileVersion>
 		<BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
 		<AssemblyName>TerrainPlanner</AssemblyName>
 		<RootNamespace>TerrainPlanner.Server</RootNamespace>

--- a/TerrainPlanner/TerrainPlanner.Tests/DeploymentContractTests.cs
+++ b/TerrainPlanner/TerrainPlanner.Tests/DeploymentContractTests.cs
@@ -54,6 +54,8 @@ public class DeploymentContractTests
 		Assert.IsTrue(windows.Contains("Get-ScheduledTask -TaskName 'FutureMUD Web Client HTTPS'", StringComparison.Ordinal));
 		Assert.IsTrue(windows.Contains("--adapter caddyfile", StringComparison.Ordinal));
 		Assert.IsTrue(windows.Contains("Caddy already contains a site block", StringComparison.Ordinal));
+		Assert.IsTrue(windows.Contains("$main -match \"(?m)^\\s*$escapedHostname\\s*\\{\"", StringComparison.Ordinal));
+		Assert.IsFalse(windows.Contains("$main -match \"(?m)^\\\\s*$escapedHostname\\\\s*\\\\{\"", StringComparison.Ordinal));
 	}
 
 	[TestMethod]

--- a/TerrainPlanner/deploy/windows/Install-CaddySite.ps1
+++ b/TerrainPlanner/deploy/windows/Install-CaddySite.ps1
@@ -59,7 +59,7 @@ if (-not $CaddyExecutable -or -not $Caddyfile) {
 
 $main = Get-Content -LiteralPath $Caddyfile -Raw
 $escapedHostname = [regex]::Escape($Hostname)
-if ($main -match "(?m)^\\s*$escapedHostname\\s*\\{") {
+if ($main -match "(?m)^\s*$escapedHostname\s*\{") {
 	Write-Host "Caddy already contains a site block for $Hostname; preserving the existing configuration."
 	return
 }


### PR DESCRIPTION
## Summary
- fix Windows installer detection of an existing direct Caddy hostname block
- preserve current healthy Caddy configuration instead of adding a duplicate site fragment
- document the 2.0.4 recovery path and publish the 2.0.5 patch note

## Validation
- dotnet test TerrainPlanner\\TerrainPlanner.Tests\\TerrainPlanner.Tests.csproj -c Debug --no-build --no-restore -m:1 (32 passed)
- Windows PowerShell 5.1 parser and direct-site pattern check
- representative self-contained win-x64 package smoke check
- dotnet test FutureMUD.Web.Tests\\FutureMUD.Web.Tests.csproj -c Debug --no-restore -m:1 (54 passed)