### PR TITLE
Announce published releases in Discord

### DIFF
--- a/.github/workflows/publish-products.yml
+++ b/.github/workflows/publish-products.yml
@@ -419,6 +419,7 @@ jobs:
           persist-credentials: false
           sparse-checkout: |
             scripts/Publish-WebsiteRelease.ps1
+            scripts/Send-DiscordReleaseNotification.ps1
             scripts/New-MudClientUpdateManifest.ps1
             scripts/New-TerrainPlannerUpdateManifest.ps1
             MudClient/MudClientDeployment
@@ -473,3 +474,13 @@ jobs:
           $updateSignature = if ($env:PRODUCT -in @('mudclient', 'terrainplanner')) { 'artifacts/update-manifest.sig' } else { '' }
           $updateKeyId = if ($env:PRODUCT -in @('mudclient', 'terrainplanner')) { 'futuremud-mudclient-2026-08' } else { '' }
           ./scripts/Publish-WebsiteRelease.ps1 -BaseUrl https://futuremud.com -Token $env:PUBLISHING_TOKEN -Product $env:PRODUCT -Version $env:VERSION -SourceCommit $env:SOURCE_REVISION -ArtifactDirectory artifacts -DocumentationCatalogue $documentation -UpdateManifest $updateManifest -UpdateManifestSignature $updateSignature -UpdateManifestKeyId $updateKeyId
+      - name: Announce release in Discord
+        if: github.event_name == 'push'
+        continue-on-error: true
+        shell: pwsh
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.FUTUREMUD_RELEASE_DISCORD_WEBHOOK_URL }}
+          PRODUCT: ${{ needs.prepare.outputs.product }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          ./scripts/Send-DiscordReleaseNotification.ps1 -Product $env:PRODUCT -Version $env:VERSION -WebhookUrl $env:DISCORD_WEBHOOK_URL

--- a/Design Documents/Core/FutureMUD_Release_Process.md
+++ b/Design Documents/Core/FutureMUD_Release_Process.md
@@ -49,7 +49,9 @@ git push origin "refs/tags/$tag"
 
 `git ls-remote` should report no existing tag before creation; its non-zero result is expected in that case. Never move, replace, or force-push a release tag. Verify that `git rev-list -n 1` is the exact version commit before pushing.
 
-The tag starts `.github/workflows/publish-products.yml`. It validates the project version, runs the declared tests, builds each runtime, exports Engine documentation when applicable, tests the resumable publishing API against a temporary store, and atomically promotes the release to futuremud.com.
+The tag starts `.github/workflows/publish-products.yml`. It validates the project version, runs the declared tests, builds each runtime, exports Engine documentation when applicable, tests the resumable publishing API against a temporary store, and atomically promotes the release to futuremud.com. After a successful production promotion from a tag push, it posts one announcement to the FutureMUD Discord patch-notes channel with a link to the canonical website patch note. Manual retry runs do not post another announcement.
+
+The Discord webhook is stored as the `FUTUREMUD_RELEASE_DISCORD_WEBHOOK_URL` secret in the protected `production` environment. Never put the webhook URL in the workflow, repository, command output, or Actions logs. If the Discord notification fails, the step reports a warning without changing the result of a release that has already been published.
 
 The manual action in `backfill-products.yml` is restricted to specifically allowlisted historical releases. Do not add new routine releases to that workflow.
 

--- a/Design Documents/Core/Patch_Notes_Authoring_Guide.md
+++ b/Design Documents/Core/Patch_Notes_Authoring_Guide.md
@@ -388,8 +388,8 @@ When assembling patch notes for a release, use this process:
 3. Open a pull request that includes the note and any related website changes. Review the filename, front matter, summary, rendered structure, links, product version, and operational claims.
 4. Coordinate with the product release workflow. Product tags publish binaries and generated documentation; merging a patch note publishes website content. These are separate workflows. Do not say a download is available until the product release has been promoted and verified on `/downloads`.
 5. Merge the patch-note pull request to `master`. Changes below `FutureMUD.Web/**` trigger `.github/workflows/deploy-website.yml`, which restores, tests, publishes the Linux website, atomically activates it on the server, and checks `/health/ready`.
-6. Confirm the workflow succeeded, then verify both `/patch-notes` and `/patch-notes/{slug}` on the public website. Check the displayed title, summary, date, tags, body structure, links, and any referenced download.
-7. Publish the short Discord announcement with a link to the verified website note.
+6. Confirm the workflow succeeded, then verify both `/patch-notes` and `/patch-notes/{slug}` on the public website. Check the displayed title, summary, date, tags, body structure, links, and any referenced download. Product tag releases announce the canonical patch-note URL in Discord after production promotion, so the filename slug must follow the product/version convention used by the release workflow.
+7. Verify the release workflow posted the short Discord announcement with a link to the website note. If the non-blocking notification step warned, correct the webhook configuration before the next release and post the missed announcement manually.
 
 Do not edit patch-note files directly on the production server. Repository Markdown is the source of truth, and the deployment workflow is the supported publishing channel.
 

--- a/scripts/Send-DiscordReleaseNotification.ps1
+++ b/scripts/Send-DiscordReleaseNotification.ps1
@@ -1,0 +1,93 @@
+[CmdletBinding()]
+param(
+	[Parameter(Mandatory)]
+	[ValidateSet('engine', 'seeder', 'discordbot', 'terrainplanner', 'mudclient')]
+	[string]$Product,
+
+	[Parameter(Mandatory)]
+	[ValidatePattern('^\d+\.\d+\.\d+$')]
+	[string]$Version,
+
+	[Parameter(Mandatory)]
+	[string]$WebhookUrl,
+
+	[switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+$productMetadata = @{
+	engine = @{
+		Name = 'FutureMUD Engine'
+		PatchNotesSlug = 'engine'
+	}
+	seeder = @{
+		Name = 'FutureMUD Database Seeder'
+		PatchNotesSlug = 'database-seeder'
+	}
+	discordbot = @{
+		Name = 'FutureMUD Discord Bot'
+		PatchNotesSlug = 'discord-bot'
+	}
+	terrainplanner = @{
+		Name = 'FutureMUD Terrain Planner & Engine API'
+		PatchNotesSlug = 'terrain-planner'
+	}
+	mudclient = @{
+		Name = 'FutureMUD Web MUD Client'
+		PatchNotesSlug = 'mudclient'
+	}
+}
+
+$metadata = $productMetadata[$Product]
+$versionSlug = $Version.Replace('.', '-')
+$patchNotesUrl = "https://futuremud.com/patch-notes/$($metadata.PatchNotesSlug)-$versionSlug"
+$payload = @{
+	content = "**$($metadata.Name) version $Version released.** [Patch notes here]($patchNotesUrl)"
+	allowed_mentions = @{
+		parse = @()
+	}
+} | ConvertTo-Json -Depth 3 -Compress
+
+if ($DryRun) {
+	$payload
+	return
+}
+
+$webhookUri = $null
+if (-not [Uri]::TryCreate($WebhookUrl, [UriKind]::Absolute, [ref]$webhookUri) -or
+	$webhookUri.Scheme -cne 'https' -or
+	$webhookUri.Host -cne 'discord.com' -or
+	$webhookUri.Query -or
+	$webhookUri.Fragment -or
+	$webhookUri.AbsolutePath -cnotmatch '^/api/webhooks/\d+/[A-Za-z0-9._-]+$') {
+	throw 'The configured Discord webhook URL is not a valid discord.com webhook.'
+}
+
+$patchNotesAvailable = $false
+for ($attempt = 1; $attempt -le 12; $attempt++) {
+	try {
+		Invoke-WebRequest -Method Get -Uri $patchNotesUrl -MaximumRedirection 0 | Out-Null
+		$patchNotesAvailable = $true
+		break
+	}
+	catch {
+		if ($attempt -lt 12) {
+			Start-Sleep -Seconds 5
+		}
+	}
+}
+
+if (-not $patchNotesAvailable) {
+	throw "Patch notes were not live at $patchNotesUrl after 12 attempts; the Discord notification was not sent."
+}
+
+try {
+	Invoke-RestMethod -Method Post -Uri $webhookUri -ContentType 'application/json' -Body $payload | Out-Null
+}
+catch {
+	# Do not include the exception because PowerShell may render the secret webhook URL.
+	throw 'Discord rejected the release notification. Check the protected environment secret and webhook configuration.'
+}
+
+Write-Host "Published the $($metadata.Name) $Version announcement with patch notes at $patchNotesUrl."

--- a/scripts/Send-DiscordReleaseNotification.ps1
+++ b/scripts/Send-DiscordReleaseNotification.ps1
@@ -83,7 +83,9 @@ if (-not $patchNotesAvailable) {
 }
 
 try {
-	Invoke-RestMethod -Method Post -Uri $webhookUri -ContentType 'application/json' -Body $payload | Out-Null
+	$confirmedWebhookUri = [UriBuilder]::new($webhookUri)
+	$confirmedWebhookUri.Query = 'wait=true'
+	Invoke-RestMethod -Method Post -Uri $confirmedWebhookUri.Uri -ContentType 'application/json' -Body $payload | Out-Null
 }
 catch {
 	# Do not include the exception because PowerShell may render the secret webhook URL.


### PR DESCRIPTION
## Summary
- announce successful tag-push product releases in the FutureMUD Discord patch-notes channel
- link each validated product/version to its canonical futuremud.com patch note
- keep the protected webhook out of source and prevent duplicate announcements on manual retries
- document the release and patch-note workflow

## Validation
- PowerShell AST parse passed for scripts/Send-DiscordReleaseNotification.ps1
- dry-run payload generation passed for Engine, Database Seeder, Discord Bot, Terrain Planner, and MUD Client
- git diff --check passed
- https://futuremud.com/patch-notes/engine-2-8-0 returned HTTP 200

## Deployment note
Set a newly regenerated webhook as the production environment secret FUTUREMUD_RELEASE_DISCORD_WEBHOOK_URL before the next release. The webhook shared in chat was treated as compromised and was not used.