### PR TITLE
Terrain Planner 2.0.6 handles duplicate tag names

### DIFF
--- a/Design Documents/Building/Terrain_Planner_and_Engine_API.md
+++ b/Design Documents/Building/Terrain_Planner_and_Engine_API.md
@@ -39,7 +39,7 @@ Both masks contain exactly `width * height` comma-separated cells. Entry zero is
 - Terrain mask: one terrain ID per entry; `0` means no cell is created.
 - Feature/tag mask: short tag names separated by `|` inside a cell; an untagged cell is an empty entry.
 
-The UI displays hierarchical tag names but exports globally unique short names, matching `ApplyTagsToCell`. Separate copy/import controls and the combined export panel preserve empty entries. Clipboard denial leaves selectable mask text available.
+The UI displays hierarchical tag names but exports only globally unique short names, matching `ApplyTagsToCell`'s name-based resolution. If two tags share a short name, both remain visible in the palette but are disabled for feature-mask painting with an explanation; importing that ambiguous name keeps it unresolved rather than choosing a tag arbitrarily. Separate copy/import controls and the combined export panel preserve empty entries. Clipboard denial leaves selectable mask text available.
 
 ## Deployment and release
 

--- a/FutureMUD.Web/Content/PatchNotes/2026-08-27-terrain-planner-2-0-6.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-08-27-terrain-planner-2-0-6.md
@@ -1,0 +1,12 @@
+---
+title: FutureMUD Terrain Planner & Engine API 2.0.6
+summary: Handles duplicate tag short names without preventing the builder catalogue from loading.
+date: 2026-08-27
+tags: terrainplanner, release, builder, bugfix
+---
+
+Terrain Planner & Engine API 2.0.6 corrects an issue that could leave the builder catalogue loading indefinitely after sign-in when a game's tag catalogue included the same short tag name in more than one hierarchy branch.
+
+The planner now continues to load and shows every tag using its full hierarchy. Tags whose short names are not globally unique are clearly marked as unavailable for feature-mask painting, importing, and automatic selection. This prevents a feature mask from silently choosing a different tag from the one the builder intended.
+
+Installations already running 2.0.5 can use the signed in-place updater.

--- a/TerrainPlanner/DEPLOYMENT.md
+++ b/TerrainPlanner/DEPLOYMENT.md
@@ -25,8 +25,8 @@ FLUSH PRIVILEGES;
 Extract the archive. It creates one directory named for the runtime package; change into that directory, then run:
 
 ```bash
-unzip terrainplanner-2.0.5-linux-x64.zip
-cd terrainplanner-2.0.5-linux-x64
+unzip terrainplanner-2.0.6-linux-x64.zip
+cd terrainplanner-2.0.6-linux-x64
 sudo bash deploy/linux/install-terrainplanner.sh planner.example.com
 ```
 
@@ -44,10 +44,10 @@ The installer creates the unprivileged `terrainplanner` account, installs a hard
 Open an elevated PowerShell prompt. The archive extracts to an outer download directory which contains the actual runtime package directory; change into the inner directory before running the installer:
 
 ```powershell
-$archive = 'C:\Install\terrainplanner-2.0.5-win-x64.zip'
-$extractRoot = 'C:\Install\terrainplanner-2.0.5'
+$archive = 'C:\Install\terrainplanner-2.0.6-win-x64.zip'
+$extractRoot = 'C:\Install\terrainplanner-2.0.6'
 Expand-Archive -LiteralPath $archive -DestinationPath $extractRoot -Force
-Set-Location "$extractRoot\terrainplanner-2.0.5-win-x64"
+Set-Location "$extractRoot\terrainplanner-2.0.6-win-x64"
 .\deploy\windows\Install-TerrainPlanner.ps1 -Hostname planner.example.com
 ```
 

--- a/TerrainPlanner/TerrainPlanner.Client/Components/PlannerWorkspace.razor
+++ b/TerrainPlanner/TerrainPlanner.Client/Components/PlannerWorkspace.razor
@@ -80,10 +80,11 @@
 					{
 						@foreach (var tag in FilteredTags)
 						{
-							var invalid = !CanExportTag(tag);
-							<button class="palette-item @(_tagBrushId == tag.Id ? "selected" : "")" disabled="@invalid" title="@(invalid ? "This tag contains a feature-mask delimiter." : tag.FullName)" @onclick="() => SelectTagAsync(tag.Id)">
+							var unavailableReason = _tagIndex.FeatureMaskUnavailableReason(tag);
+							var unavailable = unavailableReason is not null;
+							<button class="palette-item @(_tagBrushId == tag.Id ? "selected" : "")" disabled="@unavailable" title="@(unavailableReason ?? tag.FullName)" @onclick="() => SelectTagAsync(tag.Id)">
 								<span class="tag-swatch" style="background:@GetTagColour(tag.Id)"></span>
-								<span><strong>@tag.ShortName</strong><small>@tag.FullName</small></span>
+								<span><strong>@tag.ShortName</strong><small>@(unavailableReason ?? tag.FullName)</small></span>
 							</button>
 						}
 					}
@@ -215,9 +216,10 @@
 	private PlannerMap _map = new(5, 5);
 	private IReadOnlyList<TerrainCatalogueItem> _terrains = [];
 	private IReadOnlyList<TagCatalogueItem> _tags = [];
-	private Dictionary<long, TerrainCatalogueItem> _terrainById = [];
-	private Dictionary<long, TagCatalogueItem> _tagById = [];
-	private Dictionary<string, TagCatalogueItem> _tagByName = new(StringComparer.OrdinalIgnoreCase);
+	private IReadOnlyDictionary<long, TerrainCatalogueItem> _terrainById = new Dictionary<long, TerrainCatalogueItem>();
+	private IReadOnlyDictionary<long, TagCatalogueItem> _tagById = TagCatalogueIndex.Empty.ById;
+	private IReadOnlyDictionary<string, TagCatalogueItem> _tagByName = TagCatalogueIndex.Empty.ByShortName;
+	private TagCatalogueIndex _tagIndex = TagCatalogueIndex.Empty;
 	private Dictionary<long, string> _tagColours = [];
 	private Dictionary<long, string> _projectTagNames = [];
 	private PlannerLayer _layer = PlannerLayer.Terrain;
@@ -791,15 +793,21 @@
 
 	private void BuildLookups()
 	{
-		_terrainById = _terrains.ToDictionary(item => item.Id);
-		_tagById = _tags.ToDictionary(item => item.Id);
-		_tagByName = _tags.ToDictionary(item => item.ShortName, StringComparer.OrdinalIgnoreCase);
+		_terrainById = _terrains
+			.GroupBy(item => item.Id)
+			.ToDictionary(group => group.Key, group => group.First());
+		_tagIndex = TagCatalogueIndex.Create(_tags);
+		_tagById = _tagIndex.ById;
+		_tagByName = _tagIndex.ByShortName;
 	}
 
 	private void EnsureBrushesAndColours()
 	{
 		if (_terrainBrushId != 0 && !_terrainById.ContainsKey(_terrainBrushId)) _terrainBrushId = 0;
-		if (!_tagById.ContainsKey(_tagBrushId)) _tagBrushId = _tags.FirstOrDefault(CanExportTag)?.Id ?? 0;
+		if (!_tagById.ContainsKey(_tagBrushId))
+		{
+			_tagBrushId = _tags.FirstOrDefault(_tagIndex.IsAvailableForFeatureMask)?.Id ?? 0;
+		}
 		foreach (var tag in _tags)
 		{
 			_tagColours.TryAdd(tag.Id, DeterministicTagColour(tag.Id));
@@ -852,9 +860,6 @@
 	private string TagFullName(long id) => _tagById.GetValueOrDefault(id)?.FullName ?? $"Missing tag #{id}";
 	private string GetTagColour(long id) => _tagColours.GetValueOrDefault(id, DeterministicTagColour(id));
 	private int TagUseCount(long id) => _map.Cells.Count(cell => cell.TagIds.Contains(id));
-	private static bool CanExportTag(TagCatalogueItem tag) =>
-		!string.IsNullOrWhiteSpace(tag.ShortName) && !tag.ShortName.Contains(',') && !tag.ShortName.Contains('|') &&
-		!tag.ShortName.Contains('\r') && !tag.ShortName.Contains('\n');
 	private static string WebColour(string colour) => colour.Length == 9 && colour.StartsWith('#') ? $"#{colour[3..]}" : colour;
 	private static string DeterministicTagColour(long id)
 	{

--- a/TerrainPlanner/TerrainPlanner.Contracts/TagCatalogueIndex.cs
+++ b/TerrainPlanner/TerrainPlanner.Contracts/TagCatalogueIndex.cs
@@ -1,0 +1,65 @@
+namespace TerrainPlanner.Contracts;
+
+public sealed class TagCatalogueIndex
+{
+	private readonly HashSet<string> _ambiguousShortNames;
+
+	private TagCatalogueIndex(
+		IReadOnlyDictionary<long, TagCatalogueItem> byId,
+		IReadOnlyDictionary<string, TagCatalogueItem> byShortName,
+		HashSet<string> ambiguousShortNames)
+	{
+		ById = byId;
+		ByShortName = byShortName;
+		_ambiguousShortNames = ambiguousShortNames;
+	}
+
+	public static TagCatalogueIndex Empty { get; } = Create([]);
+
+	public IReadOnlyDictionary<long, TagCatalogueItem> ById { get; }
+	public IReadOnlyDictionary<string, TagCatalogueItem> ByShortName { get; }
+
+	public static TagCatalogueIndex Create(IEnumerable<TagCatalogueItem> tags)
+	{
+		ArgumentNullException.ThrowIfNull(tags);
+
+		var byId = tags
+			.GroupBy(tag => tag.Id)
+			.ToDictionary(group => group.Key, group => group.First());
+		var ambiguousShortNames = byId.Values
+			.GroupBy(tag => tag.ShortName, StringComparer.OrdinalIgnoreCase)
+			.Where(group => group.Count() > 1)
+			.Select(group => group.Key)
+			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+		var byShortName = byId.Values
+			.Where(tag => FeatureMaskUnavailableReason(tag, ambiguousShortNames) is null)
+			.ToDictionary(tag => tag.ShortName, StringComparer.OrdinalIgnoreCase);
+
+		return new TagCatalogueIndex(byId, byShortName, ambiguousShortNames);
+	}
+
+	public bool IsAvailableForFeatureMask(TagCatalogueItem tag) =>
+		FeatureMaskUnavailableReason(tag) is null;
+
+	public string? FeatureMaskUnavailableReason(TagCatalogueItem tag) =>
+		FeatureMaskUnavailableReason(tag, _ambiguousShortNames);
+
+	private static string? FeatureMaskUnavailableReason(TagCatalogueItem tag,
+		IReadOnlySet<string> ambiguousShortNames)
+	{
+		if (string.IsNullOrWhiteSpace(tag.ShortName))
+		{
+			return "This tag has no short name for an autobuilder feature mask.";
+		}
+
+		if (tag.ShortName.Contains(',') || tag.ShortName.Contains('|') ||
+			tag.ShortName.Contains('\r') || tag.ShortName.Contains('\n'))
+		{
+			return "This tag's short name contains an autobuilder feature-mask delimiter.";
+		}
+
+		return ambiguousShortNames.Contains(tag.ShortName)
+			? $"The short name '{tag.ShortName}' is shared by multiple tags."
+			: null;
+	}
+}

--- a/TerrainPlanner/TerrainPlanner.Server/TerrainPlanner.Server.csproj
+++ b/TerrainPlanner/TerrainPlanner.Server/TerrainPlanner.Server.csproj
@@ -4,9 +4,9 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>2.0.5</Version>
-		<AssemblyVersion>2.0.5</AssemblyVersion>
-		<FileVersion>2.0.5</FileVersion>
+		<Version>2.0.6</Version>
+		<AssemblyVersion>2.0.6</AssemblyVersion>
+		<FileVersion>2.0.6</FileVersion>
 		<BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
 		<AssemblyName>TerrainPlanner</AssemblyName>
 		<RootNamespace>TerrainPlanner.Server</RootNamespace>

--- a/TerrainPlanner/TerrainPlanner.Tests/MaskSerializerTests.cs
+++ b/TerrainPlanner/TerrainPlanner.Tests/MaskSerializerTests.cs
@@ -54,4 +54,19 @@ public class MaskSerializerTests
 		Assert.ThrowsException<InvalidDataException>(() =>
 			MaskSerializer.ImportFeatureMask(map, "", new Dictionary<string, TagCatalogueItem>()));
 	}
+
+	[TestMethod]
+	public void DuplicateTagShortNamesAreVisibleButUnavailableForFeatureMasks()
+	{
+		var firstRoad = new TagCatalogueItem(10, "road", "world / trade / road", null);
+		var secondRoad = new TagCatalogueItem(11, "ROAD", "world / travel / road", null);
+		var index = TagCatalogueIndex.Create([Forest, firstRoad, secondRoad]);
+
+		Assert.AreEqual(3, index.ById.Count);
+		Assert.IsTrue(index.ByShortName.ContainsKey(Forest.ShortName));
+		Assert.IsFalse(index.ByShortName.ContainsKey(firstRoad.ShortName));
+		Assert.IsFalse(index.IsAvailableForFeatureMask(firstRoad));
+		Assert.AreEqual("The short name 'road' is shared by multiple tags.",
+			index.FeatureMaskUnavailableReason(firstRoad));
+	}
 }


### PR DESCRIPTION
## Summary
- prevent the WASM planner from crashing while indexing a catalogue with duplicate tag short names
- keep ambiguous tags visible by hierarchy, but disable them for feature masks so the autobuilder never picks an arbitrary tag
- add a duplicate-short-name regression test and update builder/release documentation

## Validation
- dotnet build TerrainPlanner\\TerrainPlanner.Tests\\TerrainPlanner.Tests.csproj -c Debug --no-restore -m:1 
- dotnet build TerrainPlanner\\TerrainPlanner.Client\\TerrainPlanner.Client.csproj -c Debug --no-restore -m:1`n- dotnet test TerrainPlanner\\TerrainPlanner.Tests\\TerrainPlanner.Tests.csproj -c Debug --no-build --no-restore -m:1 (33 passed)
- dotnet test FutureMUD.Web.Tests\\FutureMUD.Web.Tests.csproj -c Debug --no-restore -m:1 (54 passed)
- self-contained win-x64 package smoke check