### PR TITLE
Fix Cloudflare-compatible publishing chunks

### DIFF
--- a/FutureMUD.Web.Tests/ReleaseStoreTests.cs
+++ b/FutureMUD.Web.Tests/ReleaseStoreTests.cs
@@ -433,7 +433,7 @@ public sealed class ReleaseStoreTests
 	[TestMethod]
 	public async Task ConcurrentUploadsCannotBothSpendTheSameFreeSpaceMargin()
 	{
-		var bytes = new byte[8 * 1024 * 1024];
+		var bytes = new byte[ReleaseStore.ChunkSize];
 		RandomNumberGenerator.Fill(bytes);
 		var firstRequest = CreateTerrainPlannerRequest("4.0.0", bytes, 'b');
 		var secondRequest = CreateTerrainPlannerRequest("4.0.1", bytes, 'c');

--- a/FutureMUD.Web/Deployment/README.md
+++ b/FutureMUD.Web/Deployment/README.md
@@ -159,7 +159,7 @@ Cloudflare publishes the AOP CA at <https://developers.cloudflare.com/ssl/static
 
 The Nginx template deliberately:
 
-- allows a 1 MiB request body by default and 34 MiB only beneath `/api/publishing/`;
+- allows a 1 MiB request body by default and 34 MiB only beneath `/api/publishing/`; the publisher sends resumable 4 MiB chunks so each proxied upload returns well within Cloudflare's origin timeout on the production micro instance;
 - gives slow publishing uploads longer body/upstream timeouts while keeping public and health timeouts short;
 - emits one one-year HSTS header with `includeSubDomains` and no `preload` on every FutureMUD HTTPS response;
 - hides the application's HSTS header and replaces API/health cache headers so duplicates cannot weaken policy;

--- a/FutureMUD.Web/Publishing/ReleaseStore.cs
+++ b/FutureMUD.Web/Publishing/ReleaseStore.cs
@@ -13,7 +13,8 @@ namespace FutureMUD.Web.Publishing;
 
 public sealed partial class ReleaseStore
 {
-	public const int ChunkSize = 32 * 1024 * 1024;
+	// Keep individual upload requests comfortably below Cloudflare's origin timeout on small production hosts.
+	public const int ChunkSize = 4 * 1024 * 1024;
 	private const long MaximumArtifactSize = 4L * 1024 * 1024 * 1024;
 	private const long MaximumDocumentationCatalogueSize = 32L * 1024 * 1024;
 	private const int MaximumDocumentationEntries = 50_000;

--- a/scripts/Publish-WebsiteRelease.ps1
+++ b/scripts/Publish-WebsiteRelease.ps1
@@ -12,7 +12,7 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
-$chunkSize = 32MB
+$chunkSize = 4MB
 $headers = @{ Authorization = "Bearer $Token" }
 
 function Get-Sha256Bytes([byte[]]$Bytes) {


### PR DESCRIPTION
## Summary
- reduce publishing chunks from 32 MiB to 4 MiB so individual Cloudflare-proxied requests complete reliably
- keep Kestrel request limits and the publishing script on the same contract
- document the Cloudflare timeout rationale and update the storage-reservation concurrency test

## Validation
- dotnet test FutureMUD.Web.Tests/FutureMUD.Web.Tests.csproj -c Release --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 (54 passed)
- live production retry reproduced a Cloudflare 524 on a 32 MiB upload after storage capacity was corrected