### PR TITLE
Version update to Engine 2.8.0 and Terrain Planner 2.1.0

### DIFF
--- a/Design Documents/Building/Autobuilder_Builder_How_To.md
+++ b/Design Documents/Building/Autobuilder_Builder_How_To.md
@@ -66,7 +66,7 @@ Important rules:
 - The mask is row-major from the bottom-left `(0,0)` cell: proceed right across the southern row, then move one row north.
 - `0` means no room should be created at that coordinate.
 - The number of entries must exactly match `height x width`.
-- Feature-mask entries use short tag names separated by `|`; an untagged cell is an empty entry.
+- Feature-mask entries use positive tag IDs separated by `|`; an untagged cell is an empty entry. The Terrain Planner displays the names for you but exports the IDs, so duplicate or renamed tag names cannot change the target tag.
 
 ## Building An Area
 
@@ -131,7 +131,7 @@ Use:
 - area template: `Feature Rectangle`
 - room template: `Seeded Terrain Wilderness Grouped Description` or a custom random room template
 
-`Feature Rectangle` takes an extra feature mask argument after the terrain mask. Each cell's features are separated with `|`, and cells are still separated with commas.
+`Feature Rectangle` takes an extra feature mask argument after the terrain mask. Each cell's tag IDs are separated with `|`, and cells are still separated with commas. It resolves those IDs directly to framework tags while supplying their names to the selected room template's descriptive feature rules.
 
 That lets you drive extra descriptive tags into the room template deliberately.
 

--- a/Design Documents/Building/Autobuilder_System_Implementation.md
+++ b/Design Documents/Building/Autobuilder_System_Implementation.md
@@ -145,7 +145,7 @@ Road elements are special because they interpret one tag as `tag=directions` and
 
 There are two different feature/tag paths:
 
-- `terrain feature rectangle` takes an explicit feature mask from the builder.
+- `terrain feature rectangle` takes an explicit tag-ID mask from the builder.
 - `room by terrain random features` generates features internally through feature groups.
 
 Feature groups currently include:
@@ -154,7 +154,7 @@ Feature groups currently include:
 - uniform per-room feature groups
 - road feature groups
 
-Those features become string tags passed into the room template. If `ApplyAutobuilderTagsAsFrameworkTags` is on, matching framework tags are also written to the cells themselves.
+Generated feature groups become string tags passed into the room template. If `ApplyAutobuilderTagsAsFrameworkTags` is on, matching framework tags are also written to the cells themselves. In contrast, `terrain feature rectangle` parses each explicit feature-mask entry as a positive framework tag ID, resolves it to the exact tag, passes its name to descriptive feature rules, and applies that resolved tag directly to the created cell. This prevents duplicate tag names from selecting the wrong framework tag.
 
 The stock wilderness package also uses internal marker tags such as `Physical Primary` and `Physical Secondary` so its mandatory first and second prose layers remain stable even when the same descriptive feature name is reused in different terrain domains.
 
@@ -193,6 +193,8 @@ Terrain Planner 2.x is a hosted Interactive WebAssembly application bundled with
 The mask format matches Cartesian coordinates: the first entry is the south-west `(0,0)` cell, each row proceeds
 west-to-east, and subsequent rows proceed northward. Terrain Planner displays north at the top while exporting the
 southern row first.
+
+Terrain entries are numeric terrain IDs. `Feature Rectangle` entries are numeric framework tag IDs, with multiple IDs in a cell separated by `|`; names are not accepted for that explicit-mask template.
 
 ## Extension Guidance
 

--- a/Design Documents/Building/Room_Building_Builder_Guide.md
+++ b/Design Documents/Building/Room_Building_Builder_Guide.md
@@ -666,11 +666,13 @@ The IDs above are examples. Use `terrain planner` or `show terrain` to get the c
 Feature mask example:
 
 ```text
-cell new "Feature Rectangle" 2 3 "Seeded Terrain Wilderness Grouped Description" 12,12,12,15,15,15 "Trail Straight|Roadside Marker,Trail Bend,Wildflowers,,Dense Underbrush,Trail Straight"
+cell new "Feature Rectangle" 2 3 "Seeded Terrain Wilderness Grouped Description" 12,12,12,15,15,15 "101|102,103,104,,105,101"
 ```
 
 Feature masks use the same bottom-left row-major order. Separate cells with commas and multiple features in one cell
-with `|`. Feature names must match the room template's expected feature tags.
+with `|`. Use the numeric IDs from `tag list` or the hosted Terrain Planner; the IDs are resolved to the exact
+framework tags, and their names are supplied to the room template's descriptive feature rules. The IDs above are
+examples only.
 
 Area template editing:
 
@@ -1291,7 +1293,7 @@ When assisting a builder:
 - Prefer compact paste chains with `@n` when creating connected rooms.
 - Use quoted names for multi-word package, zone, area, terrain, and room names.
 - Do not submit, review, swap, delete, or obsolete a package unless the user explicitly wants that workflow step.
-- Use the hosted Terrain Planner's terrain mask for `Terrain Rectangle` grids and its tag mask for `Feature Rectangle`. Remember that `0` means no room and therefore no tags.
+- Use the hosted Terrain Planner's terrain mask for `Terrain Rectangle` grids and its numeric tag-ID mask for `Feature Rectangle`. Remember that `0` means no room and therefore no tags.
 - Set terrain before adjusting outdoors type and light special cases.
 - For non-cardinal exits, inspect `show exittemplates` first and choose the template whose verbs match the player's command.
 - Verify important builds with `cell show`, `cell exit list all`, `rooms <zone>`, and `landmarks`.

--- a/Design Documents/Building/Terrain_Planner_and_Engine_API.md
+++ b/Design Documents/Building/Terrain_Planner_and_Engine_API.md
@@ -26,20 +26,20 @@ Authenticated read-only endpoints are:
 
 The UI renders the visible viewport to one HTML canvas. Pointer input is batched before crossing into WebAssembly, so a 200 x 200 map does not create 40,000 Blazor components. The desktop-first workspace provides terrain and tag palettes, search, coordinate rulers, pan/zoom, paint, flood fill, rectangle, eyedropper, erase, undo/redo, cell inspection, layer/map clears, and keyboard shortcuts.
 
-A cell has one terrain and zero or more tags. Painting terrain replaces the terrain; setting terrain `0` also clears tags. Tag painting is additive and tag erasing removes only the active tag. Tags use deterministic accessible marker colours with per-project overrides; the inspector and used-tag legend show hierarchical names. Invalid short names containing `,`, `|`, CR, or LF are visibly unavailable because they cannot be represented in an autobuilder feature mask.
+A cell has one terrain and zero or more tags. Painting terrain replaces the terrain; setting terrain `0` also clears tags. Tag painting is additive and tag erasing removes only the active tag. Tags use deterministic accessible marker colours with per-project overrides; the inspector and used-tag legend show hierarchical names. Every live tag remains paintable, including tags with duplicate short names or characters that were unsafe in the former name-based mask format.
 
-Resize preserves the bottom-left overlap. Cropping removes north/east cells and requires confirmation. Projects autosave in browser local storage, namespaced by game origin and account ID, and can be imported/exported as schema-versioned JSON. They contain dimensions, terrain IDs, tag IDs plus export names, legend colours, unresolved historical tag names, and catalogue revision—not passwords, cookies, or tokens.
+Resize preserves the bottom-left overlap. Cropping removes north/east cells and requires confirmation. Canvas updates are versioned so queued input captured before a resize cannot modify the replacement grid, and cleared cells are removed from the canvas cache rather than drawn with a fallback colour. Projects autosave in browser local storage, namespaced by game origin and account ID, and can be imported/exported as schema-versioned JSON. They contain dimensions, terrain IDs, tag IDs plus display names, legend colours, unresolved historical tag IDs, and catalogue revision—not passwords, cookies, or tokens.
 
-Catalogues refresh conditionally every five minutes after first load. A cached catalogue keeps local editing available during API/database outages. Open projects preserve their original tag export names and report live renames/deletions; catalogue refresh never silently changes an existing mask.
+Catalogues refresh conditionally every five minutes after first load. A cached catalogue keeps local editing available during API/database outages. Open projects preserve their tag IDs and report live renames/deletions; catalogue refresh never silently changes an existing mask.
 
 ## Mask contract
 
 Both masks contain exactly `width * height` comma-separated cells. Entry zero is the south-west `(0,0)` cell, entries proceed east across the southern row, and later rows proceed north.
 
 - Terrain mask: one terrain ID per entry; `0` means no cell is created.
-- Feature/tag mask: short tag names separated by `|` inside a cell; an untagged cell is an empty entry.
+- Feature/tag mask: positive tag IDs separated by `|` inside a cell; an untagged cell is an empty entry.
 
-The UI displays hierarchical tag names but exports only globally unique short names, matching `ApplyTagsToCell`'s name-based resolution. If two tags share a short name, both remain visible in the palette but are disabled for feature-mask painting with an explanation; importing that ambiguous name keeps it unresolved rather than choosing a tag arbitrarily. Separate copy/import controls and the combined export panel preserve empty entries. Clipboard denial leaves selectable mask text available.
+The UI displays hierarchical tag names but exports numeric IDs. `Feature Rectangle` resolves each supplied ID to the exact framework tag before the room template is created, while still passing the tag names into descriptive feature rules. This keeps duplicate short names unambiguous and makes tag renames harmless to an existing mask. Name-based feature masks are rejected; import retains unknown positive IDs for review and round-tripping, but the engine rejects them until the tag exists again. Separate copy/import controls and the combined export panel preserve empty entries. Clipboard denial leaves selectable mask text available.
 
 ## Deployment and release
 

--- a/FutureMUD.Web/Content/PatchNotes/2026-08-27-engine-2-8-0.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-08-27-engine-2-8-0.md
@@ -1,0 +1,18 @@
+---
+title: FutureMUD Engine 2.8.0
+summary: Adds exact tag-ID masks to Feature Rectangle autobuilding so planner exports remain safe across duplicate and renamed tags.
+date: 2026-08-27
+tags: engine, release, builders, autobuilder
+---
+
+**Upgrade note:** Apply the normal database upgrades before starting Engine 2.8.0. When using the hosted Terrain Planner, upgrade it to 2.1.0 at the same time: its feature masks now use numeric tag IDs. Terrain masks are unchanged.
+
+## Exact Tags For Feature Rectangle
+
+`Feature Rectangle` now accepts an explicit mask of positive framework tag IDs. A cell remains a comma-separated entry, and multiple tags in that cell are separated by `|`; for example, `101|102,103,,104`.
+
+The Engine resolves each ID before creating its cell, applies that exact framework tag, and still supplies the tag name to the selected room template's descriptive rules. This avoids ambiguity when multiple hierarchy branches share a short tag name and protects a saved planner mask from later tag renames.
+
+Builders can obtain IDs with `tag list`, then use the mask as the final argument to `cell new "Feature Rectangle" ...`. Name-based masks are no longer accepted by that explicit template, so convert any hand-written mask before running it.
+
+Use [/downloads](/downloads) for release archives and checksums, [/getting-started](/getting-started) for installation requirements, and [/docs/commands](/docs/commands) for the published Engine reference.

--- a/FutureMUD.Web/Content/PatchNotes/2026-08-27-terrain-planner-2-1-0.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-08-27-terrain-planner-2-1-0.md
@@ -1,0 +1,22 @@
+---
+title: FutureMUD Terrain Planner & Engine API 2.1.0
+summary: Makes terrain painting dependable after resize, uses the shared FutureMUD identity, and exports unambiguous tag-ID masks.
+date: 2026-08-27
+tags: terrainplanner, release, builders, autobuilder
+---
+
+**Compatibility note:** Terrain Planner 2.1.0 exports numeric tag IDs in feature masks. Install Engine 2.8.0 before pasting a new tag mask into `Feature Rectangle`; the terrain mask itself is unchanged.
+
+## Reliable Grid Editing
+
+The planner now discards queued input from a grid that has just been resized. This prevents a delayed stroke from appearing in a distant coordinate after changing dimensions. Clearing a terrain or the full map also removes blank cells from the canvas cache, so the visual grid now agrees with the copied mask.
+
+## Stable Tag Masks
+
+Tag masks now contain positive framework tag IDs, with multiple IDs in one cell separated by `|`. The palette continues to show the full hierarchical tag name, but the exported value is stable if a tag is renamed and unambiguous when different tag branches share a short name.
+
+Use the planner's **Copy tag-ID mask** control with Engine 2.8.0's `Feature Rectangle` area template. Existing hand-written name masks need to be converted to tag IDs; `tag list` shows the IDs available in the game.
+
+## Familiar FutureMUD Branding
+
+The hosted planner now uses the same FutureMUD logo asset as the public website on both its sign-in and builder screens. Existing 2.0.5-or-later installations can use the normal signed in-place updater.

--- a/FutureMUDLibrary/Construction/Autobuilder/IAutobuilderRoom.cs
+++ b/FutureMUDLibrary/Construction/Autobuilder/IAutobuilderRoom.cs
@@ -2,12 +2,16 @@
 using MudSharp.Framework;
 using MudSharp.Framework.Revision;
 using MudSharp.Framework.Save;
+using System.Collections.Generic;
 
 namespace MudSharp.Construction.Autobuilder
 {
     public interface IAutobuilderRoom : ISaveable, IEditableItem
     {
         ICell CreateRoom(ICharacter builder, ITerrain specifiedTerrain, bool deferDescription, params string[] tags);
+        ICell CreateRoom(ICharacter builder, ITerrain specifiedTerrain, bool deferDescription,
+            IReadOnlyCollection<ITag> frameworkTags, params string[] tags) =>
+            CreateRoom(builder, specifiedTerrain, deferDescription, tags);
         IAutobuilderRoom Clone(string newName);
         void RedescribeRoom(ICell cell, params string[] tags);
         string ShowCommandByline { get; }

--- a/MudSharpCore Unit Tests/AutobuilderFeatureMaskTests.cs
+++ b/MudSharpCore Unit Tests/AutobuilderFeatureMaskTests.cs
@@ -1,0 +1,54 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Construction.Autobuilder.Areas;
+using MudSharp.Framework;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class AutobuilderFeatureMaskTests
+{
+	[TestMethod]
+	public void Parse_ResolvesTagIdsInBottomLeftMaskOrder()
+	{
+		var road = Tag(41, "Road");
+		var bridge = Tag(42, "Bridge");
+
+		var result = AutobuilderFeatureMask.Parse("41|42,,42,41", 4, [road, bridge]);
+
+		CollectionAssert.AreEqual(new long[] { 41, 42 }, result[0].Select(tag => tag.Id).ToArray());
+		Assert.AreEqual(0, result[1].Length);
+		CollectionAssert.AreEqual(new long[] { 42 }, result[2].Select(tag => tag.Id).ToArray());
+		CollectionAssert.AreEqual(new long[] { 41 }, result[3].Select(tag => tag.Id).ToArray());
+	}
+
+	[DataTestMethod]
+	[DataRow("road", "not a positive tag ID")]
+	[DataRow("0", "not a positive tag ID")]
+	[DataRow("99", "unknown tag ID 99")]
+	public void TryParse_RejectsNamesNonPositiveIdsAndUnknownIds(string mask, string expectedError)
+	{
+		var parsed = AutobuilderFeatureMask.TryParse(mask, 1, [Tag(41, "Road")], out _, out var error);
+
+		Assert.IsFalse(parsed);
+		StringAssert.Contains(error, expectedError);
+	}
+
+	[TestMethod]
+	public void TryParse_RejectsIncorrectCellCount()
+	{
+		var parsed = AutobuilderFeatureMask.TryParse("41,", 1, [Tag(41, "Road")], out _, out var error);
+
+		Assert.IsFalse(parsed);
+		Assert.AreEqual("The feature mask must exactly match the size of the grid.", error);
+	}
+
+	private static ITag Tag(long id, string name)
+	{
+		var tag = new Mock<ITag>();
+		tag.SetupGet(x => x.Id).Returns(id);
+		tag.SetupGet(x => x.Name).Returns(name);
+		return tag.Object;
+	}
+}

--- a/MudSharpCore/Construction/Autobuilder/Areas/AutobuilderAreaTerrainFeatureRectangle.cs
+++ b/MudSharpCore/Construction/Autobuilder/Areas/AutobuilderAreaTerrainFeatureRectangle.cs
@@ -1,6 +1,7 @@
 ﻿using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Database;
+using System.IO;
 
 namespace MudSharp.Construction.Autobuilder.Areas;
 
@@ -33,33 +34,22 @@ public class AutobuilderAreaTerrainFeatureRectangle : AutobuilderAreaTerrainRect
             IsOptional = false,
             ParameterName = "featuresmask",
             MissingErrorMessage =
-                "You must enter a mask of features for each location, separated by vertical lines (|) within the location and commas between the locations, starting from the bottom left corner of the rectangle and proceeding right and up.",
+                "You must enter a mask of tag IDs for each location, separated by vertical lines (|) within the location and commas between the locations, starting from the bottom left corner of the rectangle and proceeding right and up.",
             TypeName = "feature mask",
             IsValidArgumentFunction = (arg, game, args) =>
             {
                 int height = (int)args[0];
                 int width = (int)args[1];
-                string[] split = arg.Split(',');
-                if (split.Length != height * width)
-                {
-                    return false;
-                }
-
-                return true;
+                return AutobuilderFeatureMask.TryParse(arg, height * width, game.Tags, out _, out _);
             },
             WhyIsNotValidArgumentFunction = (arg, game, args) =>
             {
                 int height = (int)args[0];
                 int width = (int)args[1];
-                string[] split = arg.Split(',');
-                if (split.Length != height * width)
-                {
-                    return "The feature mask must exactly match the size of the grid.";
-                }
-
-                return "";
+                AutobuilderFeatureMask.TryParse(arg, height * width, game.Tags, out _, out string error);
+                return error;
             },
-            GetArgumentFunction = (arg, game) => { return arg.Split(',').Select(x => x.Split('|')).ToArray(); }
+            GetArgumentFunction = (arg, game) => AutobuilderFeatureMask.Parse(arg, game.Tags)
         });
     }
 
@@ -71,10 +61,10 @@ public class AutobuilderAreaTerrainFeatureRectangle : AutobuilderAreaTerrainRect
         int width = (int)argList.ElementAt(1);
         IAutobuilderRoom roomTemplate = (IAutobuilderRoom)argList.ElementAt(2);
         ITerrain[] terrainArg = (ITerrain[])argList.ElementAt(3);
-        string[][] featureArg = (string[][])argList.ElementAt(4);
+        ITag[][] featureArg = (ITag[][])argList.ElementAt(4);
 
         ITerrain[,] terrains = new ITerrain[width, height];
-        string[,][] features = new string[width, height][];
+        ITag[,][] features = new ITag[width, height][];
         int x = 0, y = 0;
         for (int i = 0; i < terrainArg.Length; i++)
         {
@@ -97,7 +87,9 @@ public class AutobuilderAreaTerrainFeatureRectangle : AutobuilderAreaTerrainRect
                     continue;
                 }
 
-                ICell cell = roomTemplate.CreateRoom(builder, terrains[i, j], false, features[i, j]);
+                ITag[] tags = features[i, j];
+                ICell cell = roomTemplate.CreateRoom(builder, terrains[i, j], false, tags,
+                    tags.Select(x => x.Name).ToArray());
                 cells[i, j] = cell;
 
             }
@@ -121,7 +113,7 @@ public class AutobuilderAreaTerrainFeatureRectangle : AutobuilderAreaTerrainRect
     public override string Show(ICharacter builder)
     {
         return
-            $"{$"Autobuilder Area Template #{Id} ({Name})".Colour(Telnet.Cyan)}\n\n{$"This autobuilder template will return a rectangular area of cells with height, width, terrain, room features and room template supplied by the builder. It also requires the builder to specify a matching mask of tags to be applied to the generated rooms. This template {(ConnectCellsWithDiagonalExits ? "does" : "does not")} connect rooms diagonally.".Wrap(builder.InnerLineFormatLength)}";
+            $"{$"Autobuilder Area Template #{Id} ({Name})".Colour(Telnet.Cyan)}\n\n{$"This autobuilder template will return a rectangular area of cells with height, width, terrain, room features and room template supplied by the builder. It also requires the builder to specify a matching mask of tag IDs to be applied to the generated rooms. This template {(ConnectCellsWithDiagonalExits ? "does" : "does not")} connect rooms diagonally.".Wrap(builder.InnerLineFormatLength)}";
     }
 
     public override IAutobuilderArea Clone(string newName)
@@ -139,4 +131,92 @@ public class AutobuilderAreaTerrainFeatureRectangle : AutobuilderAreaTerrainRect
             return new AutobuilderAreaTerrainFeatureRectangle(dbitem, Gameworld);
         }
     }
+}
+
+public static class AutobuilderFeatureMask
+{
+	public static bool TryParse(string mask, int expectedCellCount, IEnumerable<ITag> tags,
+		out ITag[][] result, out string error)
+	{
+		try
+		{
+			result = Parse(mask, expectedCellCount, tags);
+			error = string.Empty;
+			return true;
+		}
+		catch (InvalidDataException exception)
+		{
+			result = [];
+			error = exception.Message;
+			return false;
+		}
+	}
+
+	public static ITag[][] Parse(string mask, IEnumerable<ITag> tags)
+	{
+		var entries = SplitEntries(mask);
+		return Parse(entries, entries.Length, tags);
+	}
+
+	public static ITag[][] Parse(string mask, int expectedCellCount, IEnumerable<ITag> tags)
+	{
+		return Parse(SplitEntries(mask), expectedCellCount, tags);
+	}
+
+	private static ITag[][] Parse(IReadOnlyList<string> entries, int expectedCellCount, IEnumerable<ITag> tags)
+	{
+		ArgumentNullException.ThrowIfNull(tags);
+		if (entries.Count != expectedCellCount)
+		{
+			throw new InvalidDataException("The feature mask must exactly match the size of the grid.");
+		}
+
+		var tagsById = tags
+			.GroupBy(tag => tag.Id)
+			.ToDictionary(group => group.Key, group => group.First());
+		var result = new ITag[entries.Count][];
+		for (var index = 0; index < entries.Count; index++)
+		{
+			if (string.IsNullOrWhiteSpace(entries[index]))
+			{
+				result[index] = [];
+				continue;
+			}
+
+			var tagIds = entries[index]
+				.Split('|', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+				.Select(value => ParseTagId(value, index))
+				.Distinct()
+				.ToArray();
+			var cellTags = new List<ITag>(tagIds.Length);
+			foreach (var tagId in tagIds)
+			{
+				if (!tagsById.TryGetValue(tagId, out var tag))
+				{
+					throw new InvalidDataException($"Feature mask entry {index + 1} refers to unknown tag ID {tagId}.");
+				}
+
+				cellTags.Add(tag);
+			}
+
+			result[index] = cellTags.ToArray();
+		}
+
+		return result;
+	}
+
+	private static string[] SplitEntries(string mask) =>
+		mask.Trim().Split(',', StringSplitOptions.None);
+
+	private static long ParseTagId(string value, int entryIndex)
+	{
+		if (!long.TryParse(value, System.Globalization.NumberStyles.None,
+			System.Globalization.CultureInfo.InvariantCulture, out long tagId) || tagId <= 0)
+		{
+			throw new InvalidDataException(
+				$"Feature mask entry {entryIndex + 1} contains '{value}', which is not a positive tag ID.");
+		}
+
+		return tagId;
+	}
 }

--- a/MudSharpCore/Construction/Autobuilder/Rooms/AutobuilderRoomBase.cs
+++ b/MudSharpCore/Construction/Autobuilder/Rooms/AutobuilderRoomBase.cs
@@ -32,8 +32,23 @@ public abstract class AutobuilderRoomBase : SaveableItem, IAutobuilderRoom
 
     protected void ApplyTagsToCell(ICell cell, string[] tags)
     {
+        ApplyTagsToCell(cell, [], tags);
+    }
+
+    protected void ApplyTagsToCell(ICell cell, IReadOnlyCollection<ITag> frameworkTags, string[] tags)
+    {
         if (!ApplyAutobuilderTagsAsFrameworkTags)
         {
+            return;
+        }
+
+        if (frameworkTags.Count > 0)
+        {
+            foreach (ITag frameworkTag in frameworkTags.DistinctBy(x => x.Id))
+            {
+                cell.AddTag(frameworkTag);
+            }
+
             return;
         }
 
@@ -59,6 +74,9 @@ public abstract class AutobuilderRoomBase : SaveableItem, IAutobuilderRoom
 
     public abstract ICell CreateRoom(ICharacter builder, ITerrain specifiedTerrain, bool deferDescription,
         params string[] tags);
+    public virtual ICell CreateRoom(ICharacter builder, ITerrain specifiedTerrain, bool deferDescription,
+        IReadOnlyCollection<ITag> frameworkTags, params string[] tags) =>
+        CreateRoom(builder, specifiedTerrain, deferDescription, tags);
 
     public virtual void RedescribeRoom(ICell cell, params string[] tags)
     {
@@ -110,7 +128,7 @@ public abstract class AutobuilderRoomBase : SaveableItem, IAutobuilderRoom
         ApplyAutobuilderTagsAsFrameworkTags = !ApplyAutobuilderTagsAsFrameworkTags;
         Changed = true;
         actor.OutputHandler.Send(
-            $"This room builder template will {(ApplyAutobuilderTagsAsFrameworkTags ? "now" : "no longer")} attempt to match room builder tags with identically-named framework tags and apply them to the created room.");
+            $"This room builder template will {(ApplyAutobuilderTagsAsFrameworkTags ? "now" : "no longer")} apply framework tags to created rooms. Feature Rectangle masks use their tag IDs directly; legacy and generated named features are matched by name.");
         return true;
     }
 

--- a/MudSharpCore/Construction/Autobuilder/Rooms/AutobuilderRoomByTerrain.cs
+++ b/MudSharpCore/Construction/Autobuilder/Rooms/AutobuilderRoomByTerrain.cs
@@ -116,6 +116,18 @@ public class AutobuilderRoomByTerrain : AutobuilderRoomBase
     public override ICell CreateRoom(ICharacter builder, ITerrain specifiedTerrain, bool deferDescription,
         params string[] tags)
     {
+        return CreateRoomCore(builder, specifiedTerrain, deferDescription, [], tags);
+    }
+
+    public override ICell CreateRoom(ICharacter builder, ITerrain specifiedTerrain, bool deferDescription,
+        IReadOnlyCollection<ITag> frameworkTags, params string[] tags)
+    {
+        return CreateRoomCore(builder, specifiedTerrain, deferDescription, frameworkTags, tags);
+    }
+
+    private ICell CreateRoomCore(ICharacter builder, ITerrain specifiedTerrain, bool deferDescription,
+        IReadOnlyCollection<ITag> frameworkTags, string[] tags)
+    {
         Room room = new(builder, builder.CurrentOverlayPackage);
         ICell cell = room.Cells.First();
         IEditableCellOverlay overlay = cell.GetOrCreateOverlay(builder.CurrentOverlayPackage);
@@ -128,7 +140,7 @@ public class AutobuilderRoomByTerrain : AutobuilderRoomBase
         overlay.OutdoorsType = info.OutdoorsType;
         overlay.Terrain = specifiedTerrain ?? info.DefaultTerrain;
         cell.ForagableProfile = info.ForagableProfile;
-        ApplyTagsToCell(cell, tags);
+        ApplyTagsToCell(cell, frameworkTags, tags);
         return cell;
     }
 

--- a/MudSharpCore/Construction/Autobuilder/Rooms/AutobuilderRoomRandomDescription.cs
+++ b/MudSharpCore/Construction/Autobuilder/Rooms/AutobuilderRoomRandomDescription.cs
@@ -158,6 +158,18 @@ public class AutobuilderRoomRandomDescription : AutobuilderRoomBase
     public override ICell CreateRoom(ICharacter builder, ITerrain specifiedTerrain, bool deferDescription,
         params string[] tags)
     {
+        return CreateRoomCore(builder, specifiedTerrain, deferDescription, [], tags);
+    }
+
+    public override ICell CreateRoom(ICharacter builder, ITerrain specifiedTerrain, bool deferDescription,
+        IReadOnlyCollection<ITag> frameworkTags, params string[] tags)
+    {
+        return CreateRoomCore(builder, specifiedTerrain, deferDescription, frameworkTags, tags);
+    }
+
+    private ICell CreateRoomCore(ICharacter builder, ITerrain specifiedTerrain, bool deferDescription,
+        IReadOnlyCollection<ITag> frameworkTags, string[] tags)
+    {
         Room room = new(builder, builder.CurrentOverlayPackage);
         ICell cell = room.Cells.First();
         IEditableCellOverlay overlay = cell.GetOrCreateOverlay(builder.CurrentOverlayPackage);
@@ -170,7 +182,7 @@ public class AutobuilderRoomRandomDescription : AutobuilderRoomBase
 		overlay.AmbientLightFactor = info.AmbientLightFactor;
 
 		cell.ForagableProfile = info.ForagableProfile;
-		ApplyTagsToCell(cell, tags);
+		ApplyTagsToCell(cell, frameworkTags, tags);
 
         if (!deferDescription)
         {

--- a/MudSharpCore/Construction/Autobuilder/Rooms/AutobuilderRoomSimple.cs
+++ b/MudSharpCore/Construction/Autobuilder/Rooms/AutobuilderRoomSimple.cs
@@ -118,6 +118,18 @@ public class AutobuilderRoomSimple : AutobuilderRoomBase
     public override ICell CreateRoom(ICharacter builder, ITerrain specifiedTerrain, bool deferDescription,
         params string[] tags)
     {
+        return CreateRoomCore(builder, specifiedTerrain, deferDescription, [], tags);
+    }
+
+    public override ICell CreateRoom(ICharacter builder, ITerrain specifiedTerrain, bool deferDescription,
+        IReadOnlyCollection<ITag> frameworkTags, params string[] tags)
+    {
+        return CreateRoomCore(builder, specifiedTerrain, deferDescription, frameworkTags, tags);
+    }
+
+    private ICell CreateRoomCore(ICharacter builder, ITerrain specifiedTerrain, bool deferDescription,
+        IReadOnlyCollection<ITag> frameworkTags, string[] tags)
+    {
         Room room = new(builder, builder.CurrentOverlayPackage);
         ICell cell = room.Cells.First();
         IEditableCellOverlay overlay = cell.GetOrCreateOverlay(builder.CurrentOverlayPackage);
@@ -127,7 +139,7 @@ public class AutobuilderRoomSimple : AutobuilderRoomBase
         overlay.OutdoorsType = OutdoorsType;
         overlay.Terrain = specifiedTerrain ?? DefaultTerrain;
         cell.ForagableProfile = ForagableProfile;
-        ApplyTagsToCell(cell, tags);
+        ApplyTagsToCell(cell, frameworkTags, tags);
         return cell;
     }
 

--- a/MudSharpCore/MudSharpCore.csproj
+++ b/MudSharpCore/MudSharpCore.csproj
@@ -10,9 +10,9 @@
 	<Product>FutureMUD</Product>
 	<ApplicationIcon>FM Logo.ico</ApplicationIcon>
 	<AssemblyName>MudSharp</AssemblyName>
-	<Version>2.7.0</Version>
-	<AssemblyVersion>2.7.0</AssemblyVersion>
-	<FileVersion>2.7.0</FileVersion>
+	<Version>2.8.0</Version>
+	<AssemblyVersion>2.8.0</AssemblyVersion>
+	<FileVersion>2.8.0</FileVersion>
   </PropertyGroup>
 
 	<PropertyGroup>

--- a/TerrainPlanner/DEPLOYMENT.md
+++ b/TerrainPlanner/DEPLOYMENT.md
@@ -25,7 +25,7 @@ FLUSH PRIVILEGES;
 Extract the archive. It creates one directory named for the runtime package; change into that directory, then run:
 
 ```bash
-version=2.0.7
+version=2.1.0
 unzip "terrainplanner-$version-linux-x64.zip"
 cd "terrainplanner-$version-linux-x64"
 sudo bash deploy/linux/install-terrainplanner.sh planner.example.com
@@ -45,7 +45,7 @@ The installer creates the unprivileged `terrainplanner` account, installs a hard
 Open an elevated PowerShell prompt. The archive extracts to an outer download directory which contains the actual runtime package directory; change into the inner directory before running the installer:
 
 ```powershell
-$version = '2.0.7'
+$version = '2.1.0'
 $archive = "C:\Install\terrainplanner-$version-win-x64.zip"
 $extractRoot = "C:\Install\terrainplanner-$version"
 Expand-Archive -LiteralPath $archive -DestinationPath $extractRoot -Force

--- a/TerrainPlanner/TerrainPlanner.Client/Components/LoginPanel.razor
+++ b/TerrainPlanner/TerrainPlanner.Client/Components/LoginPanel.razor
@@ -2,7 +2,7 @@
 
 <main class="login-page">
 	<section class="login-hero">
-		<div class="brand-mark">FM</div>
+		<img class="brand-logo" src="images/fm-logo.png" alt="" />
 		<p class="eyebrow">FutureMUD builder tools</p>
 		<h1>Shape a world,<br />one cell at a time.</h1>
 		<p>Paint terrain and room-feature tags on a fast visual grid, then copy exact masks into the in-game autobuilder.</p>

--- a/TerrainPlanner/TerrainPlanner.Client/Components/PlannerWorkspace.razor
+++ b/TerrainPlanner/TerrainPlanner.Client/Components/PlannerWorkspace.razor
@@ -6,7 +6,7 @@
 <div class="planner-shell">
 	<header class="planner-header">
 		<div class="planner-brand">
-			<div class="brand-mark compact">FM</div>
+			<img class="brand-logo compact" src="images/fm-logo.png" alt="" />
 			<div>
 				<strong>Terrain Planner</strong>
 				<span>Engine API 2.0.0</span>
@@ -80,11 +80,9 @@
 					{
 						@foreach (var tag in FilteredTags)
 						{
-							var unavailableReason = _tagIndex.FeatureMaskUnavailableReason(tag);
-							var unavailable = unavailableReason is not null;
-							<button class="palette-item @(_tagBrushId == tag.Id ? "selected" : "")" disabled="@unavailable" title="@(unavailableReason ?? tag.FullName)" @onclick="() => SelectTagAsync(tag.Id)">
+							<button class="palette-item @(_tagBrushId == tag.Id ? "selected" : "")" title="@tag.FullName" @onclick="() => SelectTagAsync(tag.Id)">
 								<span class="tag-swatch" style="background:@GetTagColour(tag.Id)"></span>
-								<span><strong>@tag.ShortName</strong><small>@(unavailableReason ?? tag.FullName)</small></span>
+								<span><strong>@tag.ShortName</strong><small>@tag.FullName · ID @tag.Id</small></span>
 							</button>
 						}
 					}
@@ -153,7 +151,7 @@
 							}
 							@foreach (var feature in _selectedCell.UnresolvedFeatures)
 							{
-								<span class="unresolved">@feature</span>
+								<span class="unresolved">Unknown tag ID @feature</span>
 							}
 						</div>
 					}
@@ -179,13 +177,13 @@
 					<p class="eyebrow">Import and export</p>
 					<div class="export-actions">
 						<button class="primary-button" @onclick="CopyTerrainMaskAsync">Copy terrain mask</button>
-						<button class="secondary-button" @onclick="CopyFeatureMaskAsync">Copy tag mask</button>
+						<button class="secondary-button" @onclick="CopyFeatureMaskAsync">Copy tag-ID mask</button>
 					</div>
 					<details>
 						<summary>Mask text and import</summary>
 						<label>Terrain mask<textarea @bind="_terrainMaskText"></textarea></label>
 						<button class="quiet-button" @onclick="ImportTerrainMaskAsync">Import terrain mask</button>
-						<label>Feature/tag mask<textarea @bind="_featureMaskText"></textarea></label>
+						<label>Feature/tag ID mask<textarea @bind="_featureMaskText"></textarea></label>
 						<button class="quiet-button" @onclick="ImportFeatureMaskAsync">Import tag mask</button>
 					</details>
 					<details>
@@ -218,8 +216,6 @@
 	private IReadOnlyList<TagCatalogueItem> _tags = [];
 	private IReadOnlyDictionary<long, TerrainCatalogueItem> _terrainById = new Dictionary<long, TerrainCatalogueItem>();
 	private IReadOnlyDictionary<long, TagCatalogueItem> _tagById = TagCatalogueIndex.Empty.ById;
-	private IReadOnlyDictionary<string, TagCatalogueItem> _tagByName = TagCatalogueIndex.Empty.ByShortName;
-	private TagCatalogueIndex _tagIndex = TagCatalogueIndex.Empty;
 	private Dictionary<long, string> _tagColours = [];
 	private Dictionary<long, string> _projectTagNames = [];
 	private PlannerLayer _layer = PlannerLayer.Terrain;
@@ -250,6 +246,7 @@
 	private PeriodicTimer? _refreshTimer;
 	private readonly List<MapChangeSet> _activeStrokeChanges = [];
 	private bool _strokeActive;
+	private long _canvasMapVersion;
 
 	private IEnumerable<TerrainCatalogueItem> FilteredTerrains => _terrains.Where(terrain =>
 		string.IsNullOrWhiteSpace(_paletteSearch) || terrain.Name.Contains(_paletteSearch, StringComparison.OrdinalIgnoreCase));
@@ -347,9 +344,9 @@
 	}
 
 	[JSInvokable]
-	public async Task HandleCanvasStroke(GridCoordinate[] coordinates)
+	public async Task HandleCanvasStroke(long mapVersion, GridCoordinate[] coordinates)
 	{
-		if (coordinates.Length == 0)
+		if (mapVersion != _canvasMapVersion || coordinates.Length == 0)
 		{
 			return;
 		}
@@ -395,17 +392,22 @@
 	}
 
 	[JSInvokable]
-	public Task BeginCanvasStroke()
+	public Task BeginCanvasStroke(long mapVersion)
 	{
+		if (mapVersion != _canvasMapVersion)
+		{
+			return Task.CompletedTask;
+		}
+
 		_strokeActive = true;
 		_activeStrokeChanges.Clear();
 		return Task.CompletedTask;
 	}
 
 	[JSInvokable]
-	public Task EndCanvasStroke()
+	public Task EndCanvasStroke(long mapVersion)
 	{
-		if (_strokeActive)
+		if (_strokeActive && mapVersion == _canvasMapVersion)
 		{
 			_history.Record(MapChangeSet.Merge(_activeStrokeChanges));
 			_strokeActive = false;
@@ -416,14 +418,21 @@
 	}
 
 	[JSInvokable]
-	public Task HandleCanvasRectangle(GridCoordinate first, GridCoordinate second) =>
-		ApplyChangeAsync(_map.PaintRectangle(first, second, _layer,
-			_layer == PlannerLayer.Terrain ? _terrainBrushId : _tagBrushId,
-			_tool != PlannerTool.Erase));
+	public Task HandleCanvasRectangle(long mapVersion, GridCoordinate first, GridCoordinate second) =>
+		mapVersion == _canvasMapVersion
+			? ApplyChangeAsync(_map.PaintRectangle(first, second, _layer,
+				_layer == PlannerLayer.Terrain ? _terrainBrushId : _tagBrushId,
+				_tool != PlannerTool.Erase))
+			: Task.CompletedTask;
 
 	[JSInvokable]
-	public Task SelectCell(GridCoordinate coordinate)
+	public Task SelectCell(long mapVersion, GridCoordinate coordinate)
 	{
+		if (mapVersion != _canvasMapVersion)
+		{
+			return Task.CompletedTask;
+		}
+
 		_selectedCell = _map.Contains(coordinate.X, coordinate.Y) ? _map.CellAt(coordinate.X, coordinate.Y) : null;
 		StateHasChanged();
 		return Task.CompletedTask;
@@ -567,7 +576,7 @@
 	{
 		await RunImportAsync(() =>
 		{
-			MaskSerializer.ImportFeatureMask(_map, _featureMaskText, _tagByName);
+			MaskSerializer.ImportFeatureMask(_map, _featureMaskText, _tagById);
 			foreach (var tagId in _map.Cells.SelectMany(cell => cell.TagIds).Distinct())
 			{
 				if (_tagById.TryGetValue(tagId, out var tag))
@@ -604,8 +613,8 @@
 	{
 		try
 		{
-			_featureMaskText = MaskSerializer.ExportFeatureMask(_map, ProjectTags());
-			return CopyAsync(_featureMaskText, "Tag mask copied.");
+			_featureMaskText = MaskSerializer.ExportFeatureMask(_map);
+			return CopyAsync(_featureMaskText, "Tag-ID mask copied.");
 		}
 		catch (Exception exception)
 		{
@@ -702,7 +711,7 @@
 		_terrainMaskText = MaskSerializer.ExportTerrainMask(_map);
 		try
 		{
-			_featureMaskText = MaskSerializer.ExportFeatureMask(_map, ProjectTags());
+			_featureMaskText = MaskSerializer.ExportFeatureMask(_map);
 		}
 		catch
 		{
@@ -776,8 +785,8 @@
 					.Select(item => item.Value)
 					.ToList();
 				_statusMessage = renamed.Count > 0 || deleted.Count > 0
-					? $"The live tag catalogue changed. This plan keeps its original export names. Renamed: {string.Join(", ", renamed)}. Missing: {string.Join(", ", deleted)}."
-					: "The live terrain or tag catalogue changed. Existing painted IDs and export names were preserved.";
+					? $"The live tag catalogue changed. This plan keeps its tag IDs. Renamed: {string.Join(", ", renamed)}. Missing: {string.Join(", ", deleted)}."
+					: "The live terrain or tag catalogue changed. Existing painted IDs were preserved.";
 				await RenderFullMapAsync();
 			}
 			_offline = false;
@@ -796,9 +805,7 @@
 		_terrainById = _terrains
 			.GroupBy(item => item.Id)
 			.ToDictionary(group => group.Key, group => group.First());
-		_tagIndex = TagCatalogueIndex.Create(_tags);
-		_tagById = _tagIndex.ById;
-		_tagByName = _tagIndex.ByShortName;
+		_tagById = TagCatalogueIndex.Create(_tags).ById;
 	}
 
 	private void EnsureBrushesAndColours()
@@ -806,7 +813,7 @@
 		if (_terrainBrushId != 0 && !_terrainById.ContainsKey(_terrainBrushId)) _terrainBrushId = 0;
 		if (!_tagById.ContainsKey(_tagBrushId))
 		{
-			_tagBrushId = _tags.FirstOrDefault(_tagIndex.IsAvailableForFeatureMask)?.Id ?? 0;
+			_tagBrushId = _tags.FirstOrDefault()?.Id ?? 0;
 		}
 		foreach (var tag in _tags)
 		{
@@ -821,7 +828,10 @@
 			return;
 		}
 
+		_strokeActive = false;
+		_activeStrokeChanges.Clear();
 		var view = new CanvasMapView(
+			++_canvasMapVersion,
 			_map.Width,
 			_map.Height,
 			_map.Cells
@@ -837,7 +847,8 @@
 	{
 		if (_canvasModule is not null)
 		{
-			await _canvasModule.InvokeVoidAsync("updateCells", _canvas, cells.Select(ToCanvasCell).ToArray());
+			await _canvasModule.InvokeVoidAsync("updateCells", _canvas, _canvasMapVersion,
+				cells.Select(ToCanvasCell).ToArray());
 		}
 	}
 
@@ -936,7 +947,7 @@
 		IReadOnlyList<TagCatalogueItem> Tags,
 		string? TerrainRevision,
 		string? TagRevision);
-	private sealed record CanvasMapView(int Width, int Height, CanvasCell[] Cells, CanvasTerrain[] Terrains, CanvasTag[] Tags);
+	private sealed record CanvasMapView(long Version, int Width, int Height, CanvasCell[] Cells, CanvasTerrain[] Terrains, CanvasTag[] Tags);
 	private sealed record CanvasCell(int X, int Y, long TerrainId, long[] TagIds);
 	private sealed record CanvasTerrain(long Id, string Colour, string Text);
 	private sealed record CanvasTag(long Id, string Colour);

--- a/TerrainPlanner/TerrainPlanner.Client/Components/PlannerWorkspace.razor
+++ b/TerrainPlanner/TerrainPlanner.Client/Components/PlannerWorkspace.razor
@@ -9,7 +9,7 @@
 			<img class="brand-logo compact" src="images/fm-logo.png" alt="" />
 			<div>
 				<strong>Terrain Planner</strong>
-				<span>Engine API 2.0.0</span>
+				<span>Engine API v1</span>
 			</div>
 		</div>
 		<div class="project-title">

--- a/TerrainPlanner/TerrainPlanner.Client/Pages/Home.razor
+++ b/TerrainPlanner/TerrainPlanner.Client/Pages/Home.razor
@@ -6,7 +6,7 @@
 @if (_loading)
 {
 	<main class="message-page" aria-live="polite">
-		<div class="brand-mark">FM</div>
+		<img class="brand-logo" src="images/fm-logo.png" alt="" />
 		<h1>Terrain Planner</h1>
 		<p>Connecting to your game catalogue…</p>
 	</main>

--- a/TerrainPlanner/TerrainPlanner.Client/TerrainPlanner.Client.csproj
+++ b/TerrainPlanner/TerrainPlanner.Client/TerrainPlanner.Client.csproj
@@ -18,4 +18,12 @@
 		<ProjectReference Include="..\TerrainPlanner.Contracts\TerrainPlanner.Contracts.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<!-- Keep the planner's identity mark byte-for-byte aligned with the public FutureMUD website. -->
+		<Content Include="..\..\Futuremud Configuration Tool\Images\FM Logo.png"
+			 Link="wwwroot\images\fm-logo.png"
+			 CopyToOutputDirectory="PreserveNewest"
+			 CopyToPublishDirectory="PreserveNewest" />
+	</ItemGroup>
+
 </Project>

--- a/TerrainPlanner/TerrainPlanner.Client/wwwroot/plannerCanvas.js
+++ b/TerrainPlanner/TerrainPlanner.Client/wwwroot/plannerCanvas.js
@@ -28,17 +28,34 @@ function mapPoint(state, point) {
 	return x >= 0 && x < state.width && y >= 0 && y < state.height ? { x, y } : null;
 }
 
+function hasVisibleContent(cell) {
+	return cell.terrainId !== 0 || (cell.tagIds?.length || 0) > 0;
+}
+
+function resetInputState(state) {
+	state.strokeGeneration++;
+	state.stroke.clear();
+	state.framePending = false;
+	state.painting = false;
+	state.panning = false;
+	state.lastPaintCoordinate = null;
+	state.rectangleStart = null;
+}
+
 function queueStroke(state, coordinate) {
-	if (!coordinate) return;
+	if (!coordinate || state.strokeRevision !== state.mapVersion) return;
 	state.stroke.set(key(coordinate.x, coordinate.y), coordinate);
 	if (state.framePending) return;
 	state.framePending = true;
+	const generation = state.strokeGeneration;
+	const mapVersion = state.strokeRevision;
 	requestAnimationFrame(async () => {
+		if (generation !== state.strokeGeneration || mapVersion !== state.mapVersion) return;
 		state.framePending = false;
 		const coordinates = [...state.stroke.values()];
 		state.stroke.clear();
 		if (coordinates.length) {
-			state.strokePromise = queueDotNet(state, 'HandleCanvasStroke', coordinates);
+			state.strokePromise = queueDotNet(state, 'HandleCanvasStroke', mapVersion, coordinates);
 			await state.strokePromise;
 		}
 	});
@@ -187,6 +204,9 @@ export function initialise(canvas, dotnet) {
 		selected: null,
 		stroke: new Map(),
 		strokePromise: Promise.resolve(),
+		mapVersion: 0,
+		strokeRevision: 0,
+		strokeGeneration: 0,
 		framePending: false,
 		handlers: {}
 	};
@@ -203,13 +223,14 @@ export function initialise(canvas, dotnet) {
 		const coordinate = mapPoint(state, point);
 		if (!coordinate) return;
 		state.selected = coordinate;
-		state.dotnet.invokeMethodAsync('SelectCell', coordinate);
+		queueDotNet(state, 'SelectCell', state.mapVersion, coordinate);
 		if (state.tool === 'rectangle') {
-			state.rectangleStart = coordinate;
+			state.rectangleStart = { coordinate, mapVersion: state.mapVersion };
 		} else {
 			state.painting = true;
 			state.lastPaintCoordinate = coordinate;
-			queueDotNet(state, 'BeginCanvasStroke');
+			state.strokeRevision = state.mapVersion;
+			queueDotNet(state, 'BeginCanvasStroke', state.strokeRevision);
 			queueStroke(state, coordinate);
 		}
 		render(state);
@@ -233,14 +254,18 @@ export function initialise(canvas, dotnet) {
 		const completedPaintStroke = state.painting;
 		if (state.rectangleStart) {
 			const end = mapPoint(state, point);
-			if (end) state.dotnet.invokeMethodAsync('HandleCanvasRectangle', state.rectangleStart, end);
+			if (end && state.rectangleStart.mapVersion === state.mapVersion) {
+				queueDotNet(state, 'HandleCanvasRectangle', state.rectangleStart.mapVersion,
+					state.rectangleStart.coordinate, end);
+			}
 		}
 		state.rectangleStart = null;
 		state.painting = false;
 		state.lastPaintCoordinate = null;
 		if (completedPaintStroke) {
+			const mapVersion = state.strokeRevision;
 			requestAnimationFrame(() => {
-				queueDotNet(state, 'EndCanvasStroke');
+				if (mapVersion === state.mapVersion) queueDotNet(state, 'EndCanvasStroke', mapVersion);
 			});
 		}
 		state.panning = false;
@@ -276,7 +301,7 @@ export function initialise(canvas, dotnet) {
 			if (event.key === 'ArrowDown') next.y--;
 			if (next.x >= 0 && next.x < state.width && next.y >= 0 && next.y < state.height) {
 				state.selected = next;
-				state.dotnet.invokeMethodAsync('SelectCell', next);
+				queueDotNet(state, 'SelectCell', state.mapVersion, next);
 				render(state);
 			}
 		}
@@ -294,6 +319,9 @@ export function initialise(canvas, dotnet) {
 export function setMap(canvas, model) {
 	const state = instances.get(canvas);
 	if (!state) return;
+	if (model.version < state.mapVersion) return;
+	if (model.version !== state.mapVersion) resetInputState(state);
+	state.mapVersion = model.version;
 	state.width = model.width;
 	state.height = model.height;
 	state.cells = new Map(model.cells.map(cell => [key(cell.x, cell.y), cell]));
@@ -302,10 +330,13 @@ export function setMap(canvas, model) {
 	render(state);
 }
 
-export function updateCells(canvas, cells) {
+export function updateCells(canvas, mapVersion, cells) {
 	const state = instances.get(canvas);
-	if (!state) return;
-	for (const cell of cells) state.cells.set(key(cell.x, cell.y), cell);
+	if (!state || mapVersion !== state.mapVersion) return;
+	for (const cell of cells) {
+		if (hasVisibleContent(cell)) state.cells.set(key(cell.x, cell.y), cell);
+		else state.cells.delete(key(cell.x, cell.y));
+	}
 	render(state);
 }
 

--- a/TerrainPlanner/TerrainPlanner.Contracts/MaskSerializer.cs
+++ b/TerrainPlanner/TerrainPlanner.Contracts/MaskSerializer.cs
@@ -20,7 +20,7 @@ public static class MaskSerializer
 		}
 	}
 
-	public static string ExportFeatureMask(PlannerMap map, IReadOnlyDictionary<long, TagCatalogueItem> tags)
+	public static string ExportFeatureMask(PlannerMap map)
 	{
 		return string.Join(',', map.Cells.Select(cell =>
 		{
@@ -29,18 +29,16 @@ public static class MaskSerializer
 				return string.Empty;
 			}
 
-			var names = cell.TagIds.Select(id => tags.TryGetValue(id, out var tag)
-					? ValidateFeatureName(tag.ShortName)
-					: throw new InvalidDataException($"Tag #{id} no longer exists in the live catalogue."))
-				.Concat(cell.UnresolvedFeatures.Select(ValidateFeatureName))
-				.Distinct(StringComparer.OrdinalIgnoreCase)
-				.Order(StringComparer.OrdinalIgnoreCase);
-			return string.Join('|', names);
+			var tagIds = cell.TagIds
+				.Concat(cell.UnresolvedFeatures.Select(ParseFeatureTagId))
+				.Distinct()
+				.Order();
+			return string.Join('|', tagIds);
 		}));
 	}
 
 	public static void ImportFeatureMask(PlannerMap map, string mask,
-		IReadOnlyDictionary<string, TagCatalogueItem> tagsByName)
+		IReadOnlyDictionary<long, TagCatalogueItem> tagsById)
 	{
 		var values = SplitCells(mask);
 		EnsureCellCount(map, values.Length, "feature");
@@ -53,30 +51,30 @@ public static class MaskSerializer
 				continue;
 			}
 
-			foreach (var feature in values[index].Split('|', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+			foreach (var value in values[index].Split('|', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
 			{
-				ValidateFeatureName(feature);
-				if (tagsByName.TryGetValue(feature, out var tag))
+				var tagId = ParseFeatureTagId(value);
+				if (tagsById.ContainsKey(tagId))
 				{
-					cell.AddTag(tag.Id);
+					cell.AddTag(tagId);
 				}
 				else
 				{
-					cell.AddUnresolvedFeature(feature);
+					cell.AddUnresolvedFeature(tagId.ToString(System.Globalization.CultureInfo.InvariantCulture));
 				}
 			}
 		}
 	}
 
-	public static string ValidateFeatureName(string name)
+	public static long ParseFeatureTagId(string value)
 	{
-		if (string.IsNullOrWhiteSpace(name) || name.Contains(',') || name.Contains('|') ||
-			name.Contains('\r') || name.Contains('\n'))
+		if (!long.TryParse(value?.Trim(), System.Globalization.NumberStyles.None,
+			System.Globalization.CultureInfo.InvariantCulture, out var tagId) || tagId <= 0)
 		{
-			throw new InvalidDataException($"Feature name '{name}' cannot be represented in an autobuilder feature mask.");
+			throw new InvalidDataException($"Feature tag ID '{value}' must be a positive integer.");
 		}
 
-		return name;
+		return tagId;
 	}
 
 	private static string[] SplitCells(string mask) =>

--- a/TerrainPlanner/TerrainPlanner.Contracts/TagCatalogueIndex.cs
+++ b/TerrainPlanner/TerrainPlanner.Contracts/TagCatalogueIndex.cs
@@ -2,22 +2,14 @@ namespace TerrainPlanner.Contracts;
 
 public sealed class TagCatalogueIndex
 {
-	private readonly HashSet<string> _ambiguousShortNames;
-
-	private TagCatalogueIndex(
-		IReadOnlyDictionary<long, TagCatalogueItem> byId,
-		IReadOnlyDictionary<string, TagCatalogueItem> byShortName,
-		HashSet<string> ambiguousShortNames)
+	private TagCatalogueIndex(IReadOnlyDictionary<long, TagCatalogueItem> byId)
 	{
 		ById = byId;
-		ByShortName = byShortName;
-		_ambiguousShortNames = ambiguousShortNames;
 	}
 
 	public static TagCatalogueIndex Empty { get; } = Create([]);
 
 	public IReadOnlyDictionary<long, TagCatalogueItem> ById { get; }
-	public IReadOnlyDictionary<string, TagCatalogueItem> ByShortName { get; }
 
 	public static TagCatalogueIndex Create(IEnumerable<TagCatalogueItem> tags)
 	{
@@ -26,40 +18,7 @@ public sealed class TagCatalogueIndex
 		var byId = tags
 			.GroupBy(tag => tag.Id)
 			.ToDictionary(group => group.Key, group => group.First());
-		var ambiguousShortNames = byId.Values
-			.GroupBy(tag => tag.ShortName, StringComparer.OrdinalIgnoreCase)
-			.Where(group => group.Count() > 1)
-			.Select(group => group.Key)
-			.ToHashSet(StringComparer.OrdinalIgnoreCase);
-		var byShortName = byId.Values
-			.Where(tag => FeatureMaskUnavailableReason(tag, ambiguousShortNames) is null)
-			.ToDictionary(tag => tag.ShortName, StringComparer.OrdinalIgnoreCase);
 
-		return new TagCatalogueIndex(byId, byShortName, ambiguousShortNames);
-	}
-
-	public bool IsAvailableForFeatureMask(TagCatalogueItem tag) =>
-		FeatureMaskUnavailableReason(tag) is null;
-
-	public string? FeatureMaskUnavailableReason(TagCatalogueItem tag) =>
-		FeatureMaskUnavailableReason(tag, _ambiguousShortNames);
-
-	private static string? FeatureMaskUnavailableReason(TagCatalogueItem tag,
-		IReadOnlySet<string> ambiguousShortNames)
-	{
-		if (string.IsNullOrWhiteSpace(tag.ShortName))
-		{
-			return "This tag has no short name for an autobuilder feature mask.";
-		}
-
-		if (tag.ShortName.Contains(',') || tag.ShortName.Contains('|') ||
-			tag.ShortName.Contains('\r') || tag.ShortName.Contains('\n'))
-		{
-			return "This tag's short name contains an autobuilder feature-mask delimiter.";
-		}
-
-		return ambiguousShortNames.Contains(tag.ShortName)
-			? $"The short name '{tag.ShortName}' is shared by multiple tags."
-			: null;
+		return new TagCatalogueIndex(byId);
 	}
 }

--- a/TerrainPlanner/TerrainPlanner.Deployment/TerrainPlanner.Deployment.csproj
+++ b/TerrainPlanner/TerrainPlanner.Deployment/TerrainPlanner.Deployment.csproj
@@ -5,7 +5,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<Version>2.0.0</Version>
+		<Version>2.1.0</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/TerrainPlanner/TerrainPlanner.Server/TerrainPlanner.Server.csproj
+++ b/TerrainPlanner/TerrainPlanner.Server/TerrainPlanner.Server.csproj
@@ -4,9 +4,9 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>2.0.7</Version>
-		<AssemblyVersion>2.0.7</AssemblyVersion>
-		<FileVersion>2.0.7</FileVersion>
+		<Version>2.1.0</Version>
+		<AssemblyVersion>2.1.0</AssemblyVersion>
+		<FileVersion>2.1.0</FileVersion>
 		<BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
 		<AssemblyName>TerrainPlanner</AssemblyName>
 		<RootNamespace>TerrainPlanner.Server</RootNamespace>

--- a/TerrainPlanner/TerrainPlanner.Server/wwwroot/app.css
+++ b/TerrainPlanner/TerrainPlanner.Server/wwwroot/app.css
@@ -35,22 +35,13 @@ input, textarea, select {
 input:focus, textarea:focus, button:focus-visible { border-color: var(--cyan); box-shadow: 0 0 0 3px rgba(69, 214, 207, .14); }
 button { border: 0; border-radius: .55rem; color: inherit; }
 .app-shell { min-height: 100vh; }
-.brand-mark {
-	display: grid;
-	place-items: center;
+.brand-logo {
+	display: block;
 	width: 4.2rem;
 	height: 4.2rem;
-	border: 1px solid rgba(69, 214, 207, .5);
-	border-radius: 1.1rem;
-	background: linear-gradient(145deg, #163541, #0b1e2a);
-	box-shadow: 0 18px 50px rgba(0, 0, 0, .35), inset 0 0 30px rgba(69, 214, 207, .08);
-	color: var(--cyan);
-	font-family: Georgia, serif;
-	font-size: 1.45rem;
-	font-weight: 800;
-	letter-spacing: -.08em;
+	object-fit: contain;
 }
-.brand-mark.compact { width: 2.55rem; height: 2.55rem; border-radius: .7rem; font-size: .95rem; }
+.brand-logo.compact { width: 2.55rem; height: 2.55rem; }
 .eyebrow { margin: 0 0 .5rem; color: var(--cyan); font-size: .68rem; font-weight: 800; letter-spacing: .18em; text-transform: uppercase; }
 .muted { color: var(--muted); }
 .message-page { display: grid; place-items: center; align-content: center; min-height: 100vh; padding: 2rem; text-align: center; }

--- a/TerrainPlanner/TerrainPlanner.Tests/MaskSerializerTests.cs
+++ b/TerrainPlanner/TerrainPlanner.Tests/MaskSerializerTests.cs
@@ -13,36 +13,36 @@ public class MaskSerializerTests
 	{
 		var map = new PlannerMap(2, 2);
 		MaskSerializer.ImportTerrainMask(map, "5,5,0,5", new HashSet<long> { 5 });
-		var byName = new Dictionary<string, TagCatalogueItem>(StringComparer.OrdinalIgnoreCase)
+		var byId = new Dictionary<long, TagCatalogueItem>
 		{
-			[Forest.ShortName] = Forest,
-			[Road.ShortName] = Road
+			[Forest.Id] = Forest,
+			[Road.Id] = Road
 		};
 
-		MaskSerializer.ImportFeatureMask(map, "forest|road,,,road", byName);
+		MaskSerializer.ImportFeatureMask(map, "1|2,,,2", byId);
 
-		var byId = byName.Values.ToDictionary(tag => tag.Id);
-		Assert.AreEqual("forest|road,,,road", MaskSerializer.ExportFeatureMask(map, byId));
+		Assert.AreEqual("1|2,,,2", MaskSerializer.ExportFeatureMask(map));
 	}
 
 	[TestMethod]
-	public void UnknownFeaturesArePreservedAndVisibleOnExport()
+	public void UnknownTagIdsArePreservedAndVisibleOnExport()
 	{
 		var map = new PlannerMap(1, 1);
 		map.PaintTerrain([new(0, 0)], 5);
 
-		MaskSerializer.ImportFeatureMask(map, "removed-tag", new Dictionary<string, TagCatalogueItem>());
+		MaskSerializer.ImportFeatureMask(map, "999", new Dictionary<long, TagCatalogueItem>());
 
-		Assert.AreEqual("removed-tag", MaskSerializer.ExportFeatureMask(map, new Dictionary<long, TagCatalogueItem>()));
+		Assert.AreEqual("999", MaskSerializer.ExportFeatureMask(map));
 	}
 
-	[TestMethod]
-	[DataRow("bad,name")]
-	[DataRow("bad|name")]
-	[DataRow("bad\nname")]
-	public void DelimiterNamesAreRejected(string name)
+	[DataTestMethod]
+	[DataRow("forest")]
+	[DataRow("0")]
+	[DataRow("-1")]
+	[DataRow("1.5")]
+	public void NonPositiveOrNonNumericTagIdsAreRejected(string value)
 	{
-		Assert.ThrowsException<InvalidDataException>(() => MaskSerializer.ValidateFeatureName(name));
+		Assert.ThrowsException<InvalidDataException>(() => MaskSerializer.ParseFeatureTagId(value));
 	}
 
 	[TestMethod]
@@ -52,21 +52,20 @@ public class MaskSerializerTests
 		Assert.ThrowsException<InvalidDataException>(() =>
 			MaskSerializer.ImportTerrainMask(map, "1,999", new HashSet<long> { 1 }));
 		Assert.ThrowsException<InvalidDataException>(() =>
-			MaskSerializer.ImportFeatureMask(map, "", new Dictionary<string, TagCatalogueItem>()));
+			MaskSerializer.ImportFeatureMask(map, "", new Dictionary<long, TagCatalogueItem>()));
 	}
 
 	[TestMethod]
-	public void DuplicateTagShortNamesAreVisibleButUnavailableForFeatureMasks()
+	public void DuplicateTagShortNamesRemainIndependentlyRepresentableById()
 	{
 		var firstRoad = new TagCatalogueItem(10, "road", "world / trade / road", null);
 		var secondRoad = new TagCatalogueItem(11, "ROAD", "world / travel / road", null);
 		var index = TagCatalogueIndex.Create([Forest, firstRoad, secondRoad]);
+		var map = new PlannerMap(1, 1);
+		map.PaintTerrain([new(0, 0)], 5);
 
 		Assert.AreEqual(3, index.ById.Count);
-		Assert.IsTrue(index.ByShortName.ContainsKey(Forest.ShortName));
-		Assert.IsFalse(index.ByShortName.ContainsKey(firstRoad.ShortName));
-		Assert.IsFalse(index.IsAvailableForFeatureMask(firstRoad));
-		Assert.AreEqual("The short name 'road' is shared by multiple tags.",
-			index.FeatureMaskUnavailableReason(firstRoad));
+		MaskSerializer.ImportFeatureMask(map, "10|11", index.ById);
+		Assert.AreEqual("10|11", MaskSerializer.ExportFeatureMask(map));
 	}
 }

--- a/TerrainPlanner/TerrainPlanner.Tests/PlannerMapTests.cs
+++ b/TerrainPlanner/TerrainPlanner.Tests/PlannerMapTests.cs
@@ -88,7 +88,7 @@ public class PlannerMapTests
 	}
 
 	[TestMethod]
-	public void ProjectRoundTripPreservesTagsColoursAndUnknownNames()
+	public void ProjectRoundTripPreservesTagIdsColoursAndDisplayNames()
 	{
 		var map = new PlannerMap(1, 1);
 		map.PaintTerrain([new(0, 0)], 5);


### PR DESCRIPTION
## Summary
- Fixes stale canvas input after resize and blank-cell render artifacts in the hosted Terrain Planner.
- Uses the shared FutureMUD logo and exports Feature Rectangle tag masks as exact numeric tag IDs.
- Adds direct tag-ID resolution to the Engine's Feature Rectangle path and documents conversion from legacy name masks.
- Prepares coordinated releases: FutureMUD Engine 2.8.0 and Terrain Planner & Engine API 2.1.0.

## Validation
- `dotnet test TerrainPlanner/TerrainPlanner.Tests/TerrainPlanner.Tests.csproj -c Release --no-restore --no-build -m:1` (34 passed)
- `dotnet test MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj -c Release --no-restore --no-build -m:1` (2,505 passed)
- `dotnet test FutureMUD.Web.Tests/FutureMUD.Web.Tests.csproj -c Release --no-restore -m:1` (54 passed)
- Published representative Engine win-x64 archive and exported a populated 2.8.0 documentation catalogue.
- Packaged Terrain Planner 2.1.0 win-x64 and verified installer, verifier, version file, and shared-logo hash.