### PR TITLE
Add NPC skill packages

### DIFF
--- a/DatabaseSeeder Unit Tests/AnimalSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/AnimalSeederTemplateTests.cs
@@ -1642,8 +1642,8 @@ public class AnimalSeederTemplateTests
 		AnimalSeeder.EnsureAnimalNeedsModelConfiguration(context);
 		context.SaveChanges();
 
-        Assert.AreEqual(ShouldSeedResult.MayAlreadyBeInstalled, new AnimalSeeder().ShouldSeedData(context),
-            "Once the expanded animal catalogue is present, the seeder should stop advertising extra stock content.");
+		Assert.AreEqual(ShouldSeedResult.ExtraPackagesAvailable, new AnimalSeeder().ShouldSeedData(context),
+			"An otherwise current animal catalogue should advertise the newly available stock NPC skill packages.");
     }
 
     [TestMethod]

--- a/DatabaseSeeder Unit Tests/NPCSkillPackageSeederTests.cs
+++ b/DatabaseSeeder Unit Tests/NPCSkillPackageSeederTests.cs
@@ -1,0 +1,171 @@
+#nullable enable
+
+using System;
+using System.Linq;
+using DatabaseSeeder.Seeders;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Database;
+using MudSharp.GameItems;
+using MudSharp.Models;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class NPCSkillPackageSeederTests
+{
+	private static FuturemudDatabaseContext BuildContext()
+	{
+		var options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.Options;
+		return new FuturemudDatabaseContext(options);
+	}
+
+	private static TraitDefinition Skill(long id, string name)
+	{
+		return new TraitDefinition
+		{
+			Id = id,
+			Name = name,
+			Alias = name,
+			Type = 0,
+			TraitGroup = "Tests",
+			ChargenBlurb = string.Empty,
+			ValueExpression = string.Empty
+		};
+	}
+
+	[TestMethod]
+	public void UniversalPackage_ResolvesSimpleAndComplexSkillVariants()
+	{
+		using var simple = BuildContext();
+		simple.TraitDefinitions.AddRange(Skill(1, "Perception"), Skill(2, "Athletics"));
+		simple.SaveChanges();
+		NPCSkillPackageSeederHelper.EnsureUniversalPackage(simple);
+		var simplePackage = simple.NpcSkillPackages.Include(x => x.Skills).Single();
+		CollectionAssert.AreEquivalent(new long[] { 1, 2 }, simplePackage.Skills.Select(x => x.TraitDefinitionId).ToArray());
+		Assert.IsTrue(simplePackage.Skills.All(x => x.Chance == 1.0 && x.Mean == 25.0 &&
+			x.StandardDeviation == 5.0 && x.Skewness == 0.0));
+
+		using var complex = BuildContext();
+		complex.TraitDefinitions.AddRange(
+			Skill(1, "Listen"), Skill(2, "Search"), Skill(3, "Scan"),
+			Skill(4, "Climb"), Skill(5, "Balance"), Skill(6, "Run"));
+		complex.SaveChanges();
+		NPCSkillPackageSeederHelper.EnsureUniversalPackage(complex);
+		Assert.AreEqual(6, complex.NpcSkillPackages.Include(x => x.Skills).Single().Skills.Count);
+	}
+
+	[TestMethod]
+	public void CombatPackages_RerunUpdatesStockAndPreservesCustomPackage()
+	{
+		using var context = BuildContext();
+		var brawling = Skill(1, "Brawling");
+		var dodge = Skill(2, "Dodge");
+		context.TraitDefinitions.AddRange(brawling, dodge);
+		var custom = new NpcSkillPackage { Name = "Builder Custom" };
+		custom.Skills.Add(new NpcSkillPackageSkill
+		{
+			TraitDefinition = brawling,
+			Chance = 0.5,
+			Mean = 99.0,
+			StandardDeviation = 1.0,
+			Skewness = 0.25
+		});
+		context.NpcSkillPackages.Add(custom);
+		context.SaveChanges();
+
+		var first = NPCSkillPackageSeederHelper.EnsureCombatPackages(context);
+		var second = NPCSkillPackageSeederHelper.EnsureCombatPackages(context);
+
+		Assert.AreEqual(5, first.PackagesChanged);
+		Assert.AreEqual(0, second.PackagesChanged);
+		Assert.AreEqual(6, context.NpcSkillPackages.Count());
+		var preserved = context.NpcSkillPackages.Include(x => x.Skills).Single(x => x.Name == "Builder Custom");
+		Assert.AreEqual(99.0, preserved.Skills.Single().Mean);
+		Assert.IsTrue(context.NpcSkillPackages
+			.Where(x => x.Name.EndsWith("Beast Attacker"))
+			.All(x => x.Skills.Count == 2));
+	}
+
+	[TestMethod]
+	public void CombatTierMapping_PlacesWargAndDragonAtRequiredThreatLevels()
+	{
+		var warg = new StockNPCSkillPackageRace("Warg", false, true, true, NonHumanCombatTier.SeriousThreat);
+		var dragon = new StockNPCSkillPackageRace("Dragon", true, true, true, NonHumanCombatTier.PartyBoss);
+
+		Assert.AreEqual("Terrifying Beast Attacker", NPCSkillPackageSeederHelper.CombatPackageFor(warg));
+		Assert.AreEqual("Apex Beast Attacker", NPCSkillPackageSeederHelper.CombatPackageFor(dragon));
+		Assert.AreEqual(NonHumanCombatTier.Avatar,
+			NPCSkillPackageSeederHelper.TierForAnimal(SizeCategory.Titanic));
+	}
+
+	[TestMethod]
+	public void StockDetection_AdvertisesDefinitionAndRaceLinkRepairs()
+	{
+		using var context = BuildContext();
+		context.TraitDefinitions.AddRange(
+			Skill(1, "Brawling"),
+			Skill(2, "Dodge"),
+			Skill(3, "Athletics"));
+		var race = new Race
+		{
+			Id = 1,
+			Name = "Test Flyer",
+			Description = string.Empty,
+			AllowedGenders = string.Empty,
+			DiceExpression = string.Empty,
+			CommunicationStrategyType = string.Empty,
+			HandednessOptions = string.Empty,
+			MaximumDragWeightExpression = string.Empty,
+			MaximumLiftWeightExpression = string.Empty,
+			EatCorpseEmoteText = string.Empty,
+			BreathingVolumeExpression = string.Empty,
+			HoldBreathLengthExpression = string.Empty
+		};
+		context.Races.Add(race);
+		context.SaveChanges();
+		var stockRaces = new[]
+		{
+			new StockNPCSkillPackageRace(race.Name, true, false, false, NonHumanCombatTier.SeriousThreat)
+		};
+
+		NPCSkillPackageSeederHelper.EnsureRacePackages(context, stockRaces);
+		Assert.IsFalse(NPCSkillPackageSeederHelper.HasMissingStockRacePackages(context, stockRaces));
+
+		var combatEntry = context.NpcSkillPackages
+			.Include(x => x.Skills)
+			.Single(x => x.Name == "Competent Beast Attacker")
+			.Skills.First();
+		combatEntry.Mean = 999.0;
+		context.SaveChanges();
+		Assert.IsTrue(NPCSkillPackageSeederHelper.HasMissingStockRacePackages(context, stockRaces));
+
+		NPCSkillPackageSeederHelper.EnsureRacePackages(context, stockRaces);
+		Assert.IsFalse(NPCSkillPackageSeederHelper.HasMissingStockRacePackages(context, stockRaces));
+
+		context.Entry(race).Collection(x => x.NpcSkillPackages).Load();
+		race.NpcSkillPackages.Remove(race.NpcSkillPackages.Single(x => x.Name == "Flying Race"));
+		context.SaveChanges();
+		Assert.IsTrue(NPCSkillPackageSeederHelper.HasMissingStockRacePackages(context, stockRaces));
+	}
+
+	[TestMethod]
+	public void UniversalDetection_AdvertisesStaleDefinitionRepair()
+	{
+		using var context = BuildContext();
+		context.TraitDefinitions.AddRange(Skill(1, "Perception"), Skill(2, "Athletics"));
+		context.SaveChanges();
+		NPCSkillPackageSeederHelper.EnsureUniversalPackage(context);
+		Assert.IsFalse(NPCSkillPackageSeederHelper.HasMissingUniversalPackage(context));
+
+		context.NpcSkillPackages
+			.Include(x => x.Skills)
+			.Single(x => x.Name == "Universal Common")
+			.Skills.First().StandardDeviation = 99.0;
+		context.SaveChanges();
+
+		Assert.IsTrue(NPCSkillPackageSeederHelper.HasMissingUniversalPackage(context));
+	}
+}

--- a/DatabaseSeeder/BlankDatabaseSnapshot.manifest.json
+++ b/DatabaseSeeder/BlankDatabaseSnapshot.manifest.json
@@ -1,5 +1,5 @@
 {
   "ProductVersion": "3.2.0.0",
-  "LatestMigrationId": "20260827113842_AddRangedWeaponMinimumFiringPosition",
-  "GeneratedUtc": "2026-08-27T14:37:26.5326787Z"
+  "LatestMigrationId": "20260828014622_AddNPCSkillPackages",
+  "GeneratedUtc": "2026-08-28T02:04:52.8813995Z"
 }

--- a/DatabaseSeeder/BlankDatabaseSnapshot.sql
+++ b/DatabaseSeeder/BlankDatabaseSnapshot.sql
@@ -15194,3 +15194,49 @@ CREATE TABLE IF NOT EXISTS `propertysalesorders` (
 
 -- Dump completed on 2026-08-28 00:37:26
 -- Total time: 0:0:0:1:475 (d:h:m:s:ms)
+
+-- EF-generated idempotent delta for 20260828014622_AddNPCSkillPackages
+START TRANSACTION;
+DROP PROCEDURE IF EXISTS MigrationsScript;
+DELIMITER //
+CREATE PROCEDURE MigrationsScript()
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM `__efmigrationshistory` WHERE `MigrationId` = '20260828014622_AddNPCSkillPackages') THEN
+        CREATE TABLE `npcskillpackages` (
+            `Id` bigint(20) NOT NULL AUTO_INCREMENT,
+            `Name` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+            CONSTRAINT `PRIMARY` PRIMARY KEY (`Id`)
+        ) CHARACTER SET=utf8mb4;
+
+        CREATE TABLE `npcskillpackageskills` (
+            `NpcSkillPackageId` bigint(20) NOT NULL,
+            `TraitDefinitionId` bigint(20) NOT NULL,
+            `Chance` double NOT NULL,
+            `Mean` double NOT NULL,
+            `StandardDeviation` double NOT NULL,
+            `Skewness` double NOT NULL,
+            CONSTRAINT `PRIMARY` PRIMARY KEY (`NpcSkillPackageId`, `TraitDefinitionId`),
+            CONSTRAINT `FK_NPCSkillPackageSkills_Packages` FOREIGN KEY (`NpcSkillPackageId`) REFERENCES `npcskillpackages` (`Id`) ON DELETE CASCADE,
+            CONSTRAINT `FK_NPCSkillPackageSkills_Traits` FOREIGN KEY (`TraitDefinitionId`) REFERENCES `traitdefinitions` (`Id`) ON DELETE RESTRICT
+        ) CHARACTER SET=utf8mb4;
+
+        CREATE TABLE `races_npcskillpackages` (
+            `RaceId` bigint(20) NOT NULL,
+            `NpcSkillPackageId` bigint(20) NOT NULL,
+            CONSTRAINT `PRIMARY` PRIMARY KEY (`RaceId`, `NpcSkillPackageId`),
+            CONSTRAINT `FK_RacesNPCSkillPackages_Packages` FOREIGN KEY (`NpcSkillPackageId`) REFERENCES `npcskillpackages` (`Id`) ON DELETE CASCADE,
+            CONSTRAINT `FK_RacesNPCSkillPackages_Races` FOREIGN KEY (`RaceId`) REFERENCES `races` (`Id`) ON DELETE CASCADE
+        ) CHARACTER SET=utf8mb4;
+
+        CREATE UNIQUE INDEX `UX_NPCSkillPackages_Name` ON `npcskillpackages` (`Name`);
+        CREATE INDEX `FK_NPCSkillPackageSkills_Traits_idx` ON `npcskillpackageskills` (`TraitDefinitionId`);
+        CREATE INDEX `IX_Races_NPCSkillPackages_NpcSkillPackageId` ON `races_npcskillpackages` (`NpcSkillPackageId`);
+
+        INSERT INTO `__efmigrationshistory` (`MigrationId`, `ProductVersion`)
+        VALUES ('20260828014622_AddNPCSkillPackages', '9.0.11');
+    END IF;
+END //
+DELIMITER ;
+CALL MigrationsScript();
+DROP PROCEDURE MigrationsScript;
+COMMIT;

--- a/DatabaseSeeder/Seeders/AnimalSeeder.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.cs
@@ -298,6 +298,8 @@ public partial class AnimalSeeder : IDatabaseSeeder
 
             RefreshExistingAnimalDietSettings();
             CombatAuxiliarySeedResult auxiliaryResult = CombatAuxiliarySeederHelper.EnsureAnimalAuxiliaryLinks(context);
+			NPCSkillPackageSeedResult packageResult = NPCSkillPackageSeederHelper.EnsureRacePackages(context,
+				StockSkillPackageRaces());
             context.Database.CommitTransaction();
             List<string> updates = ["Updated the animal combat balance profile"];
             if (hasMissingCatalogue)
@@ -334,6 +336,11 @@ public partial class AnimalSeeder : IDatabaseSeeder
             {
                 updates.Add($"refreshed animal auxiliary combat links ({auxiliaryResult.RaceLinks} links)");
             }
+
+			if (packageResult.HasChanges)
+			{
+				updates.Add($"refreshed NPC skill packages ({packageResult.PackagesChanged} packages, {packageResult.RaceLinksAdded} race links)");
+			}
 
             return $"{string.Join(", ", updates)}.";
         }
@@ -877,11 +884,13 @@ public partial class AnimalSeeder : IDatabaseSeeder
 		context.SaveChanges();
         SeedAnimalAIStockTemplates();
         CombatAuxiliarySeedResult freshAuxiliaryResult = CombatAuxiliarySeederHelper.EnsureAnimalAuxiliaryLinks(context);
+		NPCSkillPackageSeedResult freshPackageResult = NPCSkillPackageSeederHelper.EnsureRacePackages(context,
+			StockSkillPackageRaces());
 
         context.Database.CommitTransaction();
 
-        return freshAuxiliaryResult.HasChanges
-            ? $"Successfully installed animal prototypes, stock animal AI templates, and {freshAuxiliaryResult.RaceLinks} animal auxiliary combat links."
+        return freshAuxiliaryResult.HasChanges || freshPackageResult.HasChanges
+			? $"Successfully installed animal prototypes, stock animal AI templates, {freshAuxiliaryResult.RaceLinks} animal auxiliary combat links, and {freshPackageResult.RaceLinksAdded} NPC skill package links."
             : "Successfully installed animal prototypes and stock animal AI templates.";
     }
 
@@ -899,13 +908,24 @@ public partial class AnimalSeeder : IDatabaseSeeder
                    HasMissingAnimalCatalogue(context) ||
                    HasMissingAnimalWearProfiles(context) ||
                    HasMissingAnimalAIStockTemplates(context) ||
-                   HasMissingAnimalDietSettings(context)
+                   HasMissingAnimalDietSettings(context) ||
+				   NPCSkillPackageSeederHelper.HasMissingStockRacePackages(context, StockSkillPackageRaces())
                 ? ShouldSeedResult.ExtraPackagesAvailable
                 : ShouldSeedResult.MayAlreadyBeInstalled;
         }
 
         return ShouldSeedResult.ReadyToInstall;
     }
+
+	private static IEnumerable<StockNPCSkillPackageRace> StockSkillPackageRaces()
+	{
+		return RaceTemplates.Values.Select(template => new StockNPCSkillPackageRace(
+			template.Name,
+			NPCSkillPackageSeederHelper.IsFlyingRace(template.Name, template.BodyKey),
+			true,
+			template.CanClimb,
+			NPCSkillPackageSeederHelper.TierForAnimal(template.Size)));
+	}
     private void ResetSeeder()
     {
         _attacks.Clear();

--- a/DatabaseSeeder/Seeders/CombatSeeder.cs
+++ b/DatabaseSeeder/Seeders/CombatSeeder.cs
@@ -195,6 +195,7 @@ You can choose #3Compact#f, #3Sentences#f or #3Sparse#f",
 		EnsureEraDependencyCombatContent(context, effectiveAnswers);
         CombatAuxiliarySeederHelper.EnsureStockAuxiliaryContent(context);
         ManualCombatCommandSeederHelper.EnsureStockManualCombatCommands(context);
+		NPCSkillPackageSeederHelper.EnsureCombatPackages(context);
 
         context.Database.CommitTransaction();
 
@@ -208,6 +209,11 @@ You can choose #3Compact#f, #3Sentences#f or #3Sparse#f",
 			.Where(x => x.HasChanges)
 			.Select(x => $"{x.DisplayName} ({x.Changes})")
 			.ToList();
+		NPCSkillPackageSeedResult packageResult = NPCSkillPackageSeederHelper.EnsureCombatPackages(context);
+		if (packageResult.HasChanges)
+		{
+			updates.Add($"NPC beast skill packages ({packageResult.PackagesChanged})");
+		}
 		context.SaveChanges();
 		return updates.Count > 0
 			? $"Reconciled combat modules: {updates.ListToString()}."
@@ -1906,7 +1912,9 @@ You can choose #3Compact#f, #3Sentences#f or #3Sparse#f",
     {
         if (context.WeaponAttacks.Any())
         {
-            return ShouldSeedResult.MayAlreadyBeInstalled;
+			return NPCSkillPackageSeederHelper.HasMissingCombatPackages(context)
+				? ShouldSeedResult.ExtraPackagesAvailable
+				: ShouldSeedResult.MayAlreadyBeInstalled;
         }
 
         if (!context.Races.Any(x => x.Name == "Human"))

--- a/DatabaseSeeder/Seeders/MythicalAnimalSeeder.cs
+++ b/DatabaseSeeder/Seeders/MythicalAnimalSeeder.cs
@@ -131,9 +131,11 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
         {
             RefreshExistingMythicalCombatBalance();
             CombatAuxiliarySeedResult auxiliaryResult = CombatAuxiliarySeederHelper.EnsureMythicalAuxiliaryLinks(_context);
+			NPCSkillPackageSeedResult packageResult = NPCSkillPackageSeederHelper.EnsureRacePackages(_context,
+				StockSkillPackageRaces());
             _context.Database.CommitTransaction();
-            return auxiliaryResult.HasChanges
-                ? $"Mythical races are already installed and their breathing, mobility, diet, combat balance profiles, and {auxiliaryResult.RaceLinks} auxiliary combat links have been refreshed."
+            return auxiliaryResult.HasChanges || packageResult.HasChanges
+				? $"Mythical races are already installed and their breathing, mobility, diet, combat balance profiles, {auxiliaryResult.RaceLinks} auxiliary combat links, and {packageResult.RaceLinksAdded} NPC skill package links have been refreshed."
                 : "Mythical races are already installed and their breathing, mobility, diet, and combat balance profiles have been refreshed.";
         }
 
@@ -155,6 +157,8 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
         }
 
         CombatAuxiliarySeedResult freshAuxiliaryResult = CombatAuxiliarySeederHelper.EnsureMythicalAuxiliaryLinks(_context);
+		NPCSkillPackageSeedResult freshPackageResult = NPCSkillPackageSeederHelper.EnsureRacePackages(_context,
+			StockSkillPackageRaces());
         _context.SaveChanges();
         _context.Database.CommitTransaction();
         int skippedCount = Templates.Count - templatesToSeed.Count;
@@ -183,6 +187,11 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
             updates.Add($"refreshed mythical auxiliary combat links ({freshAuxiliaryResult.RaceLinks} links)");
         }
 
+		if (freshPackageResult.HasChanges)
+		{
+			updates.Add($"refreshed NPC skill packages ({freshPackageResult.PackagesChanged} packages, {freshPackageResult.RaceLinksAdded} race links)");
+		}
+
         if (templatesToSeed.Count > 0 && skippedCount > 0)
         {
             updates.Add($"skipped {skippedCount} that already existed");
@@ -203,13 +212,24 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
             return HasMissingMythicalDisfigurementTemplates(context) ||
                    HasMythicalSatiationLimitUpdates(context) ||
                    HasMissingMythicalAnimalAIStockTemplates(context) ||
-                   HasMissingMythicalDietSettings(context)
+                   HasMissingMythicalDietSettings(context) ||
+			       NPCSkillPackageSeederHelper.HasMissingStockRacePackages(context, StockSkillPackageRaces())
                 ? ShouldSeedResult.ExtraPackagesAvailable
                 : ShouldSeedResult.MayAlreadyBeInstalled;
         }
 
         return ShouldSeedResult.ReadyToInstall;
     }
+
+	private static IEnumerable<StockNPCSkillPackageRace> StockSkillPackageRaces()
+	{
+		return Templates.Values.Select(template => new StockNPCSkillPackageRace(
+			template.Name,
+			NPCSkillPackageSeederHelper.IsFlyingRace(template.Name, template.BodyKey),
+			template.CanSwim,
+			template.CanClimb,
+			template.CombatBalance.Tier));
+	}
 
 	private static bool HasMythicalSatiationLimitUpdates(FuturemudDatabaseContext context)
 	{

--- a/DatabaseSeeder/Seeders/SkillPackageSeeder.cs
+++ b/DatabaseSeeder/Seeders/SkillPackageSeeder.cs
@@ -533,7 +533,11 @@ Please choose either #6simple#0 or #6complex#0: ", (context, answers) => true,
         IReadOnlyDictionary<string, TraitDefinition> skills = SeedSkills(context, questionAnswers, decorators, generalImprover);
         SeedAdminLanguage(context, questionAnswers, decorators, languageImprover);
         SeedChecks(context, questionAnswers, templates, skills);
-        return string.Empty;
+		NPCSkillPackageSeedResult packageResult =
+			NPCSkillPackageSeederHelper.EnsureUniversalPackage(context, skills);
+        return packageResult.HasChanges
+			? "Installed or refreshed the Universal Common NPC skill package."
+			: string.Empty;
     }
 
     private void SeedChecks(FuturemudDatabaseContext context, IReadOnlyDictionary<string, string> questionAnswers,
@@ -1607,7 +1611,9 @@ Please choose either #6simple#0 or #6complex#0: ", (context, answers) => true,
                  context.TraitDecorators.Any(x => x.Name == marker) ||
                  context.Improvers.Any(x => x.Name == marker))))
         {
-            return ShouldSeedResult.MayAlreadyBeInstalled;
+			return NPCSkillPackageSeederHelper.HasMissingUniversalPackage(context)
+				? ShouldSeedResult.ExtraPackagesAvailable
+				: ShouldSeedResult.MayAlreadyBeInstalled;
         }
 
         return SeederRepeatabilityHelper.ClassifyByPresence(

--- a/DatabaseSeeder/Seeders/SupernaturalSeeder.cs
+++ b/DatabaseSeeder/Seeders/SupernaturalSeeder.cs
@@ -87,10 +87,12 @@ public partial class SupernaturalSeeder : IDatabaseSeeder
 
 		SeedFormMerits(summary);
 		CombatAuxiliarySeedResult auxiliaryResult = CombatAuxiliarySeederHelper.EnsureSupernaturalAuxiliaryLinks(_context);
+		NPCSkillPackageSeedResult packageResult = NPCSkillPackageSeederHelper.EnsureRacePackages(_context,
+			StockSkillPackageRaces());
 
 		_context.SaveChanges();
 		_context.Database.CommitTransaction();
-		return $"{summary.ToMessage(Templates.Count)} Refreshed {auxiliaryResult.RaceLinks} supernatural auxiliary combat links.";
+		return $"{summary.ToMessage(Templates.Count)} Refreshed {auxiliaryResult.RaceLinks} supernatural auxiliary combat links and {packageResult.RaceLinksAdded} NPC skill package links.";
 	}
 
 	public ShouldSeedResult ShouldSeedData(FuturemudDatabaseContext context)
@@ -105,9 +107,20 @@ public partial class SupernaturalSeeder : IDatabaseSeeder
 			return ShouldSeedResult.ReadyToInstall;
 		}
 
-		return HasMissingSupernaturalSupport(context)
+		return HasMissingSupernaturalSupport(context) ||
+		       NPCSkillPackageSeederHelper.HasMissingStockRacePackages(context, StockSkillPackageRaces())
 			? ShouldSeedResult.ExtraPackagesAvailable
 			: ShouldSeedResult.MayAlreadyBeInstalled;
+	}
+
+	private static IEnumerable<StockNPCSkillPackageRace> StockSkillPackageRaces()
+	{
+		return Templates.Values.Select(template => new StockNPCSkillPackageRace(
+			template.Name,
+			NPCSkillPackageSeederHelper.IsFlyingRace(template.Name, template.BodyKey),
+			template.CanSwim,
+			template.CanClimb,
+			template.CombatBalance.Tier));
 	}
 
 	internal static bool HasPrerequisites(FuturemudDatabaseContext context)

--- a/DatabaseSeeder/Seeders/Utilities/NPCSkillPackageSeederHelper.cs
+++ b/DatabaseSeeder/Seeders/Utilities/NPCSkillPackageSeederHelper.cs
@@ -1,0 +1,378 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using MudSharp.Database;
+using MudSharp.Framework;
+using MudSharp.GameItems;
+using MudSharp.Models;
+
+namespace DatabaseSeeder.Seeders;
+
+internal sealed record StockNPCSkillPackageRace(
+	string RaceName,
+	bool CanFly,
+	bool CanSwim,
+	bool CanClimb,
+	NonHumanCombatTier CombatTier);
+
+internal sealed record NPCSkillPackageSeedResult(int PackagesChanged, int RaceLinksAdded)
+{
+	internal bool HasChanges => PackagesChanged > 0 || RaceLinksAdded > 0;
+}
+
+internal static class NPCSkillPackageSeederHelper
+{
+	internal static readonly string[] StockPackageNames =
+	[
+		"Universal Common",
+		"Flying Race",
+		"Swimming Race",
+		"Climbing Race",
+		"Low-Level Beast Attacker",
+		"Competent Beast Attacker",
+		"Dangerous Beast Attacker",
+		"Terrifying Beast Attacker",
+		"Apex Beast Attacker"
+	];
+
+	internal static NPCSkillPackageSeedResult EnsureUniversalPackage(
+		FuturemudDatabaseContext context,
+		IReadOnlyDictionary<string, TraitDefinition>? seededSkills = null)
+	{
+		var utilitySkills = ResolveDistinctSkills(context, seededSkills,
+			["Listening", "Listen", "Perception"],
+			["Searching", "Search", "Perception"],
+			["Spotting", "Spot", "Scan", "Perception"],
+			["Climbing", "Climb", "Athletics"],
+			["Balancing", "Balance", "Athletics"],
+			["Running", "Run", "Athletics"]);
+
+		var changed = UpsertPackage(context, "Universal Common",
+			utilitySkills.Select(x => (x, 1.0, 25.0, 5.0, 0.0)));
+		return new NPCSkillPackageSeedResult(changed ? 1 : 0, 0);
+	}
+
+	internal static NPCSkillPackageSeedResult EnsureCombatPackages(FuturemudDatabaseContext context)
+	{
+		var combatSkills = ResolveDistinctSkills(context, null,
+			["Brawling", "Brawl"],
+			["Dodging", "Dodge"]);
+		if (combatSkills.Count == 0)
+		{
+			return new NPCSkillPackageSeedResult(0, 0);
+		}
+
+		var packages = new (string Name, double Mean)[]
+		{
+			("Low-Level Beast Attacker", 25.0),
+			("Competent Beast Attacker", 45.0),
+			("Dangerous Beast Attacker", 65.0),
+			("Terrifying Beast Attacker", 75.0),
+			("Apex Beast Attacker", 85.0)
+		};
+		var changed = packages.Count(package => UpsertPackage(context, package.Name,
+			combatSkills.Select(x => (x, 1.0, package.Mean, Math.Max(5.0, package.Mean * 0.10), 0.0))));
+		return new NPCSkillPackageSeedResult(changed, 0);
+	}
+
+	internal static NPCSkillPackageSeedResult EnsureRacePackages(
+		FuturemudDatabaseContext context,
+		IEnumerable<StockNPCSkillPackageRace> races)
+	{
+		var packagesChanged = 0;
+		var fly = ResolveDistinctSkills(context, null, ["Flying", "Fly", "Athletics"]);
+		var swim = ResolveDistinctSkills(context, null, ["Swimming", "Swim", "Athletics"]);
+		var climb = ResolveDistinctSkills(context, null, ["Climbing", "Climb", "Athletics"]);
+		packagesChanged += fly.Count > 0 && UpsertPackage(context, "Flying Race",
+			fly.Select(x => (x, 1.0, 35.0, 7.5, 0.0))) ? 1 : 0;
+		packagesChanged += swim.Count > 0 && UpsertPackage(context, "Swimming Race",
+			swim.Select(x => (x, 1.0, 35.0, 7.5, 0.0))) ? 1 : 0;
+		packagesChanged += climb.Count > 0 && UpsertPackage(context, "Climbing Race",
+			climb.Select(x => (x, 1.0, 35.0, 7.5, 0.0))) ? 1 : 0;
+		packagesChanged += EnsureCombatPackages(context).PackagesChanged;
+
+		var packages = context.NpcSkillPackages
+			.Where(x => StockPackageNames.Contains(x.Name))
+			.ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
+		var linksAdded = 0;
+		foreach (var stockRace in races.DistinctBy(x => x.RaceName, StringComparer.OrdinalIgnoreCase))
+		{
+			var race = context.Races.FirstOrDefault(x => x.Name == stockRace.RaceName);
+			if (race is null)
+			{
+				continue;
+			}
+
+			context.Entry(race).Collection(x => x.NpcSkillPackages).Load();
+			var requiredPackages = new List<string>();
+			if (stockRace.CanFly && fly.Count > 0)
+			{
+				requiredPackages.Add("Flying Race");
+			}
+
+			if (stockRace.CanSwim && swim.Count > 0)
+			{
+				requiredPackages.Add("Swimming Race");
+			}
+
+			if (stockRace.CanClimb && climb.Count > 0)
+			{
+				requiredPackages.Add("Climbing Race");
+			}
+
+			requiredPackages.Add(CombatPackageFor(stockRace));
+			foreach (var name in requiredPackages.Distinct(StringComparer.OrdinalIgnoreCase))
+			{
+				if (!packages.TryGetValue(name, out var package) || race.NpcSkillPackages.Any(x => x.Id == package.Id))
+				{
+					continue;
+				}
+
+				race.NpcSkillPackages.Add(package);
+				linksAdded++;
+			}
+		}
+
+		context.SaveChanges();
+		return new NPCSkillPackageSeedResult(packagesChanged, linksAdded);
+	}
+
+	internal static bool HasMissingUniversalPackage(FuturemudDatabaseContext context)
+	{
+		var utilitySkills = ResolveDistinctSkills(context, null,
+			["Listening", "Listen", "Perception"],
+			["Searching", "Search", "Perception"],
+			["Spotting", "Spot", "Scan", "Perception"],
+			["Climbing", "Climb", "Athletics"],
+			["Balancing", "Balance", "Athletics"],
+			["Running", "Run", "Athletics"]);
+		return !PackageMatches(context, "Universal Common", utilitySkills, 1.0, 25.0, 5.0, 0.0);
+	}
+
+	internal static bool HasMissingStockRacePackages(FuturemudDatabaseContext context,
+		IEnumerable<StockNPCSkillPackageRace> races)
+	{
+		var fly = ResolveDistinctSkills(context, null, ["Flying", "Fly", "Athletics"]);
+		var swim = ResolveDistinctSkills(context, null, ["Swimming", "Swim", "Athletics"]);
+		var climb = ResolveDistinctSkills(context, null, ["Climbing", "Climb", "Athletics"]);
+		if (fly.Count > 0 && !PackageMatches(context, "Flying Race", fly, 1.0, 35.0, 7.5, 0.0) ||
+		    swim.Count > 0 && !PackageMatches(context, "Swimming Race", swim, 1.0, 35.0, 7.5, 0.0) ||
+		    climb.Count > 0 && !PackageMatches(context, "Climbing Race", climb, 1.0, 35.0, 7.5, 0.0) ||
+		    HasMissingCombatPackages(context))
+		{
+			return true;
+		}
+
+		var packages = context.NpcSkillPackages
+			.Where(x => StockPackageNames.Contains(x.Name))
+			.ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
+		foreach (var stockRace in races.DistinctBy(x => x.RaceName, StringComparer.OrdinalIgnoreCase))
+		{
+			var race = context.Races
+				.Include(x => x.NpcSkillPackages)
+				.FirstOrDefault(x => x.Name == stockRace.RaceName);
+			if (race is null)
+			{
+				continue;
+			}
+
+			var requiredPackages = new List<string>();
+			if (stockRace.CanFly && fly.Count > 0)
+			{
+				requiredPackages.Add("Flying Race");
+			}
+
+			if (stockRace.CanSwim && swim.Count > 0)
+			{
+				requiredPackages.Add("Swimming Race");
+			}
+
+			if (stockRace.CanClimb && climb.Count > 0)
+			{
+				requiredPackages.Add("Climbing Race");
+			}
+
+			requiredPackages.Add(CombatPackageFor(stockRace));
+			if (requiredPackages
+				.Distinct(StringComparer.OrdinalIgnoreCase)
+				.Any(name => !packages.TryGetValue(name, out var package) ||
+				             race.NpcSkillPackages.All(x => x.Id != package.Id)))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	internal static bool HasMissingCombatPackages(FuturemudDatabaseContext context)
+	{
+		var combatSkills = ResolveDistinctSkills(context, null,
+			["Brawling", "Brawl"],
+			["Dodging", "Dodge"]);
+		if (combatSkills.Count == 0)
+		{
+			return false;
+		}
+
+		return new (string Name, double Mean)[]
+		{
+			("Low-Level Beast Attacker", 25.0),
+			("Competent Beast Attacker", 45.0),
+			("Dangerous Beast Attacker", 65.0),
+			("Terrifying Beast Attacker", 75.0),
+			("Apex Beast Attacker", 85.0)
+		}.Any(package => !PackageMatches(context, package.Name, combatSkills, 1.0, package.Mean,
+			Math.Max(5.0, package.Mean * 0.10), 0.0));
+	}
+
+	internal static string CombatPackageFor(StockNPCSkillPackageRace race)
+	{
+		if (race.RaceName.Equals("Warg", StringComparison.OrdinalIgnoreCase))
+		{
+			return "Terrifying Beast Attacker";
+		}
+
+		return race.CombatTier switch
+		{
+			NonHumanCombatTier.Nuisance or NonHumanCombatTier.MinorThreat => "Low-Level Beast Attacker",
+			NonHumanCombatTier.SeriousThreat => "Competent Beast Attacker",
+			NonHumanCombatTier.EliteThreat => "Dangerous Beast Attacker",
+			NonHumanCombatTier.Monster or NonHumanCombatTier.GreatBeast => "Terrifying Beast Attacker",
+			_ => "Apex Beast Attacker"
+		};
+	}
+
+	internal static bool IsFlyingRace(string raceName, string bodyKey)
+	{
+		return bodyKey.Contains("Avian", StringComparison.OrdinalIgnoreCase) ||
+		       bodyKey.Contains("Winged", StringComparison.OrdinalIgnoreCase) ||
+		       bodyKey.Contains("Dragon", StringComparison.OrdinalIgnoreCase) ||
+		       raceName.In("Pegasus", "Pegacorn", "Griffin", "Hippogriff", "Phoenix", "Cockatrice",
+			       "Manticore", "Wyvern", "Fell Beast", "Garuda", "Giant Eagle", "Dragon",
+			       "Eastern Dragon", "Qilin");
+	}
+
+	internal static NonHumanCombatTier TierForAnimal(SizeCategory size)
+	{
+		return size switch
+		{
+			<= SizeCategory.VerySmall => NonHumanCombatTier.Nuisance,
+			SizeCategory.Small => NonHumanCombatTier.MinorThreat,
+			SizeCategory.Normal => NonHumanCombatTier.SeriousThreat,
+			SizeCategory.Large => NonHumanCombatTier.EliteThreat,
+			SizeCategory.VeryLarge => NonHumanCombatTier.Monster,
+			SizeCategory.Huge => NonHumanCombatTier.GreatBeast,
+			SizeCategory.Enormous or SizeCategory.Gigantic => NonHumanCombatTier.PartyBoss,
+			_ => NonHumanCombatTier.Avatar
+		};
+	}
+
+	private static IReadOnlyList<TraitDefinition> ResolveDistinctSkills(
+		FuturemudDatabaseContext context,
+		IReadOnlyDictionary<string, TraitDefinition>? seededSkills,
+		params string[][] candidates)
+	{
+		var result = new List<TraitDefinition>();
+		foreach (var names in candidates)
+		{
+			var skill = names
+				.Select(name => seededSkills?.FirstOrDefault(x => x.Key.Equals(name,
+					StringComparison.OrdinalIgnoreCase)).Value ??
+					context.TraitDefinitions.AsEnumerable().FirstOrDefault(x =>
+						x.Type == 0 && x.Name.Equals(name, StringComparison.OrdinalIgnoreCase)))
+				.FirstOrDefault(x => x is not null);
+			if (skill is not null && result.All(x => x.Id != skill.Id))
+			{
+				result.Add(skill);
+			}
+		}
+
+		return result;
+	}
+
+	private static bool UpsertPackage(
+		FuturemudDatabaseContext context,
+		string name,
+		IEnumerable<(TraitDefinition Skill, double Chance, double Mean, double Deviation, double Skewness)> entries)
+	{
+		var expected = entries
+			.DistinctBy(x => x.Skill.Id)
+			.ToList();
+		var package = context.NpcSkillPackages
+			.Include(x => x.Skills)
+			.FirstOrDefault(x => x.Name == name);
+		var changed = false;
+		if (package is null)
+		{
+			package = new NpcSkillPackage { Name = name };
+			context.NpcSkillPackages.Add(package);
+			changed = true;
+		}
+
+		var expectedIds = expected.Select(x => x.Skill.Id).ToHashSet();
+		foreach (var stale in package.Skills.Where(x => !expectedIds.Contains(x.TraitDefinitionId)).ToList())
+		{
+			context.NpcSkillPackageSkills.Remove(stale);
+			changed = true;
+		}
+
+		foreach (var entry in expected)
+		{
+			var existing = package.Skills.FirstOrDefault(x => x.TraitDefinitionId == entry.Skill.Id);
+			if (existing is null)
+			{
+				package.Skills.Add(new NpcSkillPackageSkill
+				{
+					TraitDefinition = entry.Skill,
+					Chance = entry.Chance,
+					Mean = entry.Mean,
+					StandardDeviation = entry.Deviation,
+					Skewness = entry.Skewness
+				});
+				changed = true;
+				continue;
+			}
+
+			if (existing.Chance == entry.Chance && existing.Mean == entry.Mean &&
+				existing.StandardDeviation == entry.Deviation && existing.Skewness == entry.Skewness)
+			{
+				continue;
+			}
+
+			existing.Chance = entry.Chance;
+			existing.Mean = entry.Mean;
+			existing.StandardDeviation = entry.Deviation;
+			existing.Skewness = entry.Skewness;
+			changed = true;
+		}
+
+		context.SaveChanges();
+		return changed;
+	}
+
+	private static bool PackageMatches(
+		FuturemudDatabaseContext context,
+		string name,
+		IReadOnlyCollection<TraitDefinition> skills,
+		double chance,
+		double mean,
+		double standardDeviation,
+		double skewness)
+	{
+		var package = context.NpcSkillPackages
+			.Include(x => x.Skills)
+			.FirstOrDefault(x => x.Name == name);
+		return package is not null &&
+		       package.Skills.Count == skills.Count &&
+		       skills.All(skill => package.Skills.Any(entry =>
+			       entry.TraitDefinitionId == skill.Id &&
+			       entry.Chance == chance &&
+			       entry.Mean == mean &&
+			       entry.StandardDeviation == standardDeviation &&
+			       entry.Skewness == skewness));
+	}
+}

--- a/Design Documents/Characters/NPC_Skill_Packages.md
+++ b/Design Documents/Characters/NPC_Skill_Packages.md
@@ -1,0 +1,91 @@
+# NPC Skill Packages
+
+## Purpose
+
+NPC skill packages are persistent, non-revisioned builder items that collect the routine skill distributions needed by related NPCs. Applying a package is a one-time copy operation. The NPC template or character does not retain package provenance, and later package edits do not update anything to which the package was previously applied.
+
+Each entry identifies one skill trait and stores:
+
+- a chance from 0% to 100%;
+- an arithmetic mean greater than or equal to zero;
+- a standard deviation greater than or equal to zero; and
+- skewness from -0.99 to 0.99.
+
+The skew-normal sampler normalises its raw distribution so that the configured mean and standard deviation remain the distribution's actual mean and standard deviation. Zero skewness is an ordinary normal distribution.
+
+## Package Authoring
+
+The `npcskillpackage` command uses the generic editable-item workflow:
+
+```
+npcskillpackage list
+npcskillpackage show <package>
+npcskillpackage edit <package>
+npcskillpackage new <name>
+npcskillpackage clone <package> <new name>
+npcskillpackage delete [<package>]
+npcskillpackage set name <name>
+npcskillpackage set skill <skill> <chance%> <mean> <standard deviation> [<skewness>]
+npcskillpackage set skill <skill> 0%
+```
+
+Package names are globally unique without regard to case and cannot be blank or entirely numeric, because numeric builder input is reserved for IDs. A zero chance removes the skill entry. Omitting skewness uses zero. The package display includes chance, mean, standard deviation, skewness, and weighted expected value (`chance x mean`).
+
+Deletion requires confirmation through the standard `ACCEPT` workflow. Once confirmed, it cascades to the package's skill rows and race links. Trait definitions remain protected by a restrictive foreign key while referenced by a package.
+
+## NPC Template Application
+
+Use `npc set skillpackage <package>` while editing either kind of NPC template.
+
+Simple templates independently roll each entry's chance. Successful entries sample a value, clamp a negative result to zero, and add or raise the template's stored skill. An application never lowers a stored skill. The command reports additions, raises, skips, and failed chance rolls.
+
+Variable templates copy the package distribution rather than resolving it. If the template already contains the skill, replacement occurs only when the package's weighted expected value is strictly greater:
+
+```
+weighted expected value = chance x arithmetic mean
+```
+
+An equal expected value preserves the existing entry. A replacement copies chance, mean, standard deviation, and skewness together. Variable-template XML writes the `Skewness` attribute; older XML without that attribute loads with zero skewness.
+
+The package application changes a template only when at least one stored skill changes. Applying overlapping packages is therefore deterministic for variable templates and raise-only for simple templates, apart from the simple template's chance and value rolls.
+
+Language skills are permitted, but package application does not invent an accent. Existing NPC-template submission validation still requires the builder to configure any required accent.
+
+## Race Defaults
+
+Use `race set skillpackage <package>` to toggle a direct default on the race. Race defaults inherit from parent to child. Cloning a race copies only that race's direct selections; inherited selections continue to come from its parent.
+
+Whenever the NPC builder assigns or changes a template's race, all inherited and direct race packages are applied. This is additive. Changing the race does not remove skills supplied by the earlier race, repeated assignment follows the ordinary no-lower or weighted-replacement rules, and no package provenance is recorded.
+
+## FutureProg
+
+`NPCSkillPackage` is a FutureProg type with `id`, `name`, and `skills` properties. Packages can be resolved with numeric or text lookup overloads:
+
+```
+npcskillpackage(123)
+npcskillpackage("Universal Common")
+```
+
+Use `applyskillpackage(character, package)` to roll a package for a live character. The function adds missing skills, raises existing skills only when the sampled result is higher, and returns the number of skills added or raised. A null package returns zero.
+
+## Seeder Ownership
+
+The existing `Skill Package` seeder owns `Universal Common` and resolves the installed simple, complex, or RPI utility-skill equivalents. The Combat seeder owns the five beast-attacker definitions. Animal, Mythical Animal, and Supernatural seeders own capability definitions and additive links from their stock races.
+
+Stock definitions are upserted by their reserved names. Seeder reruns repair their entries and add missing required race links. They do not delete custom packages or unrelated race links.
+
+The stock catalogue is:
+
+- `Universal Common`: utility traits at 100%, mean 25, deviation 5, skew zero;
+- `Flying Race`, `Swimming Race`, and `Climbing Race`: the installed capability trait at 100%, mean 35, deviation 7.5, skew zero;
+- `Low-Level Beast Attacker`: mean 25;
+- `Competent Beast Attacker`: mean 45;
+- `Dangerous Beast Attacker`: mean 65;
+- `Terrifying Beast Attacker`: mean 75; and
+- `Apex Beast Attacker`: mean 85.
+
+Beast packages contain the installed brawling/natural-attack and dodge/defence traits at 100% chance and zero skew. Their deviation is the greater of 5 or 10% of the mean. Non-human combat-balance tiers select the appropriate package; explicit high-threat exceptions such as wargs and tier metadata for dragons retain the intended 75/85 placement.
+
+## Deliberate V1 Limitations
+
+Packages contain skill traits only. They do not contain attributes, knowledges, merits, languages' required accents, or other NPC data. There is no application history, removal workflow, rollback, live link, or retroactive reconciliation. Builders must reapply a changed package manually when they want its new definition copied elsewhere.

--- a/Design Documents/README.md
+++ b/Design Documents/README.md
@@ -13,6 +13,7 @@ This folder is organised by subsystem so implementation notes, builder workflows
 - [OpenAI Integration](./AI/OpenAI_Integration.md)
 - [Event System for AI and Hooks](./AI/Event_System_for_AI_and_Hooks.md)
 - [NPC AI and Group AI Runtime](./AI/NPC_AI_and_Group_AI_Runtime.md)
+- [NPC Skill Packages](./Characters/NPC_Skill_Packages.md)
 
 ## Building
 - [Autobuilder Builder How-To](./Building/Autobuilder_Builder_How_To.md)

--- a/FutureMUDLibrary Unit Tests/NPCSkillPackageProgTypeTests.cs
+++ b/FutureMUDLibrary Unit Tests/NPCSkillPackageProgTypeTests.cs
@@ -1,0 +1,26 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.FutureProg;
+
+namespace FutureMUDLibrary_Unit_Tests.FutureProg;
+
+[TestClass]
+public class NPCSkillPackageProgTypeTests
+{
+	[TestMethod]
+	public void NPCSkillPackageType_ParsesAndRoundTripsStorage()
+	{
+		Assert.IsTrue(ProgVariableTypeRegistry.TryParse("npcskillpackage", out var packageType));
+		Assert.AreEqual(ProgVariableTypes.NPCSkillPackage, packageType);
+		Assert.IsTrue(ProgVariableTypeRegistry.TryParse(packageType.ToStorageString(), out var roundTripped));
+		Assert.AreEqual(ProgVariableTypes.NPCSkillPackage, roundTripped);
+	}
+
+	[TestMethod]
+	public void NPCSkillPackageType_IsAvailableInCollections()
+	{
+		Assert.IsTrue(ProgVariableTypes.CollectionItem.HasFlag(ProgVariableTypes.NPCSkillPackage));
+		Assert.AreEqual(ProgTypeKind.NPCSkillPackage, ProgVariableTypes.NPCSkillPackage.ExactKind);
+	}
+}

--- a/FutureMUDLibrary Unit Tests/RandomSkewNormalTests.cs
+++ b/FutureMUDLibrary Unit Tests/RandomSkewNormalTests.cs
@@ -1,0 +1,26 @@
+#nullable enable
+
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Framework;
+
+namespace FutureMUDLibrary_Unit_Tests.Framework;
+
+[TestClass]
+public class RandomSkewNormalTests
+{
+	[TestMethod]
+	public void RandomSkewNormal_PreservesConfiguredMeanAndDeviation()
+	{
+		const double expectedMean = 42.0;
+		const double expectedDeviation = 7.0;
+		var samples = Enumerable.Range(0, 100_000)
+			.Select(_ => RandomUtilities.RandomSkewNormal(expectedMean, expectedDeviation, 0.8))
+			.ToArray();
+		var actualMean = samples.Average();
+		var actualDeviation = System.Math.Sqrt(samples.Average(x => System.Math.Pow(x - actualMean, 2.0)));
+
+		Assert.AreEqual(expectedMean, actualMean, 0.15);
+		Assert.AreEqual(expectedDeviation, actualDeviation, 0.15);
+	}
+}

--- a/FutureMUDLibrary/Character/Heritage/IRace.cs
+++ b/FutureMUDLibrary/Character/Heritage/IRace.cs
@@ -2,6 +2,7 @@
 using MudSharp.Body.Needs;
 using MudSharp.Body.Position;
 using MudSharp.Body.Traits;
+using MudSharp.NPC.Templates;
 using MudSharp.Body.Traits.Subtypes;
 using MudSharp.CharacterCreation;
 using MudSharp.CharacterCreation.Resources;
@@ -16,7 +17,6 @@ using MudSharp.FutureProg;
 using MudSharp.GameItems;
 using MudSharp.Health;
 using MudSharp.Health.Breathing;
-using MudSharp.NPC.Templates;
 using MudSharp.Strategies.BodyStratagies;
 using MudSharp.Work.Butchering;
 using System;
@@ -117,6 +117,11 @@ namespace MudSharp.Character.Heritage
         double SweatRateInLitresPerMinute { get; }
 
         IEnumerable<ITraitDefinition> HealthTraits { get; }
+
+		IEnumerable<INPCSkillPackage> DirectDefaultSkillPackages { get; }
+		IEnumerable<INPCSkillPackage> DefaultSkillPackages { get; }
+		void AddDefaultSkillPackage(INPCSkillPackage package);
+		void RemoveDefaultSkillPackage(INPCSkillPackage package);
 
         IEnumerable<IFluid> BreathableFluids { get; }
 

--- a/FutureMUDLibrary/Framework/IFuturemud.cs
+++ b/FutureMUDLibrary/Framework/IFuturemud.cs
@@ -198,6 +198,7 @@ namespace MudSharp.Framework
         IUneditableAll<IHealthStrategy> HealthStrategies { get; }
         IUneditableAll<IHearingProfile> HearingProfiles { get; }
         IUneditableAll<IHeightWeightModel> HeightWeightModels { get; }
+		IUneditableAll<INPCSkillPackage> NpcSkillPackages { get; }
         IUneditableAll<IHelpfile> Helpfiles { get; }
         IUneditableAll<IHook> Hooks { get; }
         IUneditableAll<IArtificialIntelligence> AIs { get; }
@@ -429,6 +430,7 @@ namespace MudSharp.Framework
         void Add(IChargenResource resource);
         void Add(IShieldType shield);
         void Add(IHeightWeightModel model);
+		void Add(INPCSkillPackage package);
         void Add(IHearingProfile profile);
         void Add(ITrack track);
         void Add(IMoveSpeed speed);
@@ -615,6 +617,7 @@ namespace MudSharp.Framework
         void Destroy(IAIStorytellerReferenceDocument item);
         void Destroy(IShopper shopper);
         void Destroy(IHeightWeightModel model);
+		void Destroy(INPCSkillPackage package);
         void Destroy(IHearingProfile profile);
         void Destroy(ITrack track);
         void Destroy(ICurrency currency);

--- a/FutureMUDLibrary/Framework/IFuturemudLoader.cs
+++ b/FutureMUDLibrary/Framework/IFuturemudLoader.cs
@@ -26,6 +26,7 @@ namespace MudSharp.Framework
         void LoadAIs();
         void LoadGroupAIs();
         void LoadNPCTemplates();
+		void LoadNPCSkillPackages();
         void LoadChargenResources();
         void LoadHeightWeightModels();
         void LoadHearingProfiles();

--- a/FutureMUDLibrary/Framework/RandomUtilities.cs
+++ b/FutureMUDLibrary/Framework/RandomUtilities.cs
@@ -156,6 +156,24 @@ namespace MudSharp.Framework
             return mean + stdev * x0;
         }
 
+		/// <summary>
+		/// Generates a skew-normal value while preserving the supplied arithmetic mean and standard deviation.
+		/// </summary>
+		public static double RandomSkewNormal(double mean, double stdev, double skewness)
+		{
+			if (Math.Abs(skewness) < 1e-9)
+			{
+				return RandomNormal(mean, stdev);
+			}
+
+			double alpha = SolveForAlpha(skewness);
+			double delta = alpha / Math.Sqrt(1.0 + alpha * alpha);
+			double rawMean = delta * Math.Sqrt(2.0 / Math.PI);
+			double rawStandardDeviation = Math.Sqrt(1.0 - 2.0 * delta * delta / Math.PI);
+			double standardised = (NextSkewNormalAlpha(alpha) - rawMean) / rawStandardDeviation;
+			return mean + stdev * standardised;
+		}
+
         /// <summary>
         /// A wrapper for RandomNormal that assumes the mean is the mid-point of the supplied range and the the standard deviation is 1/8 of the difference
         /// </summary>

--- a/FutureMUDLibrary/FutureProg/ProgTypeKind.cs
+++ b/FutureMUDLibrary/FutureProg/ProgTypeKind.cs
@@ -70,5 +70,6 @@ public enum ProgTypeKind
 	VehicleRoute,
 	VehicleService,
 	VehicleJourney,
-	Trap
+	Trap,
+	NPCSkillPackage
 }

--- a/FutureMUDLibrary/FutureProg/ProgVariableTypeRegistry.cs
+++ b/FutureMUDLibrary/FutureProg/ProgVariableTypeRegistry.cs
@@ -105,6 +105,7 @@ public static class ProgVariableTypeRegistry
 		RegisterExact(ProgTypeKind.VehicleService, ProgVariableTypes.VehicleService, "VehicleService", "vehicleservice", "service");
 		RegisterExact(ProgTypeKind.VehicleJourney, ProgVariableTypes.VehicleJourney, "VehicleJourney", "vehiclejourney", "journey");
 		RegisterExact(ProgTypeKind.Trap, ProgVariableTypes.Trap, "Trap", "trap");
+		RegisterExact(ProgTypeKind.NPCSkillPackage, ProgVariableTypes.NPCSkillPackage, "NPCSkillPackage", "npcskillpackage", "skillpackage");
 
         RegisterNamed(ProgVariableTypes.CollectionItem, "CollectionItem", false, "collectionitem");
         RegisterNamed(ProgVariableTypes.Perceivable, "Perceivable", false, "perceivable");

--- a/FutureMUDLibrary/FutureProg/ProgVariableTypes.cs
+++ b/FutureMUDLibrary/FutureProg/ProgVariableTypes.cs
@@ -91,6 +91,7 @@ public readonly struct ProgVariableTypes : IEquatable<ProgVariableTypes>
 	public static readonly ProgVariableTypes VehicleService = FromLegacyBitIndex(66);
 	public static readonly ProgVariableTypes VehicleJourney = FromLegacyBitIndex(67);
 	public static readonly ProgVariableTypes Trap = FromLegacyBitIndex(68);
+	public static readonly ProgVariableTypes NPCSkillPackage = FromLegacyBitIndex(69);
 
     public static readonly ProgVariableTypes CollectionItem =
         Number | Boolean | Gender | Text | DateTime | TimeSpan | Character | Item | Chargen | Location | Zone |
@@ -99,7 +100,7 @@ public readonly struct ProgVariableTypes : IEquatable<ProgVariableTypes>
 		WeatherEvent | Shop | Merchandise | Outfit | OutfitItem | OverlayPackage | Terrain | Project | Solid |
 		Liquid | Gas | MagicSchool | MagicCapability | MagicSpell | Bank | BankAccount | BankAccountType |
 		LegalAuthority | Law | Crime | Market | MarketCategory | LiquidMixture | Script | Writing | Area |
-		LegalClass | AgricultureField | VehicleRoute | VehicleService | VehicleJourney | Trap;
+		LegalClass | AgricultureField | VehicleRoute | VehicleService | VehicleJourney | Trap | NPCSkillPackage;
 
     public static readonly ProgVariableTypes Perceivable = Item | Character | Location | Zone | Shard;
     public static readonly ProgVariableTypes Perceiver = Item | Character;

--- a/FutureMUDLibrary/NPC/Templates/INPCSkillPackage.cs
+++ b/FutureMUDLibrary/NPC/Templates/INPCSkillPackage.cs
@@ -1,0 +1,35 @@
+#nullable enable
+
+using System.Collections.Generic;
+using MudSharp.Body.Traits;
+using MudSharp.Framework.Revision;
+using MudSharp.FutureProg;
+
+namespace MudSharp.NPC.Templates;
+
+public sealed record NPCSkillPackageEntry(
+	ITraitDefinition Skill,
+	double Chance,
+	double Mean,
+	double StandardDeviation,
+	double Skewness)
+{
+	public double WeightedExpectedValue => Chance * Mean;
+}
+
+public sealed record NPCSkillPackageApplicationResult(
+	int Added,
+	int Raised,
+	int Replaced,
+	int Skipped,
+	int FailedChance)
+{
+	public int Changed => Added + Raised + Replaced;
+	public static NPCSkillPackageApplicationResult Empty { get; } = new(0, 0, 0, 0, 0);
+}
+
+public interface INPCSkillPackage : IEditableItem, IProgVariable
+{
+	IReadOnlyCollection<NPCSkillPackageEntry> Skills { get; }
+	INPCSkillPackage Clone(string name);
+}

--- a/FutureMUDLibrary/NPC/Templates/INPCTemplate.cs
+++ b/FutureMUDLibrary/NPC/Templates/INPCTemplate.cs
@@ -26,6 +26,7 @@ namespace MudSharp.NPC.Templates
         ICharacter CreateNewCharacter(SpatialLocation location);
         IEnumerable<string> ApplyTemplateLoadAdditions(ICharacter character, bool logWarnings = true);
         INPCTemplate Clone(ICharacter builder);
+		NPCSkillPackageApplicationResult ApplySkillPackage(INPCSkillPackage package);
         string ReferenceDescription(IPerceiver voyeur);
     }
 }

--- a/MudSharpCore Unit Tests/NPCSkillPackageApplicationTests.cs
+++ b/MudSharpCore Unit Tests/NPCSkillPackageApplicationTests.cs
@@ -1,0 +1,258 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Body.Traits;
+using MudSharp.Character.Heritage;
+using MudSharp.Commands.Helpers;
+using MudSharp.Commands.Modules;
+using MudSharp.Effects.Concrete;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.FutureProg.Functions;
+using MudSharp.FutureProg.Variables;
+using MudSharp.NPC.Templates;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class NPCSkillPackageApplicationTests
+{
+	[TestMethod]
+	public void GenericBuilderHelper_RegistersCompleteNPCSkillPackageWorkflow()
+	{
+		var helper = EditableItemHelper.NPCSkillPackageHelper;
+		Assert.AreEqual("npcskillpackage", helper.CommandName);
+		Assert.AreEqual(typeof(INPCSkillPackage), helper.CastToType);
+		Assert.IsNotNull(helper.EditableNewAction);
+		Assert.IsNotNull(helper.EditableCloneAction);
+		Assert.IsNotNull(helper.EditableDeleteAction);
+		StringAssert.Contains(helper.DefaultCommandHelp, "set skill");
+	}
+
+	[TestMethod]
+	public void PackageNames_BlankAndNumericAreRejectedForAllBuilderCreationPaths()
+	{
+		Assert.IsFalse(NPCSkillPackage.TryNormaliseName("   ", out _, out _));
+		Assert.IsFalse(NPCSkillPackage.TryNormaliseName("12345", out _, out _));
+		Assert.IsTrue(NPCSkillPackage.TryNormaliseName("universal common", out var name, out _));
+		Assert.AreEqual("Universal Common", name);
+	}
+
+	[TestMethod]
+	public void GenericDelete_QueuesConfirmationWithoutImmediatelyDeleting()
+	{
+		var standardPhrasingField = typeof(Accept)
+			.GetField("_standardAcceptPhrasing", BindingFlags.Static | BindingFlags.NonPublic)!;
+		var originalPhrasing = standardPhrasingField.GetValue(null);
+		try
+		{
+			standardPhrasingField.SetValue(null, "Type ACCEPT to confirm.");
+			var package = new Mock<INPCSkillPackage>();
+			package.SetupGet(x => x.Id).Returns(42L);
+			package.SetupGet(x => x.Name).Returns("Delete Me");
+			var packages = new All<INPCSkillPackage>();
+			packages.Add(package.Object);
+			var gameworld = new Mock<IFuturemud>();
+			gameworld.SetupGet(x => x.NpcSkillPackages).Returns(packages);
+			var actor = new Mock<MudSharp.Character.ICharacter>();
+			actor.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+			actor.SetupGet(x => x.OutputHandler)
+				.Returns(new Mock<MudSharp.PerceptionEngine.IOutputHandler>().Object);
+
+			BaseBuilderModule.GenericDelete(actor.Object, new StringStack("Delete Me"),
+				EditableItemHelper.NPCSkillPackageHelper);
+
+			actor.Verify(x => x.AddEffect(It.IsAny<Accept>(), TimeSpan.FromSeconds(120)), Times.Once);
+			gameworld.Verify(x => x.Destroy(package.Object), Times.Never);
+			Assert.AreSame(package.Object, packages.Get(42L));
+		}
+		finally
+		{
+			standardPhrasingField.SetValue(null, originalPhrasing);
+		}
+	}
+
+	[TestMethod]
+	public void RaceDefaults_InheritParentPackagesWithoutDuplicatingDirectSelections()
+	{
+		var parentPackage = Package();
+		var directPackage = Package();
+		var packages = Race.ResolveDefaultSkillPackages(
+			[parentPackage],
+			[parentPackage, directPackage]).ToList();
+
+		CollectionAssert.AreEquivalent(new[] { parentPackage, directPackage }, packages);
+	}
+
+	private static ITraitDefinition Trait(string name)
+	{
+		var trait = new Mock<ITraitDefinition>();
+		trait.SetupGet(x => x.Name).Returns(name);
+		return trait.Object;
+	}
+
+	private static INPCSkillPackage Package(params NPCSkillPackageEntry[] entries)
+	{
+		var package = new Mock<INPCSkillPackage>();
+		package.SetupGet(x => x.Skills).Returns(entries);
+		return package.Object;
+	}
+
+	[TestMethod]
+	public void SimpleApplication_IsChanceAwareClampsAndNeverLowers()
+	{
+		var lower = Trait("Lower");
+		var raise = Trait("Raise");
+		var fail = Trait("Fail");
+		var negative = Trait("Negative");
+		var add = Trait("Add");
+		var package = Package(
+			new NPCSkillPackageEntry(lower, 1.0, 50.0, 0.0, 0.0),
+			new NPCSkillPackageEntry(raise, 1.0, 40.0, 0.0, 0.0),
+			new NPCSkillPackageEntry(fail, 0.25, 30.0, 0.0, 0.0),
+			new NPCSkillPackageEntry(negative, 1.0, 10.0, 0.0, -0.5),
+			new NPCSkillPackageEntry(add, 1.0, 30.0, 0.0, 0.5));
+		var skills = new List<(ITraitDefinition Skill, double Value)> { (lower, 60.0), (raise, 20.0) };
+		var chanceRolls = new Queue<double>([0.0, 0.0, 0.75, 0.0, 0.0]);
+		var values = new Dictionary<ITraitDefinition, double>
+		{
+			[lower] = 50.0,
+			[raise] = 40.0,
+			[negative] = -10.0,
+			[add] = 30.0
+		};
+
+		var result = SimpleNPCTemplate.ApplySkillPackageToValues(skills, package,
+			() => chanceRolls.Dequeue(), entry => values[entry.Skill]);
+
+		Assert.AreEqual(1, result.Added);
+		Assert.AreEqual(1, result.Raised);
+		Assert.AreEqual(2, result.Skipped);
+		Assert.AreEqual(1, result.FailedChance);
+		Assert.AreEqual(60.0, skills.Single(x => x.Skill == lower).Value);
+		Assert.AreEqual(40.0, skills.Single(x => x.Skill == raise).Value);
+		Assert.AreEqual(30.0, skills.Single(x => x.Skill == add).Value);
+		Assert.IsFalse(skills.Any(x => x.Skill == negative));
+	}
+
+	[TestMethod]
+	public void VariableApplication_UsesStrictWeightedExpectedValueAndCopiesWholeDistribution()
+	{
+		var equal = Trait("Equal");
+		var upgrade = Trait("Upgrade");
+		var add = Trait("Add");
+		var templates = new List<VariableSkillTemplate>
+		{
+			new() { Trait = equal, Chance = 0.5, SkillMean = 50.0, SkillStddev = 4.0, SkillSkewness = -0.2 },
+			new() { Trait = upgrade, Chance = 0.5, SkillMean = 20.0, SkillStddev = 2.0, SkillSkewness = 0.0 }
+		};
+		var package = Package(
+			new NPCSkillPackageEntry(equal, 0.25, 100.0, 9.0, 0.7),
+			new NPCSkillPackageEntry(upgrade, 0.25, 50.0, 7.0, 0.6),
+			new NPCSkillPackageEntry(add, 0.5, 30.0, 5.0, -0.4));
+
+		var result = VariableNPCTemplate.ApplySkillPackageToTemplates(templates, package);
+
+		Assert.AreEqual(1, result.Added);
+		Assert.AreEqual(1, result.Raised);
+		Assert.AreEqual(1, result.Skipped);
+		Assert.AreEqual(-0.2, templates.Single(x => x.Trait == equal).SkillSkewness,
+			"Equal weighted values must preserve the existing distribution.");
+		var upgraded = templates.Single(x => x.Trait == upgrade);
+		Assert.AreEqual(0.25, upgraded.Chance);
+		Assert.AreEqual(50.0, upgraded.SkillMean);
+		Assert.AreEqual(7.0, upgraded.SkillStddev);
+		Assert.AreEqual(0.6, upgraded.SkillSkewness);
+	}
+
+	[TestMethod]
+	public void VariableSkillXml_OldFormatDefaultsSkewAndNewFormatRoundTripsIt()
+	{
+		var trait = Trait("Listen");
+		var legacy = XElement.Parse("<Skill Chance=\"0.5\" Mean=\"30\" Stddev=\"4\" Trait=\"17\" />");
+		var loadedLegacy = VariableSkillTemplate.LoadFromXml(legacy, id =>
+		{
+			Assert.AreEqual(17L, id);
+			return trait;
+		});
+		Assert.AreEqual(0.0, loadedLegacy.SkillSkewness);
+
+		var current = new VariableSkillTemplate
+		{
+			Trait = trait,
+			Chance = 0.75,
+			SkillMean = 40.0,
+			SkillStddev = 6.0,
+			SkillSkewness = -0.65
+		};
+		var roundTripped = VariableSkillTemplate.LoadFromXml(current.SaveToXml(), _ => trait);
+		Assert.AreEqual(-0.65, roundTripped.SkillSkewness);
+		Assert.AreEqual(0.75, roundTripped.Chance);
+		Assert.AreEqual(40.0, roundTripped.SkillMean);
+		Assert.AreEqual(6.0, roundTripped.SkillStddev);
+	}
+
+	[TestMethod]
+	public void FutureProgSurface_RegistersTypedLookupApplyAndDotProperties()
+	{
+		FutureProgTestBootstrap.EnsureInitialised();
+		var functions = FutureProg.GetFunctionCompilerInformations().ToList();
+		Assert.IsTrue(functions.Any(x => x.FunctionName == "npcskillpackage" &&
+			x.Parameters.SequenceEqual([ProgVariableTypes.Number]) &&
+			x.ReturnType == ProgVariableTypes.NPCSkillPackage));
+		Assert.IsTrue(functions.Any(x => x.FunctionName == "npcskillpackage" &&
+			x.Parameters.SequenceEqual([ProgVariableTypes.Text]) &&
+			x.ReturnType == ProgVariableTypes.NPCSkillPackage));
+		Assert.IsTrue(functions.Any(x => x.FunctionName == "applyskillpackage" &&
+			x.Parameters.SequenceEqual([ProgVariableTypes.Character, ProgVariableTypes.NPCSkillPackage]) &&
+			x.ReturnType == ProgVariableTypes.Number));
+		var properties = ProgVariable.DotReferenceCompileInfos[ProgVariableTypes.NPCSkillPackage].PropertyTypeMap;
+		Assert.AreEqual(ProgVariableTypes.Number, properties["id"]);
+		Assert.AreEqual(ProgVariableTypes.Text, properties["name"]);
+		Assert.AreEqual(ProgVariableTypes.Collection | ProgVariableTypes.Trait, properties["skills"]);
+	}
+
+	[TestMethod]
+	public void ApplySkillPackageFutureProg_AddsRaisesNeverLowersAndReturnsChangeCount()
+	{
+		FutureProgTestBootstrap.EnsureInitialised();
+		var lower = Trait("Lower");
+		var raise = Trait("Raise");
+		var add = Trait("Add");
+		var package = new Mock<INPCSkillPackage>();
+		package.SetupGet(x => x.Type).Returns(ProgVariableTypes.NPCSkillPackage);
+		package.SetupGet(x => x.GetObject).Returns(package.Object);
+		package.SetupGet(x => x.Skills).Returns([
+			new NPCSkillPackageEntry(lower, 1.0, 50.0, 0.0, 0.0),
+			new NPCSkillPackageEntry(raise, 1.0, 40.0, 0.0, 0.0),
+			new NPCSkillPackageEntry(add, 1.0, 30.0, 0.0, 0.0)
+		]);
+		var character = new Mock<MudSharp.Character.ICharacter>();
+		character.SetupGet(x => x.Type).Returns(ProgVariableTypes.Character);
+		character.SetupGet(x => x.GetObject).Returns(character.Object);
+		character.Setup(x => x.HasTrait(lower)).Returns(true);
+		character.Setup(x => x.TraitRawValue(lower)).Returns(60.0);
+		character.Setup(x => x.HasTrait(raise)).Returns(true);
+		character.Setup(x => x.TraitRawValue(raise)).Returns(20.0);
+		character.Setup(x => x.HasTrait(add)).Returns(false);
+
+		var compiler = FutureProg.GetFunctionCompilerInformations().Single(x =>
+			x.FunctionName == "applyskillpackage" &&
+			x.Parameters.SequenceEqual([ProgVariableTypes.Character, ProgVariableTypes.NPCSkillPackage]));
+		var function = compiler.CompilerFunction(
+			[new ConstantFunction(character.Object), new ConstantFunction(package.Object)],
+			new Mock<MudSharp.Framework.IFuturemud>().Object);
+
+		Assert.AreEqual(StatementResult.Normal, function.Execute(new VariableSpace()));
+		Assert.AreEqual(2m, function.Result.GetObject);
+		character.Verify(x => x.SetTraitValue(lower, It.IsAny<double>()), Times.Never);
+		character.Verify(x => x.SetTraitValue(raise, 40.0), Times.Once);
+		character.Verify(x => x.AddTrait(add, 30.0), Times.Once);
+	}
+}

--- a/MudSharpCore/Character/Heritage/Race.cs
+++ b/MudSharpCore/Character/Heritage/Race.cs
@@ -39,6 +39,7 @@ public partial class Race : SaveableItem, IRace
     private readonly List<Gender> _allowedGenders = new();
 
     private readonly List<ICharacteristicDefinition> _baseCharacteristics = new();
+	private readonly List<INPCSkillPackage> _defaultSkillPackages = new();
 
     private readonly List<IBodypart> _bodypartAdditions = new();
     private readonly List<IBodypart> _bodypartRemovals = new();
@@ -393,6 +394,15 @@ public partial class Race : SaveableItem, IRace
             _chargenAdvices.Add(Gameworld.ChargenAdvices.Get(item.ChargenAdviceId));
         }
 
+		foreach (var package in race.NpcSkillPackages)
+		{
+			var runtimePackage = gameworld.NpcSkillPackages.Get(package.Id);
+			if (runtimePackage is not null)
+			{
+				_defaultSkillPackages.Add(runtimePackage);
+			}
+		}
+
         foreach (RacesChargenResources item in race.RacesChargenResources)
         {
             _costs.Add(new ChargenResourceCost
@@ -620,6 +630,7 @@ public partial class Race : SaveableItem, IRace
     public Race(Race rhs, string newName)
     {
         Gameworld = rhs.Gameworld;
+		_defaultSkillPackages.AddRange(rhs._defaultSkillPackages);
         _name = newName;
         BaseBody = rhs.BaseBody;
         ParentRace = rhs.ParentRace;
@@ -826,6 +837,10 @@ public partial class Race : SaveableItem, IRace
                     _defaultHeightWeightModels.ValueOrDefault(Gender.NonBinary, null)?.Id
             };
             FMDB.Context.Races.Add(dbitem);
+			foreach (var package in _defaultSkillPackages)
+			{
+				dbitem.NpcSkillPackages.Add(FMDB.Context.NpcSkillPackages.Find(package.Id)!);
+			}
             foreach (IBodypart part in _bodypartAdditions)
             {
                 dbitem.RacesAdditionalBodyparts.Add(new RacesAdditionalBodyparts
@@ -1183,6 +1198,12 @@ public partial class Race : SaveableItem, IRace
     public override void Save()
     {
         Models.Race dbitem = FMDB.Context.Races.Find(Id);
+		FMDB.Context.Entry(dbitem).Collection(x => x.NpcSkillPackages).Load();
+		dbitem.NpcSkillPackages.Clear();
+		foreach (var package in _defaultSkillPackages)
+		{
+			dbitem.NpcSkillPackages.Add(FMDB.Context.NpcSkillPackages.Find(package.Id)!);
+		}
         dbitem.Name = _name;
         dbitem.Description = Description;
         dbitem.BaseBodyId = BaseBody.Id;
@@ -1832,6 +1853,39 @@ public partial class Race : SaveableItem, IRace
 
     public IEnumerable<ITraitDefinition> HealthTraits =>
         ParentRace?.HealthTraits.Concat(_healthTraits).Distinct() ?? _healthTraits;
+
+	public IEnumerable<INPCSkillPackage> DirectDefaultSkillPackages => _defaultSkillPackages;
+
+	public IEnumerable<INPCSkillPackage> DefaultSkillPackages =>
+		ResolveDefaultSkillPackages(ParentRace?.DefaultSkillPackages, _defaultSkillPackages);
+
+	internal static IEnumerable<INPCSkillPackage> ResolveDefaultSkillPackages(
+		IEnumerable<INPCSkillPackage> inherited,
+		IEnumerable<INPCSkillPackage> direct)
+	{
+		return (inherited ?? Enumerable.Empty<INPCSkillPackage>())
+			.Concat(direct)
+			.Distinct();
+	}
+
+	public void AddDefaultSkillPackage(INPCSkillPackage package)
+	{
+		if (_defaultSkillPackages.Contains(package))
+		{
+			return;
+		}
+
+		_defaultSkillPackages.Add(package);
+		Changed = true;
+	}
+
+	public void RemoveDefaultSkillPackage(INPCSkillPackage package)
+	{
+		if (_defaultSkillPackages.Remove(package))
+		{
+			Changed = true;
+		}
+	}
 
     private readonly List<IFluid> _breathableFluids = new();
 

--- a/MudSharpCore/Character/Heritage/RaceBuilding.cs
+++ b/MudSharpCore/Character/Heritage/RaceBuilding.cs
@@ -29,6 +29,7 @@ public partial class Race
 	#3desc#0 - drops you into an editor to describe the race
 	#3parent <race>#0 - sets a parent race for this race
 	#3parent none#0 - clears a parent race from this race
+	#3skillpackage <package>#0 - toggles a default NPC skill package for this race
 	#3body <template>#0 - changes the body template of the race
 	#3parthealth <%>#0 - sets a multiplier for bodypart HPs
 	#3partsize <##>#0 - sets a number of steps bigger/smaller for bodyparts
@@ -128,6 +129,10 @@ public partial class Race
                 return BuildingCommandName(actor, command);
             case "parent":
                 return BuildingCommandParent(actor, command);
+			case "skillpackage":
+			case "skillpack":
+			case "npcskillpackage":
+				return BuildingCommandSkillPackage(actor, command);
             case "hwmodel":
                 return BuildingCommandHeightWeightModel(actor, command);
             case "chargen":
@@ -325,6 +330,34 @@ public partial class Race
                 return false;
         }
     }
+
+	private bool BuildingCommandSkillPackage(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which NPC skill package do you want to toggle for this race?");
+			return false;
+		}
+
+		var package = Gameworld.NpcSkillPackages.GetByIdOrName(command.SafeRemainingArgument);
+		if (package is null)
+		{
+			actor.OutputHandler.Send("There is no such NPC skill package.");
+			return false;
+		}
+
+		if (_defaultSkillPackages.Remove(package))
+		{
+			Changed = true;
+			actor.OutputHandler.Send($"This race will no longer apply {package.Name.ColourName()} to new NPC templates.");
+			return true;
+		}
+
+		_defaultSkillPackages.Add(package);
+		Changed = true;
+		actor.OutputHandler.Send($"This race will now apply {package.Name.ColourName()} to new NPC templates.");
+		return true;
+	}
 
     private bool BuildingCommandHeightWeightModel(ICharacter actor, StringStack command)
     {
@@ -2756,6 +2789,8 @@ public partial class Race
             $"Corpse: {CorpseModel.Name.ColourValue()}",
             $"Health Model: {DefaultHealthStrategy.Name.ColourValue()}"
         );
+		sb.AppendLine($"Direct NPC Skill Packages: {_defaultSkillPackages.Select(x => x.Name.ColourName()).ListToString()}");
+		sb.AppendLine($"All NPC Skill Packages: {DefaultSkillPackages.Select(x => x.Name.ColourName()).ListToString()}");
 
         sb.AppendLineColumns((uint)actor.LineFormatLength, 3,
             $"Bodypart Size Mod: {BodypartSizeModifier.ToString("N0", actor).ColourValue()}",

--- a/MudSharpCore/Commands/Helpers/EditableItemHelper.cs
+++ b/MudSharpCore/Commands/Helpers/EditableItemHelper.cs
@@ -2944,6 +2944,7 @@ public partial class EditableItemHelper
     public Func<ICharacter, string, IEditableItem> GetEditableItemByIdOrNameFunc { get; private set; }
     public Func<ICharacter, IEnumerable<IEditableItem>> GetAllEditableItems { get; private set; }
     public Action<IEditableItem> AddItemToGameWorldAction { get; private set; }
+	public Action<ICharacter, IEditableItem> EditableDeleteAction { get; private set; }
 
     public Func<ICharacter, IEnumerable<IEditableItem>, IEnumerable<IEnumerable<string>>> GetListTableContentsFunc
     {

--- a/MudSharpCore/Commands/Helpers/EditableItemHelperNPC.cs
+++ b/MudSharpCore/Commands/Helpers/EditableItemHelperNPC.cs
@@ -1,0 +1,136 @@
+#nullable enable
+
+using MudSharp.Database;
+using MudSharp.Commands.Modules;
+using MudSharp.Effects.Concrete;
+using MudSharp.Framework.Revision;
+using MudSharp.Framework.Save;
+using MudSharp.NPC.Templates;
+
+namespace MudSharp.Commands.Helpers;
+
+public partial class EditableItemHelper
+{
+	public static EditableItemHelper NPCSkillPackageHelper { get; } = new()
+	{
+		ItemName = "NPC Skill Package",
+		ItemNamePlural = "NPC Skill Packages",
+		CommandName = "npcskillpackage",
+		SetEditableItemAction = (actor, item) =>
+		{
+			actor.RemoveAllEffects<BuilderEditingEffect<INPCSkillPackage>>();
+			if (item is not null)
+			{
+				actor.AddEffect(new BuilderEditingEffect<INPCSkillPackage>(actor)
+				{
+					EditingItem = (INPCSkillPackage)item
+				});
+			}
+		},
+		GetEditableItemFunc = actor => actor.CombinedEffectsOfType<BuilderEditingEffect<INPCSkillPackage>>()
+			.FirstOrDefault()?.EditingItem,
+		GetAllEditableItems = actor => actor.Gameworld.NpcSkillPackages.OrderBy(x => x.Id).ToList(),
+		GetEditableItemByIdFunc = (actor, id) => actor.Gameworld.NpcSkillPackages.Get(id),
+		GetEditableItemByIdOrNameFunc = (actor, input) => actor.Gameworld.NpcSkillPackages.GetByIdOrName(input),
+		AddItemToGameWorldAction = item => item.Gameworld.Add((INPCSkillPackage)item),
+		CastToType = typeof(INPCSkillPackage),
+		EditableNewAction = (actor, input) =>
+		{
+			if (input.IsFinished)
+			{
+				actor.OutputHandler.Send("What name do you want to give the new NPC skill package?");
+				return;
+			}
+
+			if (!NPCSkillPackage.TryNormaliseName(input.SafeRemainingArgument, out var name, out var error))
+			{
+				actor.OutputHandler.Send(error);
+				return;
+			}
+
+			if (actor.Gameworld.NpcSkillPackages.Any(x => x.Name.EqualTo(name)))
+			{
+				actor.OutputHandler.Send($"There is already an NPC skill package named {name.ColourName()}.");
+				return;
+			}
+
+			var package = new NPCSkillPackage(actor.Gameworld, name);
+			actor.Gameworld.Add(package);
+			actor.RemoveAllEffects<BuilderEditingEffect<INPCSkillPackage>>();
+			actor.AddEffect(new BuilderEditingEffect<INPCSkillPackage>(actor) { EditingItem = package });
+			actor.OutputHandler.Send($"You create {name.ColourName()} and begin editing it.");
+		},
+		EditableCloneAction = (actor, input) =>
+		{
+			if (input.CountRemainingArguments() < 2)
+			{
+				actor.OutputHandler.Send("You must specify the source package and a new name.");
+				return;
+			}
+
+			var source = actor.Gameworld.NpcSkillPackages.GetByIdOrName(input.PopSpeech());
+			if (source is null)
+			{
+				actor.OutputHandler.Send("There is no such NPC skill package.");
+				return;
+			}
+
+			if (!NPCSkillPackage.TryNormaliseName(input.SafeRemainingArgument, out var name, out var error))
+			{
+				actor.OutputHandler.Send(error);
+				return;
+			}
+
+			if (actor.Gameworld.NpcSkillPackages.Any(x => x.Name.EqualTo(name)))
+			{
+				actor.OutputHandler.Send($"There is already an NPC skill package named {name.ColourName()}.");
+				return;
+			}
+
+			var clone = source.Clone(name);
+			actor.Gameworld.Add(clone);
+			actor.RemoveAllEffects<BuilderEditingEffect<INPCSkillPackage>>();
+			actor.AddEffect(new BuilderEditingEffect<INPCSkillPackage>(actor) { EditingItem = clone });
+			actor.OutputHandler.Send($"You clone {source.Name.ColourName()} as {name.ColourName()} and begin editing it.");
+		},
+		EditableDeleteAction = (actor, item) =>
+		{
+			var package = (INPCSkillPackage)item;
+			foreach (var race in actor.Gameworld.Races.Where(x => x.DirectDefaultSkillPackages.Contains(package)))
+			{
+				race.RemoveDefaultSkillPackage(package);
+			}
+
+			if (package is ISaveable saveable)
+			{
+				actor.Gameworld.SaveManager.Abort(saveable);
+			}
+			using (new FMDB())
+			{
+				var dbitem = FMDB.Context.NpcSkillPackages.Find(package.Id);
+				if (dbitem is not null)
+				{
+					FMDB.Context.NpcSkillPackages.Remove(dbitem);
+					FMDB.Context.SaveChanges();
+				}
+			}
+
+			actor.Gameworld.Destroy(package);
+			actor.RemoveAllEffects<BuilderEditingEffect<INPCSkillPackage>>();
+			actor.OutputHandler.Send($"You permanently delete {package.Name.ColourName()}.");
+		},
+		GetListTableHeaderFunc = _ => ["Id", "Name", "Skills"],
+		GetListTableContentsFunc = (actor, items) => items.OfType<INPCSkillPackage>()
+			.Select(x => new List<string>
+			{
+				x.Id.ToString("N0", actor), x.Name, x.Skills.Count.ToString("N0", actor)
+			}),
+		CustomSearch = (items, keyword, _) => items.OfType<INPCSkillPackage>()
+			.Where(x => x.Name.Contains(keyword, StringComparison.InvariantCultureIgnoreCase) ||
+			            x.Skills.Any(y => y.Skill.Name.Contains(keyword, StringComparison.InvariantCultureIgnoreCase)))
+			.Cast<IEditableItem>()
+			.ToList(),
+		DefaultCommandHelp = NPCBuilderModule.NPCSkillPackageHelp,
+		GetEditHeader = item => $"NPC Skill Package #{item.Id:N0} ({item.Name})"
+	};
+}

--- a/MudSharpCore/Commands/Modules/BaseBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/BaseBuilderModule.cs
@@ -3,6 +3,7 @@ using MudSharp.Commands.Helpers;
 using MudSharp.Commands.Trees;
 using MudSharp.Construction;
 using MudSharp.Database;
+using MudSharp.Effects.Concrete;
 using MudSharp.Events;
 using MudSharp.Form.Characteristics;
 using MudSharp.Framework.Revision;
@@ -993,12 +994,64 @@ If you do not wish to approve or decline, you may type {"abort edit".Colour(Teln
             case "rename":
                 GenericRename(actor, input, helper);
                 return;
+			case "delete":
+			case "remove":
+				GenericDelete(actor, input, helper);
+				return;
             default:
                 actor.OutputHandler.Send(
                     $"{helper.DefaultCommandHelp.SubstituteANSIColour()}\n\n{GenericEditableItemNameRenameHelp.SubstituteANSIColour()}");
                 return;
         }
     }
+
+	public static void GenericDelete(ICharacter actor, StringStack input, EditableItemHelper helper)
+	{
+		if (helper.EditableDeleteAction is null)
+		{
+			actor.OutputHandler.Send($"{helper.ItemNamePlural} cannot be deleted with this command.");
+			return;
+		}
+
+		var item = input.IsFinished
+			? helper.GetEditableItemFunc(actor)
+			: helper.GetEditableItemByIdOrNameFunc(actor, input.SafeRemainingArgument);
+		if (item is null)
+		{
+			actor.OutputHandler.Send($"There is no such {helper.ItemName.ToLowerInvariant()} to delete.");
+			return;
+		}
+
+		actor.OutputHandler.Send(
+			$"You are proposing to permanently delete {helper.GetEditHeader(item).ColourName()}. This cannot be undone.\n{Accept.StandardAcceptPhrasing}");
+		actor.AddEffect(new Accept(actor, CreateGenericDeleteProposal(actor, helper, item.Id, item.Name)),
+			TimeSpan.FromSeconds(120));
+	}
+
+	internal static GenericProposal CreateGenericDeleteProposal(ICharacter actor, EditableItemHelper helper,
+		long itemId, string itemName)
+	{
+		return new GenericProposal
+		{
+			DescriptionString = $"Deleting {helper.ItemName.ToLowerInvariant()} {itemName}",
+			AcceptAction = _ =>
+			{
+				var currentItem = helper.GetEditableItemByIdFunc(actor, itemId);
+				if (currentItem is null)
+				{
+					actor.OutputHandler.Send(
+						$"That {helper.ItemName.ToLowerInvariant()} no longer exists, so nothing was deleted.");
+					return;
+				}
+
+				helper.EditableDeleteAction(actor, currentItem);
+			},
+			RejectAction = _ => actor.OutputHandler.Send(
+				$"You decide not to delete {helper.ItemName.ToLowerInvariant()} {itemName.ColourName()}."),
+			ExpireAction = () => actor.OutputHandler.Send(
+				$"You decide not to delete {helper.ItemName.ToLowerInvariant()} {itemName.ColourName()}.")
+		};
+	}
 
     private static bool TrySetEditableItemName(ICharacter character, StringStack input, EditableItemHelper helper,
         IEditableItem item)

--- a/MudSharpCore/Commands/Modules/NPCBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/NPCBuilderModule.cs
@@ -24,6 +24,28 @@ namespace MudSharp.Commands.Modules
 
         public static NPCBuilderModule Instance { get; } = new();
 
+		public const string NPCSkillPackageHelp = @"NPC skill packages are reusable groups of skill distributions that can be copied into NPC templates or characters.
+
+	#3npcskillpackage list [<keyword>]#0
+	#3npcskillpackage new <name>#0
+	#3npcskillpackage edit <id|name>#0
+	#3npcskillpackage clone <id|name> <new name>#0
+	#3npcskillpackage show [<id|name>]#0
+	#3npcskillpackage set name <name>#0
+	#3npcskillpackage set skill <skill> <chance%> <mean> <standard deviation> [<skewness>]#0
+	#3npcskillpackage set skill <skill> 0%#0
+	#3npcskillpackage close#0
+	#3npcskillpackage delete <id|name>#0";
+
+		[PlayerCommand("NPCSkillPackage", "npcskillpackage", "npcskillpack")]
+		[HelpInfo("NPCSkillPackage", NPCSkillPackageHelp, AutoHelp.HelpArgOrNoArg)]
+		[CommandPermission(PermissionLevel.Admin)]
+		protected static void NPCSkillPackageBuilding(ICharacter actor, string input)
+		{
+			GenericBuildingCommand(actor, new StringStack(input.RemoveFirstWord()),
+				EditableItemHelper.NPCSkillPackageHelper);
+		}
+
         #region NPCs
 
         internal static bool TryResolveNpcLoadSpatialLocation(

--- a/MudSharpCore/Framework/Futuremud.cs
+++ b/MudSharpCore/Framework/Futuremud.cs
@@ -1568,6 +1568,11 @@ public sealed partial class Futuremud : IFuturemud, IDisposable, IRuntimePerform
         _heightWeightModels.Add(model);
     }
 
+	public void Add(INPCSkillPackage package)
+	{
+		_npcSkillPackages.Add(package);
+	}
+
     public void Add(IHearingProfile profile)
     {
         _hearingProfiles.Add(profile);
@@ -1970,6 +1975,11 @@ public sealed partial class Futuremud : IFuturemud, IDisposable, IRuntimePerform
     {
         _heightWeightModels.Remove(model);
     }
+
+	public void Destroy(INPCSkillPackage package)
+	{
+		_npcSkillPackages.Remove(package);
+	}
 
     public void Destroy(IHearingProfile profile)
     {

--- a/MudSharpCore/Framework/FuturemudLoaders.cs
+++ b/MudSharpCore/Framework/FuturemudLoaders.cs
@@ -347,6 +347,7 @@ public sealed partial class Futuremud : IFuturemudLoader, IFuturemud, ICombatSim
             game.LoadImprovementModels();
             game.LoadTraitDecorators();
             game.LoadTraits(); // Depends on LoadImprovementModels and LoadTraitDecorators
+			game.LoadNPCSkillPackages(); // Depends on LoadTraits and must precede LoadRaces
             game.LoadChecks(); // Depends on LoadTraits
 
             game.LoadSurgery(); // Needs to come after LoadFutureProgs, LoadKnowledges and LoadTags, and LoadBodies
@@ -2819,6 +2820,22 @@ For information on the syntax to use in emotes (such as those included in bracke
         ConsoleUtilities.WriteLine("Loaded #2{0}#0 NPC Template{1}.", count, count == 1 ? "" : "s");
     }
 
+	void IFuturemudLoader.LoadNPCSkillPackages()
+	{
+		ConsoleUtilities.WriteLine("\nLoading #5NPC Skill Packages#0...");
+		var packages = FMDB.Context.NpcSkillPackages
+			.Include(x => x.Skills)
+			.AsNoTracking()
+			.ToList();
+		foreach (var package in packages)
+		{
+			_npcSkillPackages.Add(new NPCSkillPackage(package, this));
+		}
+
+		ConsoleUtilities.WriteLine("Loaded #2{0:N0}#0 NPC Skill Package{1}.", packages.Count,
+			packages.Count == 1 ? "" : "s");
+	}
+
     internal static bool ShouldLoadNpcAtBoot(long npcCharacterId, CharacterState state, ISet<long> activeStableMountIds)
     {
         return !state.HasFlag(CharacterState.Dead) &&
@@ -4536,6 +4553,7 @@ For information on the syntax to use in emotes (such as those included in bracke
                                       .Include(x => x.RacesEdibleMaterials)
                                       .Include(x => x.RaceEdibleForagableYields)
                                       .Include(x => x.RacesCombatActions)
+									  .Include(x => x.NpcSkillPackages)
                                       .AsSplitQuery()
                                       .AsNoTracking()
                                    select race).ToList();

--- a/MudSharpCore/Framework/FuturemudVariables.cs
+++ b/MudSharpCore/Framework/FuturemudVariables.cs
@@ -182,6 +182,7 @@ public sealed partial class Futuremud : IDisposable
     private readonly All<ICommoditySpoilageRule> _commoditySpoilageRules = new();
     private readonly All<IArtificialIntelligence> _AIs = new();
     private readonly RevisableAll<INPCTemplate> _npcTemplates = new();
+	private readonly All<INPCSkillPackage> _npcSkillPackages = new();
     private readonly All<IImprovementModel> _improvementModels = new();
 
     private readonly RevisableAll<IGameItemComponentProto> _itemComponentProtos =
@@ -457,6 +458,7 @@ public sealed partial class Futuremud : IDisposable
     public IUneditableAll<IArtificialIntelligence> AIs => _AIs;
 
     public IUneditableRevisableAll<INPCTemplate> NpcTemplates => _npcTemplates;
+	public IUneditableAll<INPCSkillPackage> NpcSkillPackages => _npcSkillPackages;
     public IUneditableAll<INPCSpawner> NPCSpawners => _npcSpawners;
 
     public IUneditableAll<IImprovementModel> ImprovementModels => _improvementModels;

--- a/MudSharpCore/FutureProg/Functions/Characters/NPCSkillPackageFunctions.cs
+++ b/MudSharpCore/FutureProg/Functions/Characters/NPCSkillPackageFunctions.cs
@@ -1,0 +1,124 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.FutureProg.Variables;
+using MudSharp.NPC.Templates;
+
+namespace MudSharp.FutureProg.Functions.Characters;
+
+internal sealed class GetNPCSkillPackageFunction : BuiltInFunction
+{
+	private readonly IFuturemud _gameworld;
+	private readonly bool _byName;
+
+	private GetNPCSkillPackageFunction(IList<IFunction> parameterFunctions, IFuturemud gameworld, bool byName)
+		: base(parameterFunctions)
+	{
+		_gameworld = gameworld;
+		_byName = byName;
+	}
+
+	public override ProgVariableTypes ReturnType
+	{
+		get => ProgVariableTypes.NPCSkillPackage;
+		protected set { }
+	}
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		Result = _byName
+			? _gameworld.NpcSkillPackages.GetByIdOrName(ParameterFunctions[0].Result?.GetObject?.ToString() ?? string.Empty)
+			: _gameworld.NpcSkillPackages.Get((long)(decimal)ParameterFunctions[0].Result!.GetObject);
+		return StatementResult.Normal;
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		foreach (var type in new[] { ProgVariableTypes.Number, ProgVariableTypes.Text })
+		{
+			var byName = type == ProgVariableTypes.Text;
+			FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+				"npcskillpackage", [type],
+				(pars, gameworld) => new GetNPCSkillPackageFunction(pars, gameworld, byName),
+				[byName ? "name" : "id"],
+				[byName ? "The package name or ID." : "The package ID."],
+				"Gets an NPC skill package by ID or name, or returns null when none matches.",
+				"NPCs", ProgVariableTypes.NPCSkillPackage));
+		}
+	}
+}
+
+internal sealed class ApplyNPCSkillPackageFunction : BuiltInFunction
+{
+	private ApplyNPCSkillPackageFunction(IList<IFunction> parameterFunctions) : base(parameterFunctions)
+	{
+	}
+
+	public override ProgVariableTypes ReturnType
+	{
+		get => ProgVariableTypes.Number;
+		protected set { }
+	}
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		var character = ParameterFunctions[0].Result?.GetObject as ICharacter;
+		var package = ParameterFunctions[1].Result?.GetObject as INPCSkillPackage;
+		if (character is null || package is null)
+		{
+			Result = new NumberVariable(0);
+			return StatementResult.Normal;
+		}
+
+		var changed = 0;
+		foreach (var entry in package.Skills)
+		{
+			if (Constants.Random.NextDouble() > entry.Chance)
+			{
+				continue;
+			}
+
+			var value = Math.Max(0.0,
+				RandomUtilities.RandomSkewNormal(entry.Mean, entry.StandardDeviation, entry.Skewness));
+			if (value <= 0.0 || character.HasTrait(entry.Skill) && character.TraitRawValue(entry.Skill) >= value)
+			{
+				continue;
+			}
+
+			if (character.HasTrait(entry.Skill))
+			{
+				character.SetTraitValue(entry.Skill, value);
+			}
+			else
+			{
+				character.AddTrait(entry.Skill, value);
+			}
+
+			changed++;
+		}
+
+		Result = new NumberVariable(changed);
+		return StatementResult.Normal;
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"applyskillpackage", [ProgVariableTypes.Character, ProgVariableTypes.NPCSkillPackage],
+			(pars, _) => new ApplyNPCSkillPackageFunction(pars),
+			["character", "package"],
+			["The character to receive the rolled package.", "The NPC skill package to apply."],
+			"Rolls an NPC skill package and adds or raises skills without lowering existing values. Returns the number changed.",
+			"NPCs", ProgVariableTypes.Number));
+	}
+}

--- a/MudSharpCore/NPC/Templates/NPCSkillPackage.cs
+++ b/MudSharpCore/NPC/Templates/NPCSkillPackage.cs
@@ -1,0 +1,279 @@
+#nullable enable
+
+using System.Globalization;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.Database;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.Framework.Save;
+using MudSharp.FutureProg;
+using MudSharp.FutureProg.Variables;
+
+namespace MudSharp.NPC.Templates;
+
+public sealed class NPCSkillPackage : SaveableItem, INPCSkillPackage
+{
+	public const double MaximumAbsoluteSkewness = 0.99;
+	private readonly List<NPCSkillPackageEntry> _skills = [];
+
+	public NPCSkillPackage(MudSharp.Models.NpcSkillPackage package, IFuturemud gameworld)
+	{
+		Gameworld = gameworld;
+		_id = package.Id;
+		_name = package.Name;
+		foreach (var skill in package.Skills)
+		{
+			if (gameworld.Traits.Get(skill.TraitDefinitionId) is not ITraitDefinition definition ||
+				definition.TraitType != TraitType.Skill)
+			{
+				continue;
+			}
+
+			_skills.Add(new NPCSkillPackageEntry(definition, skill.Chance, skill.Mean,
+				skill.StandardDeviation, skill.Skewness));
+		}
+	}
+
+	public NPCSkillPackage(IFuturemud gameworld, string name)
+	{
+		Gameworld = gameworld;
+		_name = name;
+		using (new FMDB())
+		{
+			var package = new MudSharp.Models.NpcSkillPackage { Name = name };
+			FMDB.Context.NpcSkillPackages.Add(package);
+			FMDB.Context.SaveChanges();
+			_id = package.Id;
+		}
+	}
+
+	private NPCSkillPackage(NPCSkillPackage rhs, string name) : this(rhs.Gameworld, name)
+	{
+		_skills.AddRange(rhs._skills);
+		Changed = true;
+	}
+
+	public override string FrameworkItemType => "NPCSkillPackage";
+	public IReadOnlyCollection<NPCSkillPackageEntry> Skills => _skills;
+
+	public INPCSkillPackage Clone(string name) => new NPCSkillPackage(this, name);
+
+	public override void Save()
+	{
+		var package = FMDB.Context.NpcSkillPackages
+			.Include(x => x.Skills)
+			.First(x => x.Id == Id);
+		package.Name = Name;
+		FMDB.Context.NpcSkillPackageSkills.RemoveRange(package.Skills);
+		foreach (var skill in _skills)
+		{
+			package.Skills.Add(new MudSharp.Models.NpcSkillPackageSkill
+			{
+				TraitDefinitionId = skill.Skill.Id,
+				Chance = skill.Chance,
+				Mean = skill.Mean,
+				StandardDeviation = skill.StandardDeviation,
+				Skewness = skill.Skewness
+			});
+		}
+
+		Changed = false;
+	}
+
+	private const string BuildingHelp = @"You can use the following options with this package:
+
+	name <name> - renames this package
+	skill <skill> <chance%> <mean> <standard deviation> [<skewness>] - adds or replaces a skill
+	skill <skill> 0% - removes a skill
+
+Skewness must be between -0.99 and 0.99. Omit it for an ordinary normal distribution.";
+
+	public bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopSpeech().ToLowerInvariant())
+		{
+			case "name":
+			case "rename":
+				return BuildingCommandName(actor, command);
+			case "skill":
+			case "skills":
+				return BuildingCommandSkill(actor, command);
+			case "help":
+			case "?":
+			case "":
+				actor.OutputHandler.Send(BuildingHelp.SubstituteANSIColour());
+				return false;
+			default:
+				actor.OutputHandler.Send(BuildingHelp.SubstituteANSIColour());
+				return false;
+		}
+	}
+
+	private bool BuildingCommandName(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What new name do you want to give this NPC skill package?");
+			return false;
+		}
+
+		if (!TryNormaliseName(command.SafeRemainingArgument, out var name, out var error))
+		{
+			actor.OutputHandler.Send(error);
+			return false;
+		}
+
+		if (Gameworld.NpcSkillPackages.Any(x => x.Id != Id && x.Name.EqualTo(name)))
+		{
+			actor.OutputHandler.Send($"There is already an NPC skill package named {name.ColourName()}.");
+			return false;
+		}
+
+		actor.OutputHandler.Send($"You rename the {_name.ColourName()} package to {name.ColourName()}.");
+		_name = name;
+		Changed = true;
+		return true;
+	}
+
+	internal static bool TryNormaliseName(string proposedName, out string name, out string error)
+	{
+		name = proposedName.TitleCase();
+		if (string.IsNullOrWhiteSpace(name))
+		{
+			error = "Package names cannot be blank.";
+			return false;
+		}
+
+		if (name.All(char.IsDigit))
+		{
+			error = "Package names cannot be entirely numeric, because numeric input is reserved for IDs.";
+			return false;
+		}
+
+		error = string.Empty;
+		return true;
+	}
+
+	private bool BuildingCommandSkill(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which skill do you want to add, change or remove?");
+			return false;
+		}
+
+		var skillText = command.PopSpeech();
+		var skill = Gameworld.Traits
+			.Where(x => x.TraitType == TraitType.Skill)
+			.GetByIdOrName(skillText);
+		if (skill is null)
+		{
+			actor.OutputHandler.Send("There is no such skill.");
+			return false;
+		}
+
+		if (command.IsFinished || !command.PopSpeech().TryParsePercentage(actor.Account.Culture, out var chance) ||
+			!double.IsFinite(chance) || chance < 0.0 || chance > 1.0)
+		{
+			actor.OutputHandler.Send("You must specify a chance between 0% and 100%.");
+			return false;
+		}
+
+		if (chance == 0.0)
+		{
+			if (_skills.RemoveAll(x => x.Skill == skill) == 0)
+			{
+				actor.OutputHandler.Send("That skill is not in this package.");
+				return false;
+			}
+
+			Changed = true;
+			actor.OutputHandler.Send($"You remove {skill.Name.ColourName()} from this package.");
+			return true;
+		}
+
+		if (command.IsFinished || !double.TryParse(command.PopSpeech(), NumberStyles.Float, actor, out var mean) ||
+			!double.IsFinite(mean) || mean < 0.0)
+		{
+			actor.OutputHandler.Send("You must specify a non-negative mean value.");
+			return false;
+		}
+
+		if (command.IsFinished || !double.TryParse(command.PopSpeech(), NumberStyles.Float, actor, out var deviation) ||
+			!double.IsFinite(deviation) || deviation < 0.0)
+		{
+			actor.OutputHandler.Send("You must specify a non-negative standard deviation.");
+			return false;
+		}
+
+		var skewness = 0.0;
+		if (!command.IsFinished &&
+			(!double.TryParse(command.PopSpeech(), NumberStyles.Float, actor, out skewness) ||
+			 !double.IsFinite(skewness) ||
+			 Math.Abs(skewness) > MaximumAbsoluteSkewness))
+		{
+			actor.OutputHandler.Send("Skewness must be between -0.99 and 0.99.");
+			return false;
+		}
+
+		_skills.RemoveAll(x => x.Skill == skill);
+		_skills.Add(new NPCSkillPackageEntry(skill, chance, mean, deviation, skewness));
+		Changed = true;
+		actor.OutputHandler.Send(
+			$"You set {skill.Name.ColourName()} to {chance.ToString("P1", actor).ColourValue()} chance, mean {mean.ToString("N2", actor).ColourValue()}, standard deviation {deviation.ToString("N2", actor).ColourValue()} and skewness {skewness.ToString("N2", actor).ColourValue()}.");
+		return true;
+	}
+
+	public string Show(ICharacter actor)
+	{
+		var sb = new StringBuilder();
+		sb.AppendLine($"NPC Skill Package #{Id.ToString("N0", actor)} - {Name.ColourName()}".GetLineWithTitleInner(actor, Telnet.Cyan, Telnet.BoldWhite));
+		sb.AppendLine();
+		sb.AppendLine(StringUtilities.GetTextTable(
+			_skills.OrderBy(x => x.Skill.Name).Select(x => new List<string>
+			{
+				x.Skill.Name,
+				x.Chance.ToString("P1", actor),
+				x.Mean.ToString("N2", actor),
+				x.StandardDeviation.ToString("N2", actor),
+				x.Skewness.ToString("N2", actor),
+				x.WeightedExpectedValue.ToString("N2", actor)
+			}),
+			["Skill", "Chance", "Mean", "Std Dev", "Skewness", "Weighted EV"], actor, Telnet.Yellow));
+		return sb.ToString();
+	}
+
+	public ProgVariableTypes Type => ProgVariableTypes.NPCSkillPackage;
+	public object GetObject => this;
+
+	public IProgVariable GetProperty(string property)
+	{
+		return property.ToLowerInvariant() switch
+		{
+			"id" => new NumberVariable(Id),
+			"name" => new TextVariable(Name),
+			"skills" => new CollectionVariable(_skills.Select(x => x.Skill).ToList(), ProgVariableTypes.Trait),
+			_ => throw new NotSupportedException($"Unsupported NPC skill package property {property}.")
+		};
+	}
+
+	public static void RegisterFutureProgCompiler()
+	{
+		ProgVariable.RegisterDotReferenceCompileInfo(ProgVariableTypes.NPCSkillPackage,
+			new Dictionary<string, ProgVariableTypes>(StringComparer.InvariantCultureIgnoreCase)
+			{
+				["id"] = ProgVariableTypes.Number,
+				["name"] = ProgVariableTypes.Text,
+				["skills"] = ProgVariableTypes.Collection | ProgVariableTypes.Trait
+			},
+			new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase)
+			{
+				["id"] = "The package ID.",
+				["name"] = "The package name.",
+				["skills"] = "The skill definitions contained in the package."
+			});
+	}
+}

--- a/MudSharpCore/NPC/Templates/NPCTemplateBase.cs
+++ b/MudSharpCore/NPC/Templates/NPCTemplateBase.cs
@@ -578,6 +578,7 @@ public abstract partial class NPCTemplateBase : EditableItem, INPCTemplate, IEdi
     public ICharacterCombatSettings? DefaultCombatSetting { get; set; }
 
     public abstract INPCTemplate Clone(ICharacter builder);
+	public abstract NPCSkillPackageApplicationResult ApplySkillPackage(INPCSkillPackage package);
 
     #endregion
 

--- a/MudSharpCore/NPC/Templates/SimpleNPCTemplate.cs
+++ b/MudSharpCore/NPC/Templates/SimpleNPCTemplate.cs
@@ -178,6 +178,7 @@ public class SimpleNPCTemplate : NPCTemplateBase
 	#3variable <which> <value>#0 - sets a characteristic to a particular value
 	#3attribute <which> <#>#0 - sets an attribute to a particular amount
 	#3skill <which> <#>#0 - gives this NPC a skill at a particular value. Use 0 to remove
+	#3skillpackage <which>#0 - applies an NPC skill package without lowering existing skills
 	#3accent <accent>#0 - toggles an NPC having a particular accent. Must have matching language skill.
 	#3class <class>#0 - sets the class of this NPC (if using classes)
 	#3subclass <subclass>#0 - sets the subclass of  this NPC (if using subclasses)
@@ -229,6 +230,9 @@ public class SimpleNPCTemplate : NPCTemplateBase
                 return BuildingCommandRace(actor, command);
             case "skill":
                 return BuildingCommandSkill(actor, command);
+			case "skillpackage":
+			case "skillpack":
+				return BuildingCommandSkillPackage(actor, command);
             case "weight":
                 return BuildingCommandWeight(actor, command);
             case "class":
@@ -1714,6 +1718,12 @@ public class SimpleNPCTemplate : NPCTemplateBase
         }
 
         actor.OutputHandler.Send($"This NPC is now of the {race.Name.Proper().Colour(Telnet.Cyan)} race.");
+		var packageChanges = 0;
+		foreach (var package in race.DefaultSkillPackages)
+		{
+			packageChanges += ApplySkillPackage(package).Changed;
+		}
+		actor.OutputHandler.Send($"Race defaults added or upgraded {packageChanges.ToString("N0", actor).ColourValue()} skill{(packageChanges == 1 ? "" : "s")}.");
         Changed = true;
         return true;
     }
@@ -1757,6 +1767,85 @@ public class SimpleNPCTemplate : NPCTemplateBase
             $"You set the {skill.Name.Proper().Colour(Telnet.Cyan)} skill for this NPC to be {value.ToString("N2").Colour(Telnet.Green)}.");
         return true;
     }
+
+	private bool BuildingCommandSkillPackage(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which NPC skill package do you want to apply?");
+			return false;
+		}
+
+		var package = Gameworld.NpcSkillPackages.GetByIdOrName(command.SafeRemainingArgument);
+		if (package is null)
+		{
+			actor.OutputHandler.Send("There is no such NPC skill package.");
+			return false;
+		}
+
+		var result = ApplySkillPackage(package);
+		actor.OutputHandler.Send($"Applying {package.Name.ColourName()} added {result.Added.ToString("N0", actor).ColourValue()}, raised {result.Raised.ToString("N0", actor).ColourValue()}, skipped {result.Skipped.ToString("N0", actor).ColourValue()} and failed {result.FailedChance.ToString("N0", actor).ColourValue()} chance rolls.");
+		return result.Changed > 0;
+	}
+
+	public override NPCSkillPackageApplicationResult ApplySkillPackage(INPCSkillPackage package)
+	{
+		var result = ApplySkillPackageToValues(SkillValues, package,
+			() => Constants.Random.NextDouble(),
+			entry => RandomUtilities.RandomSkewNormal(entry.Mean, entry.StandardDeviation, entry.Skewness));
+		if (result.Changed > 0)
+		{
+			Changed = true;
+		}
+
+		return result;
+	}
+
+	internal static NPCSkillPackageApplicationResult ApplySkillPackageToValues(
+		List<(ITraitDefinition Skill, double Value)> skillValues,
+		INPCSkillPackage package,
+		Func<double> chanceRoll,
+		Func<NPCSkillPackageEntry, double> valueRoll)
+	{
+		var added = 0;
+		var raised = 0;
+		var skipped = 0;
+		var failedChance = 0;
+		foreach (var entry in package.Skills)
+		{
+			if (chanceRoll() > entry.Chance)
+			{
+				failedChance++;
+				continue;
+			}
+
+			var value = Math.Max(0.0, valueRoll(entry));
+			var index = skillValues.FindIndex(x => x.Skill == entry.Skill);
+			if (index < 0)
+			{
+				if (value <= 0.0)
+				{
+					skipped++;
+					continue;
+				}
+
+				skillValues.Add((entry.Skill, value));
+				added++;
+				continue;
+			}
+
+			if (skillValues[index].Value >= value)
+			{
+				skipped++;
+				continue;
+			}
+
+			skillValues[index] = (entry.Skill, value);
+			raised++;
+		}
+
+		return new NPCSkillPackageApplicationResult(added, raised, 0, skipped, failedChance);
+	}
 
     private bool BuildingCommandWeight(ICharacter actor, StringStack command)
     {

--- a/MudSharpCore/NPC/Templates/VariableNPCTemplate.cs
+++ b/MudSharpCore/NPC/Templates/VariableNPCTemplate.cs
@@ -218,13 +218,7 @@ public class VariableNPCTemplate : NPCTemplateBase
         element = root.Element("Skills");
         foreach (XElement sub in element.Elements("Skill"))
         {
-            _skillTemplates.Add(new VariableSkillTemplate
-            {
-                Chance = double.Parse(sub.Attribute("Chance").Value),
-                SkillMean = double.Parse(sub.Attribute("Mean").Value),
-                SkillStddev = double.Parse(sub.Attribute("Stddev").Value),
-                Trait = Gameworld.Traits.Get(long.Parse(sub.Attribute("Trait").Value))
-            });
+			_skillTemplates.Add(VariableSkillTemplate.LoadFromXml(sub, id => Gameworld.Traits.Get(id)));
         }
 
         element = root.Element("Roles");
@@ -318,10 +312,7 @@ public class VariableNPCTemplate : NPCTemplateBase
                 new XElement("Skills", new object[]
                 {
                     from item in _skillTemplates
-                    select
-                        new XElement("Skill", new XAttribute("Chance", item.Chance),
-                            new XAttribute("Mean", item.SkillMean), new XAttribute("Stddev", item.SkillStddev),
-                            new XAttribute("Trait", item.Trait.Id))
+					select item.SaveToXml()
                 }),
                 new XElement("Roles", new object[]
                 {
@@ -431,7 +422,8 @@ public class VariableNPCTemplate : NPCTemplateBase
                                           .ToList<ITrait>();
         List<(ITraitDefinition Trait, double)> rolledSkills = _skillTemplates.Where(x => Constants.Random.NextDouble() <= x.Chance)
                                           .Select(y => (y.Trait,
-                                              RandomUtilities.RandomNormal(y.SkillMean, y.SkillStddev))).ToList();
+											  RandomUtilities.RandomSkewNormal(y.SkillMean, y.SkillStddev,
+												  y.SkillSkewness))).ToList();
         IPersonalName randomName = _nameProfiles[rolledGender].GetRandomPersonalName();
         MudDate birthday = _culture.PrimaryCalendar.GetRandomBirthday(rolledAge);
         List<ILanguage> languages = Gameworld.Languages.Where(x => rolledSkills.Any(y => y.Item1 == x.LinkedTrait)).ToList();
@@ -642,6 +634,8 @@ public class VariableNPCTemplate : NPCTemplateBase
                 skill.Chance.ToString("P1", actor).Colour(Telnet.Green),
                 $"{skill.SkillMean.ToString("N1", actor).Colour(Telnet.Green)} {skill.Trait.Decorator.Decorate(skill.SkillMean).ColourValue()}",
                 skill.SkillStddev.ToString("N1", actor).Colour(Telnet.Green),
+				skill.SkillSkewness.ToString("N2", actor).Colour(Telnet.Green),
+				(skill.Chance * skill.SkillMean).ToString("N1", actor).Colour(Telnet.Green),
                 $"{(skill.SkillMean - 3 * skill.SkillStddev).ToString("N1", actor).Colour(Telnet.Green)} {skill.Trait.Decorator.Decorate((skill.SkillMean - 3 * skill.SkillStddev)).ColourValue()}",
                 $"{(skill.SkillMean + 3 * skill.SkillStddev).ToString("N1", actor).Colour(Telnet.Green)} {skill.Trait.Decorator.Decorate((skill.SkillMean + 3 * skill.SkillStddev)).ColourValue()}"
             },
@@ -651,6 +645,8 @@ public class VariableNPCTemplate : NPCTemplateBase
                 "Chance",
                 "Mean",
                 "StdDev",
+				"Skewness",
+				"Weighted EV",
                 "99.7% Min",
                 "99.7% Max",
             },
@@ -819,8 +815,9 @@ public class VariableNPCTemplate : NPCTemplateBase
 	#3sdesc clear#0 - sets the NPC to use a random valid sdesc pattern
 	#3fdesc <#>#0 - sets the NPC to use a particular fdesc pattern
 	#3fdesc clear#0 - sets the NPC ot use a random valid fdesc pattern
-	#3skill <which> <%> <avg> <stddev>#0 - sets the chance/mean/stddev for a particular skill
+	#3skill <which> <%> <avg> <stddev> [<skewness>]#0 - sets the distribution for a particular skill
 	#3skill <which> 0%#0 - removes a skill from the list
+	#3skillpackage <which>#0 - applies an NPC skill package when its weighted expected value is higher
 	#3class <class>#0 - sets the class of this NPC (if using classes)
 	#3subclass <subclass>#0 - sets the subclass of  this NPC (if using subclasses)
 	#3role <which>#0 - toggles this NPC having a particular role
@@ -899,6 +896,9 @@ public class VariableNPCTemplate : NPCTemplateBase
             case "skill":
             case "skills":
                 return BuildingCommandSkill(actor, command);
+			case "skillpackage":
+			case "skillpack":
+				return BuildingCommandSkillPackage(actor, command);
             case "class":
                 return BuildingCommandClass(actor, command);
             case "subclass":
@@ -1144,8 +1144,15 @@ public class VariableNPCTemplate : NPCTemplateBase
         RefreshAutomaticNameProfiles();
 
         _priorityAttributeDefinitions.RemoveAll(x => !_race.Attributes.Contains(x));
+		var packageChanges = 0;
+		foreach (var package in _race.DefaultSkillPackages)
+		{
+			packageChanges += ApplySkillPackage(package).Changed;
+		}
         Changed = true;
-        actor.Send("You set the race of this NPC to {0}.", _race.Name.Proper().Colour(Telnet.Cyan));
+		actor.Send("You set the race of this NPC to {0}; its race defaults added or upgraded {1} skill definition{2}.",
+			_race.Name.Proper().Colour(Telnet.Cyan), packageChanges.ToString("N0", actor).ColourValue(),
+			packageChanges == 1 ? "" : "s");
         return true;
     }
 
@@ -1485,9 +1492,10 @@ public class VariableNPCTemplate : NPCTemplateBase
             return false;
         }
 
-        if (!command.PopSpeech().TryParsePercentage(out double chance))
+        if (!command.PopSpeech().TryParsePercentage(actor.Account.Culture, out double chance) ||
+	        !double.IsFinite(chance) || chance < 0.0 || chance > 1.0)
         {
-            actor.OutputHandler.Send("You must specify a valid percentage.");
+            actor.OutputHandler.Send("You must specify a percentage between 0% and 100%.");
             return false;
         }
 
@@ -1499,18 +1507,30 @@ public class VariableNPCTemplate : NPCTemplateBase
             return true;
         }
 
-        if (!double.TryParse(command.PopSpeech(), out double mean))
+        if (!double.TryParse(command.PopSpeech(), actor, out double mean) ||
+	        !double.IsFinite(mean) || mean < 0.0)
         {
-            actor.OutputHandler.Send("You must enter a mean (average) value for this skill to be given to this NPC.");
+            actor.OutputHandler.Send("You must enter a non-negative mean (average) value for this skill.");
             return false;
         }
 
-        if (!double.TryParse(command.PopSpeech(), out double stddev))
+		if (!double.TryParse(command.PopSpeech(), actor, out double stddev) ||
+		    !double.IsFinite(stddev) || stddev < 0.0)
         {
             actor.OutputHandler.Send(
                 $"You must enter a standard deviation value for this skill. Based on your average, a suggested value for standard deviation is {(mean * 0.05).ToString("N2", actor).ColourValue()}.");
             return false;
         }
+
+		double skewness = 0.0;
+		if (!command.IsFinished &&
+			(!double.TryParse(command.PopSpeech(), actor, out skewness) ||
+			 !double.IsFinite(skewness) ||
+			 Math.Abs(skewness) > NPCSkillPackage.MaximumAbsoluteSkewness))
+		{
+			actor.OutputHandler.Send("Skewness must be between -0.99 and 0.99.");
+			return false;
+		}
 
         _skillTemplates.RemoveAll(x => x.Trait == skill);
         _skillTemplates.Add(new VariableSkillTemplate
@@ -1518,17 +1538,87 @@ public class VariableNPCTemplate : NPCTemplateBase
             Trait = skill,
             Chance = chance,
             SkillMean = mean,
-            SkillStddev = stddev
+            SkillStddev = stddev,
+			SkillSkewness = skewness
         });
 
         actor.OutputHandler.Send(
             string.Format(actor,
-                "You set the {0} skill to have a {1:P2} chance to be given to this NPC, with a mean (average) value of {2:N2} and a standard deviation of {3:N2}.\n99.5% of the time, this will be between {4:N2} and {5:N2}.",
-                skill.Name.Proper().Colour(Telnet.Cyan), chance, mean, stddev, mean - 3 * stddev, mean + 3 * stddev
+				"You set the {0} skill to have a {1:P2} chance, mean {2:N2}, standard deviation {3:N2} and skewness {4:N2}.",
+				skill.Name.Proper().Colour(Telnet.Cyan), chance, mean, stddev, skewness
             ));
         Changed = true;
         return true;
     }
+
+	private bool BuildingCommandSkillPackage(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which NPC skill package do you want to apply?");
+			return false;
+		}
+
+		var package = Gameworld.NpcSkillPackages.GetByIdOrName(command.SafeRemainingArgument);
+		if (package is null)
+		{
+			actor.OutputHandler.Send("There is no such NPC skill package.");
+			return false;
+		}
+
+		var result = ApplySkillPackage(package);
+		actor.OutputHandler.Send($"Applying {package.Name.ColourName()} applied {result.Added.ToString("N0", actor).ColourValue()}, upgraded {result.Raised.ToString("N0", actor).ColourValue()}, skipped {result.Skipped.ToString("N0", actor).ColourValue()} and failed {result.FailedChance.ToString("N0", actor).ColourValue()} chance rolls.");
+		return result.Changed > 0;
+	}
+
+	public override NPCSkillPackageApplicationResult ApplySkillPackage(INPCSkillPackage package)
+	{
+		var result = ApplySkillPackageToTemplates(_skillTemplates, package);
+		if (result.Changed > 0)
+		{
+			Changed = true;
+		}
+
+		return result;
+	}
+
+	internal static NPCSkillPackageApplicationResult ApplySkillPackageToTemplates(
+		List<VariableSkillTemplate> skillTemplates,
+		INPCSkillPackage package)
+	{
+		var added = 0;
+		var upgraded = 0;
+		var skipped = 0;
+		foreach (var entry in package.Skills)
+		{
+			var existing = skillTemplates.FirstOrDefault(x => x.Trait == entry.Skill);
+			if (existing is not null && existing.Chance * existing.SkillMean >= entry.WeightedExpectedValue)
+			{
+				skipped++;
+				continue;
+			}
+
+			skillTemplates.RemoveAll(x => x.Trait == entry.Skill);
+			skillTemplates.Add(new VariableSkillTemplate
+			{
+				Trait = entry.Skill,
+				Chance = entry.Chance,
+				SkillMean = entry.Mean,
+				SkillStddev = entry.StandardDeviation,
+				SkillSkewness = entry.Skewness
+			});
+			if (existing is null)
+			{
+				added++;
+			}
+			else
+			{
+				upgraded++;
+			}
+		}
+
+		return new NPCSkillPackageApplicationResult(added, upgraded, 0, skipped, 0);
+	}
 
     private bool BuildingCommandClass(ICharacter actor, StringStack command)
     {

--- a/MudSharpCore/NPC/Templates/VariableSkillTemplate.cs
+++ b/MudSharpCore/NPC/Templates/VariableSkillTemplate.cs
@@ -8,4 +8,28 @@ public class VariableSkillTemplate
     public double Chance { get; init; }
     public double SkillMean { get; init; }
     public double SkillStddev { get; init; }
+	public double SkillSkewness { get; init; }
+
+	public static VariableSkillTemplate LoadFromXml(System.Xml.Linq.XElement element,
+		System.Func<long, ITraitDefinition> traitResolver)
+	{
+		return new VariableSkillTemplate
+		{
+			Chance = double.Parse(element.Attribute("Chance")!.Value),
+			SkillMean = double.Parse(element.Attribute("Mean")!.Value),
+			SkillStddev = double.Parse(element.Attribute("Stddev")!.Value),
+			SkillSkewness = double.Parse(element.Attribute("Skewness")?.Value ?? "0"),
+			Trait = traitResolver(long.Parse(element.Attribute("Trait")!.Value))
+		};
+	}
+
+	public System.Xml.Linq.XElement SaveToXml()
+	{
+		return new System.Xml.Linq.XElement("Skill",
+			new System.Xml.Linq.XAttribute("Chance", Chance),
+			new System.Xml.Linq.XAttribute("Mean", SkillMean),
+			new System.Xml.Linq.XAttribute("Stddev", SkillStddev),
+			new System.Xml.Linq.XAttribute("Skewness", SkillSkewness),
+			new System.Xml.Linq.XAttribute("Trait", Trait.Id));
+	}
 }

--- a/MudsharpDatabaseLibrary Unit Tests/NPCSkillPackageModelTests.cs
+++ b/MudsharpDatabaseLibrary Unit Tests/NPCSkillPackageModelTests.cs
@@ -1,0 +1,68 @@
+#nullable enable
+
+using System.Linq;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Database;
+using MudSharp.Migrations;
+using MudSharp.Models;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class NPCSkillPackageModelTests
+{
+	[TestMethod]
+	public void Model_UsesNormalisedEntriesAndRequiredDeletionRules()
+	{
+		var options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseMySql("server=localhost;port=3306;database=dbo;uid=futuremud;password=unused",
+				ServerVersion.Parse("8.0.36-mysql"))
+			.Options;
+		using var context = new FuturemudDatabaseContext(options);
+		var model = context.GetService<IDesignTimeModel>().Model;
+
+		var package = model.FindEntityType(typeof(NpcSkillPackage));
+		var entry = model.FindEntityType(typeof(NpcSkillPackageSkill));
+		Assert.IsNotNull(package);
+		Assert.IsNotNull(entry);
+		Assert.IsTrue(package.GetIndexes().Single(x => x.Properties.Single().Name == nameof(NpcSkillPackage.Name)).IsUnique);
+		CollectionAssert.AreEquivalent(
+			new[] { nameof(NpcSkillPackageSkill.NpcSkillPackageId), nameof(NpcSkillPackageSkill.TraitDefinitionId) },
+			entry.FindPrimaryKey()!.Properties.Select(x => x.Name).ToArray());
+
+		var packageForeignKey = entry.GetForeignKeys().Single(x => x.PrincipalEntityType.ClrType == typeof(NpcSkillPackage));
+		var traitForeignKey = entry.GetForeignKeys().Single(x => x.PrincipalEntityType.ClrType == typeof(TraitDefinition));
+		Assert.AreEqual(DeleteBehavior.Cascade, packageForeignKey.DeleteBehavior);
+		Assert.AreEqual(DeleteBehavior.Restrict, traitForeignKey.DeleteBehavior);
+
+		var raceNavigation = model.FindEntityType(typeof(Race))!.FindSkipNavigation(nameof(Race.NpcSkillPackages));
+		Assert.IsNotNull(raceNavigation);
+		Assert.AreEqual(DeleteBehavior.Cascade, raceNavigation.ForeignKey.DeleteBehavior);
+		Assert.AreEqual(DeleteBehavior.Cascade, raceNavigation.Inverse.ForeignKey.DeleteBehavior);
+	}
+
+	[TestMethod]
+	public void Migration_CreatesPackageEntryAndRaceLinkTables()
+	{
+		var builder = new MigrationBuilder("MySql");
+		var migration = new AddNPCSkillPackages();
+		var up = migration.GetType().GetMethod("Up", BindingFlags.Instance | BindingFlags.NonPublic);
+		Assert.IsNotNull(up);
+		up.Invoke(migration, [builder]);
+
+		var tables = builder.Operations.OfType<CreateTableOperation>().ToDictionary(x => x.Name);
+		Assert.IsTrue(tables.ContainsKey("NPCSkillPackages"));
+		Assert.IsTrue(tables.ContainsKey("NPCSkillPackageSkills"));
+		Assert.IsTrue(tables.ContainsKey("Races_NPCSkillPackages"));
+		Assert.AreEqual(ReferentialAction.Cascade,
+			tables["NPCSkillPackageSkills"].ForeignKeys.Single(x => x.PrincipalTable == "NPCSkillPackages").OnDelete);
+		Assert.AreEqual(ReferentialAction.Restrict,
+			tables["NPCSkillPackageSkills"].ForeignKeys.Single(x => x.PrincipalTable == "TraitDefinitions").OnDelete);
+	}
+}

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContext.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContext.cs
@@ -357,6 +357,8 @@ namespace MudSharp.Database
         public virtual DbSet<NPCSpawnerCell> NpcSpawnerCells { get; set; }
         public virtual DbSet<NPCSpawnerZone> NpcSpawnerZones { get; set; }
         public virtual DbSet<NpcTemplate> NpcTemplates { get; set; }
+		public virtual DbSet<NpcSkillPackage> NpcSkillPackages { get; set; }
+		public virtual DbSet<NpcSkillPackageSkill> NpcSkillPackageSkills { get; set; }
         public virtual DbSet<NpcTemplatesArtificalIntelligences> NpctemplatesArtificalIntelligences { get; set; }
         public virtual DbSet<OutfitTemplate> OutfitTemplates { get; set; }
         public virtual DbSet<OutfitTemplateItem> OutfitTemplateItems { get; set; }

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextShopDeals.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextShopDeals.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using MudSharp.Models;
+using System.Collections.Generic;
 
 namespace MudSharp.Database
 {
@@ -7,6 +8,49 @@ namespace MudSharp.Database
     {
         partial void OnModelCreatingPartial(ModelBuilder modelBuilder)
         {
+			modelBuilder.Entity<NpcSkillPackage>(entity =>
+			{
+				entity.ToTable("NPCSkillPackages");
+				entity.HasKey(e => e.Id).HasName("PRIMARY");
+				entity.HasIndex(e => e.Name).IsUnique().HasDatabaseName("UX_NPCSkillPackages_Name");
+				entity.Property(e => e.Id).HasColumnType("bigint(20)");
+				entity.Property(e => e.Name).IsRequired().HasColumnType("varchar(200)")
+					.HasCharSet("utf8mb4").UseCollation("utf8mb4_unicode_ci");
+				entity.HasMany(e => e.Races)
+					.WithMany(e => e.NpcSkillPackages)
+					.UsingEntity<Dictionary<string, object>>(
+						"RacesNpcSkillPackages",
+						r => r.HasOne<Race>().WithMany().HasForeignKey("RaceId")
+							.OnDelete(DeleteBehavior.Cascade).HasConstraintName("FK_RacesNPCSkillPackages_Races"),
+						l => l.HasOne<NpcSkillPackage>().WithMany().HasForeignKey("NpcSkillPackageId")
+							.OnDelete(DeleteBehavior.Cascade).HasConstraintName("FK_RacesNPCSkillPackages_Packages"),
+						j =>
+						{
+							j.ToTable("Races_NPCSkillPackages");
+							j.HasKey("RaceId", "NpcSkillPackageId").HasName("PRIMARY");
+							j.IndexerProperty<long>("RaceId").HasColumnType("bigint(20)");
+							j.IndexerProperty<long>("NpcSkillPackageId").HasColumnType("bigint(20)");
+						});
+			});
+
+			modelBuilder.Entity<NpcSkillPackageSkill>(entity =>
+			{
+				entity.ToTable("NPCSkillPackageSkills");
+				entity.HasKey(e => new { e.NpcSkillPackageId, e.TraitDefinitionId }).HasName("PRIMARY");
+				entity.HasIndex(e => e.TraitDefinitionId).HasDatabaseName("FK_NPCSkillPackageSkills_Traits_idx");
+				entity.Property(e => e.NpcSkillPackageId).HasColumnType("bigint(20)");
+				entity.Property(e => e.TraitDefinitionId).HasColumnType("bigint(20)");
+				entity.Property(e => e.Chance).HasColumnType("double");
+				entity.Property(e => e.Mean).HasColumnType("double");
+				entity.Property(e => e.StandardDeviation).HasColumnType("double");
+				entity.Property(e => e.Skewness).HasColumnType("double");
+				entity.HasOne(e => e.NpcSkillPackage).WithMany(e => e.Skills)
+					.HasForeignKey(e => e.NpcSkillPackageId).OnDelete(DeleteBehavior.Cascade)
+					.HasConstraintName("FK_NPCSkillPackageSkills_Packages");
+				entity.HasOne(e => e.TraitDefinition).WithMany(e => e.NpcSkillPackageSkills)
+					.HasForeignKey(e => e.TraitDefinitionId).OnDelete(DeleteBehavior.Restrict)
+					.HasConstraintName("FK_NPCSkillPackageSkills_Traits");
+			});
             ConfigureCharacterComputerWorkspace(modelBuilder);
             ConfigureComputerMail(modelBuilder);
             ConfigureStables(modelBuilder);

--- a/MudsharpDatabaseLibrary/Migrations/20260828014622_AddNPCSkillPackages.Designer.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260828014622_AddNPCSkillPackages.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MudSharp.Database;
 
@@ -11,9 +12,11 @@ using MudSharp.Database;
 namespace MudSharp.Migrations
 {
     [DbContext(typeof(FuturemudDatabaseContext))]
-    partial class FutureMUDContextModelSnapshot : ModelSnapshot
+    [Migration("20260828014622_AddNPCSkillPackages")]
+    partial class AddNPCSkillPackages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MudsharpDatabaseLibrary/Migrations/20260828014622_AddNPCSkillPackages.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260828014622_AddNPCSkillPackages.cs
@@ -1,0 +1,113 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MudSharp.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNPCSkillPackages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "NPCSkillPackages",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint(20)", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    Name = table.Column<string>(type: "varchar(200)", nullable: false, collation: "utf8mb4_unicode_ci")
+                        .Annotation("MySql:CharSet", "utf8mb4")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PRIMARY", x => x.Id);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "NPCSkillPackageSkills",
+                columns: table => new
+                {
+                    NpcSkillPackageId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    TraitDefinitionId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    Chance = table.Column<double>(type: "double", nullable: false),
+                    Mean = table.Column<double>(type: "double", nullable: false),
+                    StandardDeviation = table.Column<double>(type: "double", nullable: false),
+                    Skewness = table.Column<double>(type: "double", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PRIMARY", x => new { x.NpcSkillPackageId, x.TraitDefinitionId });
+                    table.ForeignKey(
+                        name: "FK_NPCSkillPackageSkills_Packages",
+                        column: x => x.NpcSkillPackageId,
+                        principalTable: "NPCSkillPackages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_NPCSkillPackageSkills_Traits",
+                        column: x => x.TraitDefinitionId,
+                        principalTable: "TraitDefinitions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "Races_NPCSkillPackages",
+                columns: table => new
+                {
+                    RaceId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    NpcSkillPackageId = table.Column<long>(type: "bigint(20)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PRIMARY", x => new { x.RaceId, x.NpcSkillPackageId });
+                    table.ForeignKey(
+                        name: "FK_RacesNPCSkillPackages_Packages",
+                        column: x => x.NpcSkillPackageId,
+                        principalTable: "NPCSkillPackages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_RacesNPCSkillPackages_Races",
+                        column: x => x.RaceId,
+                        principalTable: "Races",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_NPCSkillPackages_Name",
+                table: "NPCSkillPackages",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "FK_NPCSkillPackageSkills_Traits_idx",
+                table: "NPCSkillPackageSkills",
+                column: "TraitDefinitionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Races_NPCSkillPackages_NpcSkillPackageId",
+                table: "Races_NPCSkillPackages",
+                column: "NpcSkillPackageId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "NPCSkillPackageSkills");
+
+            migrationBuilder.DropTable(
+                name: "Races_NPCSkillPackages");
+
+            migrationBuilder.DropTable(
+                name: "NPCSkillPackages");
+        }
+    }
+}

--- a/MudsharpDatabaseLibrary/Models/NpcSkillPackage.cs
+++ b/MudsharpDatabaseLibrary/Models/NpcSkillPackage.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace MudSharp.Models;
+
+public partial class NpcSkillPackage
+{
+	public NpcSkillPackage()
+	{
+		Skills = new HashSet<NpcSkillPackageSkill>();
+		Races = new HashSet<Race>();
+	}
+
+	public long Id { get; set; }
+	public string Name { get; set; }
+
+	public virtual ICollection<NpcSkillPackageSkill> Skills { get; set; }
+	public virtual ICollection<Race> Races { get; set; }
+}

--- a/MudsharpDatabaseLibrary/Models/NpcSkillPackageSkill.cs
+++ b/MudsharpDatabaseLibrary/Models/NpcSkillPackageSkill.cs
@@ -1,0 +1,14 @@
+namespace MudSharp.Models;
+
+public partial class NpcSkillPackageSkill
+{
+	public long NpcSkillPackageId { get; set; }
+	public long TraitDefinitionId { get; set; }
+	public double Chance { get; set; }
+	public double Mean { get; set; }
+	public double StandardDeviation { get; set; }
+	public double Skewness { get; set; }
+
+	public virtual NpcSkillPackage NpcSkillPackage { get; set; }
+	public virtual TraitDefinition TraitDefinition { get; set; }
+}

--- a/MudsharpDatabaseLibrary/Models/Race.cs
+++ b/MudsharpDatabaseLibrary/Models/Race.cs
@@ -21,6 +21,7 @@ namespace MudSharp.Models
             RacesEdibleMaterials = new HashSet<RacesEdibleMaterials>();
             RacesWeaponAttacks = new HashSet<RacesWeaponAttacks>();
             RacesCombatActions = new HashSet<RacesCombatActions>();
+			NpcSkillPackages = new HashSet<NpcSkillPackage>();
         }
 
         public long Id { get; set; }
@@ -127,5 +128,6 @@ namespace MudSharp.Models
         public virtual ICollection<RacesEdibleMaterials> RacesEdibleMaterials { get; set; }
         public virtual ICollection<RacesWeaponAttacks> RacesWeaponAttacks { get; set; }
         public virtual ICollection<RacesCombatActions> RacesCombatActions { get; set; }
+		public virtual ICollection<NpcSkillPackage> NpcSkillPackages { get; set; }
     }
 }

--- a/MudsharpDatabaseLibrary/Models/TraitDefinition.cs
+++ b/MudsharpDatabaseLibrary/Models/TraitDefinition.cs
@@ -22,6 +22,7 @@ namespace MudSharp.Models
             WeaponTypesAttackTrait = new HashSet<WeaponType>();
             WeaponTypesParryTrait = new HashSet<WeaponType>();
             WearableSizeParameterRule = new HashSet<WearableSizeParameterRule>();
+			NpcSkillPackageSkills = new HashSet<NpcSkillPackageSkill>();
         }
 
         public long Id { get; set; }
@@ -67,5 +68,6 @@ namespace MudSharp.Models
         public virtual ICollection<WeaponType> WeaponTypesAttackTrait { get; set; }
         public virtual ICollection<WeaponType> WeaponTypesParryTrait { get; set; }
         public virtual ICollection<WearableSizeParameterRule> WearableSizeParameterRule { get; set; }
+		public virtual ICollection<NpcSkillPackageSkill> NpcSkillPackageSkills { get; set; }
     }
 }


### PR DESCRIPTION
Implements persistent NPC Skill Packages with builder workflows, simple and variable template application, race defaults, FutureProg support, skew-aware distributions, EF persistence and migration, seeders, documentation, and regression tests. Validation: MudSharpCore 2,529 passed; DatabaseSeeder 727 passed; focused package tests passed; git diff --check clean.