### PR TITLE
Fix skill package combat skill seeding

### DIFF
--- a/DatabaseSeeder Unit Tests/SkillPackageSeederTests.cs
+++ b/DatabaseSeeder Unit Tests/SkillPackageSeederTests.cs
@@ -60,6 +60,17 @@ public class SkillPackageSeederTests
 	}
 
 	[TestMethod]
+	public void ComplexSkillPackage_IncludesUniversalCombatSkills()
+	{
+		var names = new SkillPackageSeeder().ComplexNonGerundSkillNamesForTesting;
+
+		foreach (var name in new[] { "Block", "Dodge", "Brawling", "Subdue", "Ward", "Throwing", "Gunnery", "Seafaring", "Veterancy" })
+		{
+			CollectionAssert.Contains(names.ToList(), name);
+		}
+	}
+
+	[TestMethod]
 	public void SkillPackageChecks_MountSprawlUsesRidingAndBalance()
 	{
 		string source = SeederSourceTestHelper.ReadSeederSource("SkillPackageSeeder.cs");

--- a/DatabaseSeeder/Seeders/SkillPackageSeeder.cs
+++ b/DatabaseSeeder/Seeders/SkillPackageSeeder.cs
@@ -268,6 +268,20 @@ Please choose either #6simple#0 or #6complex#0: ", (context, answers) => true,
                 @"The $0 skill covers the use of blowguns and other breath-fired dart weapons. It is primarily a precision skill for very close ranged shots.")
         };
 
+    private IEnumerable<SkillDetails> UniversalCombatSkills =>
+        new[]
+        {
+            new SkillDetails("Blocking", "Block", "Combat", "min(99,2*str + 3*agi)", "General", "General", true, 1.0),
+            new SkillDetails("Dodging", "Dodge", "Combat", "min(99,2*str + 3*agi)", "General", "General", true, 1.0),
+            new SkillDetails("Brawling", "Brawling", "Combat", "min(99,2*str + 3*agi)", "General", "General", true, 1.0),
+            new SkillDetails("Wrestling", "Subdue", "Combat", "min(99,2*str + 3*agi)", "General", "General", true, 1.0),
+            new SkillDetails("Warding", "Ward", "Combat", "min(99,2*str + 3*agi)", "General", "General", true, 1.0),
+            new SkillDetails("Throwing", "Throwing", "Combat", "min(99,2*str + 3*agi)", "General", "General", true, 1.0),
+            new SkillDetails("Gunnery", "Gunnery", "Combat", "min(99,2*str + 3*agi)", "General", "General", true, 1.0),
+            new SkillDetails("Seafaring", "Seafaring", "Combat", "min(99,2*str + 3*agi)", "General", "General", true, 1.0),
+            new SkillDetails("Veterancy", "Veterancy", "Combat", "min(99,2*str + 3*agi)", "Veterancy", "General", true, 1.0)
+        };
+
     private IEnumerable<SkillDetails> UniversalCraftSkills =>
         new[]
         {
@@ -511,6 +525,7 @@ Please choose either #6simple#0 or #6complex#0: ", (context, answers) => true,
             .Concat(FunctionalCraftSkills)
             .Concat(UniversalProfessionalSkills)
             .Concat(RangedCombatSkills)
+            .Concat(UniversalCombatSkills)
             .Concat(RpiLegacySkills)
             .Select(x => x.ImperativeName)
             .ToArray();
@@ -601,6 +616,15 @@ Please choose either #6simple#0 or #6complex#0: ", (context, answers) => true,
                 {
                     return skill;
                 }
+
+                TraitDefinition? existingSkill = context.TraitDefinitions
+                    .Where(x => x.Type == 0)
+                    .AsEnumerable()
+                    .FirstOrDefault(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+                if (existingSkill is not null)
+                {
+                    return existingSkill;
+                }
             }
 
             throw new InvalidOperationException($"None of the expected seeded skill traits exist: {string.Join(", ", names)}.");
@@ -633,7 +657,7 @@ Please choose either #6simple#0 or #6complex#0: ", (context, answers) => true,
 		TraitDefinition ridingTrait = GetSkill("Riding", "Ride", "Athletics");
 		TraitDefinition drivingTrait = GetSkill("Driving", "Drive", "Riding", "Athletics");
 		TraitDefinition seafaringTrait = GetSkill("Seafaring", "Sailing", "Survival");
-		TraitDefinition veterancyTrait = GetSkill("Veterancy", "Melee", "Athletics");
+		TraitDefinition veterancyTrait = GetSkill("Veterancy", "Melee", "Athletics", "Balance", "Balancing", "Run", "Running");
 		TraitDefinition poisonTrait = GetSkill("Poisoning", "Chemistry", "Herbalism", "Medicine");
         TraitDefinition? lawTrait = skills.GetValueOrDefault("Law");
 
@@ -1517,6 +1541,7 @@ Please choose either #6simple#0 or #6complex#0: ", (context, answers) => true,
                          .Concat(FunctionalCraftSkills)
                          .Concat(UniversalProfessionalSkills)
                          .Concat(RangedCombatSkills)
+                         .Concat(UniversalCombatSkills)
                     )
             {
                 AddSkill(skill);
@@ -1533,6 +1558,7 @@ Please choose either #6simple#0 or #6complex#0: ", (context, answers) => true,
                          .Concat(FunctionalCraftSkills)
                          .Concat(UniversalProfessionalSkills)
                          .Concat(RangedCombatSkills)
+                         .Concat(UniversalCombatSkills)
                     )
             {
                 AddSkill(skill);

--- a/Design Documents/Characters/NPC_Skill_Packages.md
+++ b/Design Documents/Characters/NPC_Skill_Packages.md
@@ -70,7 +70,7 @@ Use `applyskillpackage(character, package)` to roll a package for a live charact
 
 ## Seeder Ownership
 
-The existing `Skill Package` seeder owns `Universal Common` and resolves the installed simple, complex, or RPI utility-skill equivalents. The Combat seeder owns the five beast-attacker definitions. Animal, Mythical Animal, and Supernatural seeders own capability definitions and additive links from their stock races.
+The existing `Skill Package` seeder owns `Universal Common` and resolves the installed simple, complex, or RPI utility-skill equivalents. It also seeds the universally-required combat traits (block, dodge, brawling, subdue/wrestling, ward, throwing, gunnery, seafaring, and veterancy) so its check definitions do not depend on a later seeder. The Combat seeder still ensures those traits are present when combat content is installed and owns the five beast-attacker definitions. Animal, Mythical Animal, and Supernatural seeders own capability definitions and additive links from their stock races.
 
 Stock definitions are upserted by their reserved names. Seeder reruns repair their entries and add missing required race links. They do not delete custom packages or unrelated race links.
 


### PR DESCRIPTION
Fixes Skill Package seeding for fresh and existing installations. The seeder now owns the always-present combat traits needed by its own checks, resolves persisted Combat skills for reruns, and supports complex/RPI athletic fallbacks. Adds regression coverage and documents the ownership boundary. Validation: DatabaseSeeder tests 728 passed; DatabaseSeeder build succeeded; git diff --check clean.