### PR TITLE
Release Terrain Planner 2.0.7

### DIFF
--- a/FutureMUD.Web/Content/PatchNotes/2026-08-27-terrain-planner-2-0-7.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-08-27-terrain-planner-2-0-7.md
@@ -1,0 +1,12 @@
+---
+title: FutureMUD Terrain Planner & Engine API 2.0.7
+summary: Restores reliable public publishing for the duplicate-tag catalogue correction and clarifies hosted-installation steps.
+date: 2026-08-27
+tags: terrainplanner, release, deployment, bugfix
+---
+
+Terrain Planner & Engine API 2.0.7 makes the duplicate-tag catalogue correction from the unpublished 2.0.6 build available through the normal signed update channel. Builders can now sign in and load catalogues containing the same short tag name in different hierarchy branches without the planner stalling.
+
+The website publisher now transfers releases in Cloudflare-compatible chunks, preventing long upload requests from timing out on the hosted website. The hosted-installation guide also makes the Windows archive's nested package directory and the non-standard Caddy fallback explicit.
+
+Installations already running Terrain Planner 2.0.5 or later can use the signed in-place updater.

--- a/TerrainPlanner/DEPLOYMENT.md
+++ b/TerrainPlanner/DEPLOYMENT.md
@@ -25,8 +25,9 @@ FLUSH PRIVILEGES;
 Extract the archive. It creates one directory named for the runtime package; change into that directory, then run:
 
 ```bash
-unzip terrainplanner-2.0.6-linux-x64.zip
-cd terrainplanner-2.0.6-linux-x64
+version=2.0.7
+unzip "terrainplanner-$version-linux-x64.zip"
+cd "terrainplanner-$version-linux-x64"
 sudo bash deploy/linux/install-terrainplanner.sh planner.example.com
 ```
 
@@ -44,12 +45,15 @@ The installer creates the unprivileged `terrainplanner` account, installs a hard
 Open an elevated PowerShell prompt. The archive extracts to an outer download directory which contains the actual runtime package directory; change into the inner directory before running the installer:
 
 ```powershell
-$archive = 'C:\Install\terrainplanner-2.0.6-win-x64.zip'
-$extractRoot = 'C:\Install\terrainplanner-2.0.6'
+$version = '2.0.7'
+$archive = "C:\Install\terrainplanner-$version-win-x64.zip"
+$extractRoot = "C:\Install\terrainplanner-$version"
 Expand-Archive -LiteralPath $archive -DestinationPath $extractRoot -Force
-Set-Location "$extractRoot\terrainplanner-2.0.6-win-x64"
+Set-Location "$extractRoot\terrainplanner-$version-win-x64"
 .\deploy\windows\Install-TerrainPlanner.ps1 -Hostname planner.example.com
 ```
+
+`Expand-Archive` creates an outer download directory containing the actual runtime-package directory. Run the installer only after changing into that inner `terrainplanner-<version>-win-x64` directory. If the Web MUD Client's scheduled task cannot identify Caddy because it was installed in a non-standard location, use the explicit Caddy fallback shown below on the first install and on future updates.
 
 On the first run it creates `%ProgramFiles%\FutureMUD\TerrainPlanner\shared\appsettings.Production.json` and stops before creating a release. Replace `REPLACE_WITH_SECRET`, restrict that file to Administrators and SYSTEM, then rerun the same command.
 

--- a/TerrainPlanner/TerrainPlanner.Server/TerrainPlanner.Server.csproj
+++ b/TerrainPlanner/TerrainPlanner.Server/TerrainPlanner.Server.csproj
@@ -4,9 +4,9 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>2.0.6</Version>
-		<AssemblyVersion>2.0.6</AssemblyVersion>
-		<FileVersion>2.0.6</FileVersion>
+		<Version>2.0.7</Version>
+		<AssemblyVersion>2.0.7</AssemblyVersion>
+		<FileVersion>2.0.7</FileVersion>
 		<BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
 		<AssemblyName>TerrainPlanner</AssemblyName>
 		<RootNamespace>TerrainPlanner.Server</RootNamespace>


### PR DESCRIPTION
## Summary
- release the duplicate-tag catalogue-loading correction through a new immutable 2.0.7 tag
- document Cloudflare-compatible release publishing and clearer hosted-installation steps
- update the packaged planner assembly version to 2.0.7

## Validation
- dotnet test TerrainPlanner\\TerrainPlanner.Tests\\TerrainPlanner.Tests.csproj -c Release --no-build --no-restore -m:1 (33 passed)
- dotnet test FutureMUD.Web.Tests\\FutureMUD.Web.Tests.csproj -c Release --no-restore -m:1 (54 passed)

2.0.6 remains immutable and unpublished; 2.0.7 is the public replacement release.