### PR TITLE
Version update to Engine 2.9.0 and Database Seeder 3.3.0

### DIFF
--- a/DatabaseSeeder/BlankDatabaseSnapshot.manifest.json
+++ b/DatabaseSeeder/BlankDatabaseSnapshot.manifest.json
@@ -1,5 +1,5 @@
 {
-  "ProductVersion": "3.2.0.0",
+  "ProductVersion": "3.3.0.0",
   "LatestMigrationId": "20260828014622_AddNPCSkillPackages",
   "GeneratedUtc": "2026-08-28T02:04:52.8813995Z"
 }

--- a/DatabaseSeeder/DatabaseSeeder.csproj
+++ b/DatabaseSeeder/DatabaseSeeder.csproj
@@ -4,9 +4,9 @@
 	<OutputType>Exe</OutputType>
 	<TargetFramework>net10.0</TargetFramework>
 	<Nullable>enable</Nullable>
-	<Version>3.2.0</Version>
-	<AssemblyVersion>3.2.0</AssemblyVersion>
-	<FileVersion>3.2.0</FileVersion>
+	<Version>3.3.0</Version>
+	<AssemblyVersion>3.3.0</AssemblyVersion>
+	<FileVersion>3.3.0</FileVersion>
   </PropertyGroup>
 
 	<PropertyGroup>

--- a/FutureMUD.Web/Content/PatchNotes/2026-08-28-database-seeder-3-3-0.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-08-28-database-seeder-3-3-0.md
@@ -1,0 +1,27 @@
+---
+title: Database Seeder 3.3.0
+summary: Expands the stock world with reusable NPC skill packages, a modern combat catalogue and far broader terrain foundations, while making supported reruns more resilient.
+date: 2026-08-28
+tags: seeder, release, upgrade, content, npcs
+---
+**Upgrade note:** Database Seeder 3.3.0 targets .NET 10. Apply the normal database upgrades before seeding, and update to Engine 2.9.0 to use the accompanying runtime support.
+
+## More Capable NPC Foundations
+
+The stock catalogue now gives builders a practical starting point for the Engine's reusable NPC Skill Packages. Fresh worlds receive the combat traits and dependencies that package checks need, while established worlds can rerun the supported package content without losing the intended ownership boundaries. The profiles also account for the more complex physical and athletic combinations used by RPI-style characters, so a package can describe a believable role rather than merely a flat list of skills.
+
+## From Bowstrings To Breech Loaders
+
+The combat catalogue has been widened and rebalanced as a coherent toolkit. It now includes fourteen modern firearm archetypes alongside breech-loading howitzers and mortars, ammunition, explosives, modern armour, attachments and cover. Builders have a much more useful set of examples for a modern or mixed-era world, while the updated primitive and melee foundations keep the catalogue internally consistent.
+
+## Terrain That Describes More Worlds
+
+The stock terrain catalogue now reaches beyond ordinary outdoor ground. It includes vehicle, ship and spaceship settings, global and extraterrestrial biomes, and supernatural spaces such as astral, fae, shadow, celestial, infernal and dream terrain. The existing terrain entries were also reviewed for presentation colour, editor colour and code, movement, stamina, concealment, tracking and behavioural metadata, so the expanded choices read and behave like a maintained catalogue rather than a loose collection of labels.
+
+## Safer Supported Reruns
+
+Several foundational reconciliation paths now handle their real-world edge cases more carefully. Core material tags resolve through their intended hierarchy, stock terrain atmospheres can be repaired without conflicting database readers, and skill-package checks resolve the persisted skills already present in an established world. These improvements keep supported reruns additive and predictable without recreating canonical tags or overwriting unrelated builder content.
+
+The bundled blank database snapshot is current through `20260828014622_AddNPCSkillPackages`, so a new installation begins from the same schema baseline as this release and safely falls back to normal migrations whenever that baseline is not applicable.
+
+Use [/downloads](/downloads) for release archives and checksums, and [/getting-started](/getting-started) for installation requirements.

--- a/FutureMUD.Web/Content/PatchNotes/2026-08-28-engine-2-9-0.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-08-28-engine-2-9-0.md
@@ -1,0 +1,25 @@
+---
+title: FutureMUD Engine 2.9.0
+summary: Gives builders safer bulk rename tools, adds reusable NPC skill packages, and makes ranged, artillery and explosive combat more dependable and expressive.
+date: 2026-08-28
+tags: engine, release, builders, combat, npcs
+---
+**Upgrade note:** Apply the normal database upgrades before starting Engine 2.9.0. This release adds persistent NPC Skill Packages and ranged-weapon firing-position data. If you use the supplied catalogue, update to Database Seeder 3.3.0 at the same time.
+
+## Safer Content Renames
+
+Routine builder clean-up no longer has to be a careful sequence of one-at-a-time edits. The shared rename workflow can now prepare a complete rename plan, verify every target name and collision in its proper scope, and make the change only when the whole plan is safe. That includes chains and swaps, so a partially applied rename cannot leave a family of builder content in an awkward in-between state.
+
+The established `renameunique` behaviour remains available for the distinct unique-name workflow. The new protection applies across the standard editable-item surfaces, including the builder paths that need the same validation when names are changed manually.
+
+## NPC Skill Packages
+
+NPC skills can now be authored as reusable packages rather than rebuilt independently for every template. Builders can create named profiles, apply them to simple and variable NPC templates, establish race defaults, and use the new FutureProg support where automation is useful. Packages support weighted and skew-aware skill distributions, which makes it practical to express an NPC population with a credible range of competence instead of a row of identical stat blocks.
+
+## A More Reliable Ranged Fight
+
+The ranged-combat pass brings aiming, cover, stamina, firing posture and weapon handling into closer agreement from the first shot through the final effect. Ranged weapon types can now declare a minimum firing position, helping builders prevent a weapon from being used in a posture that does not make sense for it.
+
+Firearms, artillery, projectile impacts, explosives and physical traps have also received a broad reliability and balance pass. The result is a more dependable set of outcomes across primitive and modern ranged weapons, breech-loading guns and explosive hazards, with troublesome loading, detonation, cover and chained-effect edge cases addressed along the way.
+
+Use [/downloads](/downloads) for release archives and checksums, [/getting-started](/getting-started) for installation requirements, and [/docs/commands](/docs/commands) for the published Engine reference.

--- a/MudSharpCore/MudSharpCore.csproj
+++ b/MudSharpCore/MudSharpCore.csproj
@@ -10,9 +10,9 @@
 	<Product>FutureMUD</Product>
 	<ApplicationIcon>FM Logo.ico</ApplicationIcon>
 	<AssemblyName>MudSharp</AssemblyName>
-	<Version>2.8.0</Version>
-	<AssemblyVersion>2.8.0</AssemblyVersion>
-	<FileVersion>2.8.0</FileVersion>
+	<Version>2.9.0</Version>
+	<AssemblyVersion>2.9.0</AssemblyVersion>
+	<FileVersion>2.9.0</FileVersion>
   </PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
## Summary

- Prepares FutureMUD Engine 2.9.0 and Database Seeder 3.3.0 for publication.
- Adds separate narrative website patch notes focused on safe bulk renames, reusable NPC skill packages, ranged combat, modern stock combat content, terrain coverage and reliable reruns.
- Keeps the current blank-database migration baseline and updates its Seeder product version.

## Validation

- Engine Release tests: 2,529 passed.
- Database Seeder Release tests: 730 passed.
- Website Release tests: 54 passed.
- Representative Engine and Seeder win-x64 single-file packages published locally.
- Engine documentation export completed against the full release-preparation commit.