### PR TITLE
Add Debug DatabaseSeeder replay profiles

### DIFF
--- a/.codex/skills/futuremud-database-seeder/SKILL.md
+++ b/.codex/skills/futuremud-database-seeder/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: futuremud-database-seeder
+description: "Use when changing FutureMUD DatabaseSeeder workflows, enabled-seeder dependency/order metadata, question contracts, or Debug replay profiles. Do not use for content-only seeder catalogue maintenance without a workflow or replay-profile change."
+---
+
+# FutureMUD Database Seeder
+
+Use this skill for DatabaseSeeder behavior and repeatability work, especially the Debug-only replay profiles. It is intentionally narrower than a seeded-catalogue audit: do not use it for content-only item, material, tag, terrain, or stock-data refreshes unless they also change the seeder workflow or replay-profile contract.
+
+## Read first
+
+1. Read `DatabaseSeeder/AGENTS.md` and the relevant seeders before changing the workflow.
+2. Read `Design Documents/Seeding/DatabaseSeeder_Repeatability_Strategy.md` for the repeatability model and replay-profile contract.
+3. Identify the live `IDatabaseSeeder` metadata, dependency plan, `SeederQuestion` declarations, filters, validators, defaults, and shared-answer behavior that the change affects.
+
+## Debug replay profiles
+
+The Debug-only profiles in `DatabaseSeeder/DebugSeederReplay.cs` are strict, typed inventories. They must:
+
+- use concrete seeder types, never a menu number or display name;
+- include every currently enabled seeder exactly once in dependency-plan order;
+- intentionally exclude only the mutually exclusive `SkillSeeder` alternative and include `SkillPackageSeeder`;
+- contain every declared question ID for every included seeder, including conditionally inactive questions;
+- keep the Medieval, Renaissance, and Early Modern profiles cumulative and deterministic.
+
+Whenever an enabled seeder, dependency/order declaration, question ID, filter, validator, default, or recommended answer changes, review every replay profile. Update profile answers deliberately; do not make a drift failure disappear by silently using an interactive default. Keep the Debug credential warning and fresh-local-database restriction intact.
+
+## Implementation rules
+
+- Keep replay types and menu paths inside `#if DEBUG`; Release behavior must retain the normal connection-string prompt and must not expose replay surfaces.
+- Both interactive and replay paths must use the shared executor for seeder execution, answer persistence, and exception handling.
+- Replay is for a freshly migrated, unseeded development database. Refuse nonblank targets; never reset or overwrite them.
+- Re-evaluate question filters and validators against the live context before each seeder. Ignore inventory answers for inactive questions, but fail before execution if an active answer is absent or invalid.
+- Preserve commits from completed seeders. Stop at the first blocked prerequisite or exception and report completed, failed, and unstarted steps rather than attempting a misleading cross-seeder rollback.
+
+## Required verification
+
+For any DatabaseSeeder workflow or replay-profile change, run these gates:
+
+1. Focused `SeederReplayTests` while iterating; it is required whenever the replay contract may drift.
+2. `dotnet build DatabaseSeeder/DatabaseSeeder.csproj -c Debug --no-restore -m:1` and the corresponding Release build, confirming replay is Debug-only.
+3. `dotnet test 'DatabaseSeeder Unit Tests/DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1`.
+4. `git diff --check`.
+
+When a local MySQL development server is available, exercise a profile against a uniquely named disposable database and confirm a second replay attempt is refused without mutation. Do not point a replay profile at a reachable or production database.

--- a/.codex/skills/futuremud-database-seeder/agents/openai.yaml
+++ b/.codex/skills/futuremud-database-seeder/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "FutureMUD Database Seeder"
+  short_description: "Maintain FutureMUD seeder replay workflows"
+  default_prompt: "Use $futuremud-database-seeder to maintain a FutureMUD DatabaseSeeder workflow or Debug replay profile."

--- a/DatabaseSeeder Unit Tests/ModernFirearmSeederTests.cs
+++ b/DatabaseSeeder Unit Tests/ModernFirearmSeederTests.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace MudSharp_Unit_Tests;
 
@@ -13,6 +14,14 @@ public class ModernFirearmSeederTests
 		var source = SeederSourceTestHelper.ReadPartialFamily("CombatSeeder");
 
 		StringAssert.Contains(source, "EnsureModernFirearmSamples(context)");
+		StringAssert.Contains(source, "EnsureTag(\"Artillery Tools\", toolsTag)");
+		StringAssert.Contains(source, "EnsureTag(\"Artillery Linstock\", artilleryToolsTag)");
+		StringAssert.Contains(source, "EnsureTag(\"Artillery Rammer\", artilleryToolsTag)");
+		StringAssert.Contains(source, "EnsureTag(\"Artillery Wadding\", materialFunctionsTag)");
+		var combatSeeder = SeederSourceTestHelper.ReadSeederSource("CombatSeeder.cs");
+		Assert.IsTrue(combatSeeder.IndexOf("SeedArmourTypes(context, effectiveAnswers);", StringComparison.Ordinal) <
+		              combatSeeder.IndexOf("EnsureModernFirearmSamples(context);", StringComparison.Ordinal),
+			"Modern firearm samples require the ballistic armour components created by SeedArmourTypes.");
 		StringAssert.Contains(source, "\"Shotgun_12_Gauge_Pump\"");
 		StringAssert.Contains(source, "\"Rifle_556_Select_Fire\"");
 		StringAssert.Contains(source, "\"Pistol_9mm_Service\"");

--- a/DatabaseSeeder Unit Tests/SeederReplayTests.cs
+++ b/DatabaseSeeder Unit Tests/SeederReplayTests.cs
@@ -1,0 +1,549 @@
+#if DEBUG
+#nullable enable
+
+using DatabaseSeeder;
+using DatabaseSeeder.Seeders;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MySql.Data.MySqlClient;
+using MudSharp.Database;
+using MudSharp.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class SeederReplayTests
+{
+	[TestMethod]
+	public void StandardProfiles_AreCompleteAndMatchTheCurrentDependencyPlan()
+	{
+		IReadOnlyList<IDatabaseSeeder> seeders = SeederCatalogue.GetEnabledSeeders();
+		Assert.IsTrue(seeders.Any(x => x.GetType() == typeof(SkillSeeder)));
+		Assert.IsTrue(((IDatabaseSeeder)new UsefulSeeder()).Metadata.RequiredSeederTypes.Contains(typeof(HumanSeeder)));
+		Assert.IsTrue(((IDatabaseSeeder)new AnimalSeeder()).Metadata.RequiredSeederTypes.Contains(typeof(CultureSeeder)));
+
+		foreach (SeederReplayProfile profile in DebugSeederReplayProfiles.All)
+		{
+			SeederReplayValidationResult validation = SeederReplayRunner.Validate(profile, seeders);
+			Assert.IsTrue(validation.IsValid,
+				$"{profile.Id}:{Environment.NewLine}{string.Join(Environment.NewLine, validation.Errors)}");
+			Assert.IsFalse(profile.Steps.Any(x => x.SeederType == typeof(SkillSeeder)));
+			Assert.IsTrue(profile.Steps.Any(x => x.SeederType == typeof(SkillPackageSeeder)));
+			var profileSteps = profile.Steps.ToList();
+			Assert.IsTrue(profileSteps.FindIndex(x => x.SeederType == typeof(SkillPackageSeeder)) <
+			              profileSteps.FindIndex(x => x.SeederType == typeof(TrapSeeder)));
+		}
+	}
+
+	[TestMethod]
+	public void ProfileValidation_RejectsOrderAndQuestionInventoryDrift()
+	{
+		SeederReplayProfile profile = DebugSeederReplayProfiles.All.First();
+		IReadOnlyList<IDatabaseSeeder> seeders = SeederCatalogue.GetEnabledSeeders();
+		var reorderedSteps = profile.Steps.ToList();
+		(reorderedSteps[0], reorderedSteps[1]) = (reorderedSteps[1], reorderedSteps[0]);
+		SeederReplayValidationResult reorderedValidation = SeederReplayRunner.Validate(
+			profile with { Steps = reorderedSteps }, seeders);
+		Assert.IsFalse(reorderedValidation.IsValid);
+		Assert.IsTrue(reorderedValidation.Errors.Any(x => x.Contains("order", StringComparison.OrdinalIgnoreCase)));
+
+		SeederReplayStep coreStep = profile.Steps.First(x => x.SeederType.Name == "CoreDataSeeder");
+		SeederReplayStep missingAnswerStep = coreStep with
+		{
+			Answers = coreStep.Answers.Where(x => x.Id != "password").ToList()
+		};
+		var missingAnswerSteps = profile.Steps
+			.Select(x => x == coreStep ? missingAnswerStep : x)
+			.ToList();
+		SeederReplayValidationResult missingAnswerValidation = SeederReplayRunner.Validate(
+			profile with { Steps = missingAnswerSteps }, seeders);
+		Assert.IsFalse(missingAnswerValidation.IsValid);
+		Assert.IsTrue(missingAnswerValidation.Errors.Any(x => x.Contains("password", StringComparison.OrdinalIgnoreCase)));
+
+		SeederReplayStep extraAnswerStep = coreStep with
+		{
+			Answers = [.. coreStep.Answers, new SeederReplayAnswer("removed-question", "yes")]
+		};
+		var extraAnswerSteps = profile.Steps
+			.Select(x => x == coreStep ? extraAnswerStep : x)
+			.ToList();
+		SeederReplayValidationResult extraAnswerValidation = SeederReplayRunner.Validate(
+			profile with { Steps = extraAnswerSteps }, seeders);
+		Assert.IsFalse(extraAnswerValidation.IsValid);
+		Assert.IsTrue(extraAnswerValidation.Errors.Any(x => x.Contains("removed-question", StringComparison.OrdinalIgnoreCase)));
+
+		SeederReplayValidationResult duplicateValidation = SeederReplayRunner.Validate(profile with
+		{
+			Steps = [.. profile.Steps, profile.Steps.First()]
+		}, seeders);
+		Assert.IsFalse(duplicateValidation.IsValid);
+		Assert.IsTrue(duplicateValidation.Errors.Any(x => x.Contains("duplicate", StringComparison.OrdinalIgnoreCase)));
+
+		SeederReplayValidationResult removedSeederValidation = SeederReplayRunner.Validate(profile with
+		{
+			Steps = profile.Steps.Skip(1).ToList()
+		}, seeders);
+		Assert.IsFalse(removedSeederValidation.IsValid);
+		Assert.IsTrue(removedSeederValidation.Errors.Any(x => x.Contains("missing enabled", StringComparison.OrdinalIgnoreCase)));
+	}
+
+	[TestMethod]
+	public void ReplayProfiles_CoreBootstrapAnswersRemainValid()
+	{
+		foreach (SeederReplayProfile profile in DebugSeederReplayProfiles.All)
+		{
+			var databaseName = Guid.NewGuid().ToString("N");
+			DbContextOptions<FuturemudDatabaseContext> options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+				.UseInMemoryDatabase(databaseName)
+				.Options;
+			using var context = new FuturemudDatabaseContext(options);
+			SeederReplayStep step = profile.Steps.Single(x => x.SeederType == typeof(CoreDataSeeder));
+			var suppliedAnswers = step.Answers.ToDictionary(x => x.Id, x => x.Answer,
+				StringComparer.OrdinalIgnoreCase);
+			var priorAnswers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+			IDatabaseSeeder seeder = new CoreDataSeeder();
+			foreach (SeederQuestion question in seeder.Questions)
+			{
+				Assert.IsTrue(SeederQuestionWorkflow.IsActive(question, context, priorAnswers),
+					$"{profile.Id} unexpectedly hid {question.Id}.");
+				Assert.IsTrue(suppliedAnswers.TryGetValue(question.Id, out string? answer),
+					$"{profile.Id} is missing {question.Id}.");
+				SeederQuestionValidationResult answerValidation =
+					SeederQuestionWorkflow.Validate(question, answer, context);
+				Assert.IsTrue(answerValidation.Success,
+					$"{profile.Id} answer for {question.Id} is invalid: {answerValidation.Error}");
+				priorAnswers[question.Id] = answer;
+			}
+		}
+	}
+
+	[TestMethod]
+	public void DebugConnection_ChangesOnlyTheDatabaseProperty()
+	{
+		Assert.IsFalse(DebugSeederConnection.TryCreateConnectionString("   ", out _, out string error));
+		Assert.IsFalse(string.IsNullOrWhiteSpace(error));
+
+		Assert.IsTrue(DebugSeederConnection.TryCreateConnectionString("replay-database.test", out string connectionString,
+			out error), error);
+		var builder = new MySqlConnectionStringBuilder(connectionString);
+		var template = new MySqlConnectionStringBuilder(DebugSeederConnection.DefaultConnectionString);
+		Assert.AreEqual("replay-database.test", builder.Database);
+		Assert.AreEqual(template.Server, builder.Server);
+		Assert.AreEqual(template.Port, builder.Port);
+		Assert.AreEqual(template.UserID, builder.UserID);
+		Assert.AreEqual(template.Password, builder.Password);
+		Assert.AreEqual(template.SslMode, builder.SslMode);
+		Assert.AreEqual(template.AllowPublicKeyRetrieval, builder.AllowPublicKeyRetrieval);
+		Assert.AreEqual(template.DefaultCommandTimeout, builder.DefaultCommandTimeout);
+
+		Assert.IsTrue(DebugSeederConnection.TryCreateConnectionString("replay;database=test", out connectionString,
+			out error), error);
+		builder = new MySqlConnectionStringBuilder(connectionString);
+		Assert.AreEqual("replay;database=test", builder.Database);
+		Assert.AreEqual("localhost", builder.Server);
+	}
+
+	[TestMethod]
+	public void ReplayRunner_PersistsCompletedStepAndStopsAfterSeederFailure()
+	{
+		SuccessfulReplaySeeder.Reset();
+		FailingReplaySeeder.Reset();
+		LaterReplaySeeder.Reset();
+		var databaseName = Guid.NewGuid().ToString("N");
+		DbContextOptions<FuturemudDatabaseContext> options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseInMemoryDatabase(databaseName)
+			.Options;
+		FuturemudDatabaseContext CreateContext() => new(options);
+
+		var successfulSeeder = new SuccessfulReplaySeeder();
+		var failingSeeder = new FailingReplaySeeder();
+		var profile = new SeederReplayProfile("test", "Test", "Test profile",
+		[
+			new SeederReplayStep(typeof(SuccessfulReplaySeeder), [new SeederReplayAnswer("answer", "ok")]),
+			new SeederReplayStep(typeof(FailingReplaySeeder), []),
+			new SeederReplayStep(typeof(LaterReplaySeeder), [])
+		]);
+
+		SeederReplayRunResult result = SeederReplayRunner.Run(
+			profile,
+			[successfulSeeder, failingSeeder, new LaterReplaySeeder()],
+			CreateContext,
+			new Version(1, 0, 0));
+
+		Assert.IsFalse(result.Success);
+		Assert.AreEqual(1, result.CompletedSeeders.Count);
+		Assert.AreEqual(1, SuccessfulReplaySeeder.RunCount);
+		Assert.AreEqual(1, FailingReplaySeeder.RunCount);
+		Assert.IsNotNull(result.Exception);
+		Assert.AreEqual(failingSeeder.Name, result.FailedSeeder);
+		Assert.AreEqual(0, LaterReplaySeeder.RunCount);
+		CollectionAssert.AreEqual(new[] { nameof(LaterReplaySeeder) }, result.UnstartedSeeders.ToList());
+		using FuturemudDatabaseContext verificationContext = CreateContext();
+		Assert.IsTrue(verificationContext.SeederChoices.Any(x =>
+			x.Seeder == successfulSeeder.Name && x.Choice == "answer" && x.Answer == "ok"));
+	}
+
+	[TestMethod]
+	public void ReplayRunner_RejectsInvalidActiveAnswerBeforeExecutingSeeder()
+	{
+		SuccessfulReplaySeeder.Reset();
+		var databaseName = Guid.NewGuid().ToString("N");
+		DbContextOptions<FuturemudDatabaseContext> options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseInMemoryDatabase(databaseName)
+			.Options;
+		FuturemudDatabaseContext CreateContext() => new(options);
+		var seeder = new SuccessfulReplaySeeder();
+		var profile = new SeederReplayProfile("invalid", "Invalid", "Invalid answer profile",
+		[
+			new SeederReplayStep(typeof(SuccessfulReplaySeeder), [new SeederReplayAnswer("answer", "invalid")])
+		]);
+
+		SeederReplayRunResult result = SeederReplayRunner.Run(profile, [seeder], CreateContext, new Version(1, 0, 0));
+
+		Assert.IsFalse(result.Success);
+		Assert.AreEqual(0, SuccessfulReplaySeeder.RunCount);
+		StringAssert.Contains(result.Failure!, "no longer valid");
+	}
+
+	[TestMethod]
+	public void ReplayRunner_IgnoresInactiveInventoryAnswersAndStopsOnBlockedPrerequisites()
+	{
+		ConditionalReplaySeeder.Reset();
+		LaterReplaySeeder.Reset();
+		var databaseName = Guid.NewGuid().ToString("N");
+		DbContextOptions<FuturemudDatabaseContext> options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseInMemoryDatabase(databaseName)
+			.Options;
+		FuturemudDatabaseContext CreateContext() => new(options);
+		var conditionalSeeder = new ConditionalReplaySeeder();
+		var blockedSeeder = new BlockedReplaySeeder();
+		var laterSeeder = new LaterReplaySeeder();
+		var profile = new SeederReplayProfile("conditional", "Conditional", "Conditional profile",
+		[
+			new SeederReplayStep(typeof(ConditionalReplaySeeder),
+			[
+				new SeederReplayAnswer("active", "ok"),
+				new SeederReplayAnswer("inactive", "intentionally-invalid")
+			]),
+			new SeederReplayStep(typeof(BlockedReplaySeeder), []),
+			new SeederReplayStep(typeof(LaterReplaySeeder), [])
+		]);
+
+		SeederReplayRunResult result = SeederReplayRunner.Run(profile,
+			[conditionalSeeder, blockedSeeder, laterSeeder], CreateContext, new Version(1, 0, 0));
+
+		Assert.IsFalse(result.Success);
+		Assert.AreEqual(1, ConditionalReplaySeeder.RunCount);
+		Assert.AreEqual(0, LaterReplaySeeder.RunCount);
+		Assert.AreEqual(blockedSeeder.Name, result.FailedSeeder);
+		CollectionAssert.AreEqual(new[] { nameof(LaterReplaySeeder) }, result.UnstartedSeeders.ToList());
+	}
+
+	[TestMethod]
+	public void ReplayRunner_RefusesASeededDatabaseBeforeRunningTheFirstStep()
+	{
+		SuccessfulReplaySeeder.Reset();
+		var databaseName = Guid.NewGuid().ToString("N");
+		DbContextOptions<FuturemudDatabaseContext> options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseInMemoryDatabase(databaseName)
+			.Options;
+		FuturemudDatabaseContext CreateContext() => new(options);
+		using (FuturemudDatabaseContext seededContext = CreateContext())
+		{
+			seededContext.SeederChoices.Add(new SeederChoice
+			{
+				Version = "test",
+				Seeder = "Existing",
+				Choice = "choice",
+				Answer = "answer",
+				DateTime = DateTime.UtcNow
+			});
+			seededContext.SaveChanges();
+		}
+
+		var profile = new SeederReplayProfile("seeded", "Seeded", "Seeded profile",
+		[
+			new SeederReplayStep(typeof(SuccessfulReplaySeeder), [new SeederReplayAnswer("answer", "ok")])
+		]);
+		SeederReplayRunResult result = SeederReplayRunner.Run(
+			profile,
+			[new SuccessfulReplaySeeder()],
+			CreateContext,
+			new Version(1, 0, 0));
+
+		Assert.IsFalse(result.Success);
+		Assert.AreEqual(0, SuccessfulReplaySeeder.RunCount);
+		StringAssert.Contains(result.Failure!, "freshly migrated, unseeded");
+		using FuturemudDatabaseContext verificationContext = CreateContext();
+		Assert.AreEqual(1, verificationContext.SeederChoices.Count());
+	}
+
+	[TestMethod]
+	public void ProfileValidation_TracksEnabledSeederAndQuestionInventoryChanges()
+	{
+		SeederReplayProfile profile = DebugSeederReplayProfiles.All.First();
+		IReadOnlyList<IDatabaseSeeder> seeders = SeederCatalogue.GetEnabledSeeders();
+
+		SeederReplayValidationResult addedSeederValidation = SeederReplayRunner.Validate(
+			profile,
+			seeders.Append(new AddedReplaySeeder()));
+		Assert.IsFalse(addedSeederValidation.IsValid);
+		Assert.IsTrue(addedSeederValidation.Errors.Any(x => x.Contains(nameof(AddedReplaySeeder), StringComparison.Ordinal)));
+
+		SeederReplayValidationResult disabledSeederValidation = SeederReplayRunner.Validate(
+			profile,
+			seeders.Append(new DisabledReplaySeeder()));
+		Assert.IsTrue(disabledSeederValidation.IsValid,
+			string.Join(Environment.NewLine, disabledSeederValidation.Errors));
+
+		var changedQuestionProfile = new SeederReplayProfile("changed", "Changed", "Changed question inventory",
+		[
+			new SeederReplayStep(typeof(ChangedQuestionIdReplaySeeder),
+				[new SeederReplayAnswer("old-question", "ok")])
+		]);
+		SeederReplayValidationResult changedQuestionValidation = SeederReplayRunner.Validate(
+			changedQuestionProfile,
+			[new ChangedQuestionIdReplaySeeder()]);
+		Assert.IsFalse(changedQuestionValidation.IsValid);
+		Assert.IsTrue(changedQuestionValidation.Errors.Any(x => x.Contains("new-question", StringComparison.Ordinal)));
+		Assert.IsTrue(changedQuestionValidation.Errors.Any(x => x.Contains("old-question", StringComparison.Ordinal)));
+	}
+
+	private sealed class SuccessfulReplaySeeder : IDatabaseSeeder
+	{
+		internal static int RunCount { get; private set; }
+
+		public IEnumerable<(string Id, string Question,
+			Func<FuturemudDatabaseContext, IReadOnlyDictionary<string, string>, bool> Filter,
+			Func<string, FuturemudDatabaseContext, (bool Success, string error)> Validator)> SeederQuestions =>
+		[
+			("answer", "Answer", (_, _) => true,
+				(answer, _) => answer == "ok" ? (true, string.Empty) : (false, "Expected ok."))
+		];
+
+		public int SortOrder => 0;
+		public string Name => "Successful Replay Seeder";
+		public string Tagline => "Test";
+		public string FullDescription => "Test";
+
+		public string SeedData(FuturemudDatabaseContext context, IReadOnlyDictionary<string, string> questionAnswers)
+		{
+			RunCount++;
+			return "Completed";
+		}
+
+		public ShouldSeedResult ShouldSeedData(FuturemudDatabaseContext context)
+		{
+			return ShouldSeedResult.ReadyToInstall;
+		}
+
+		internal static void Reset()
+		{
+			RunCount = 0;
+		}
+	}
+
+	private sealed class FailingReplaySeeder : IDatabaseSeeder
+	{
+		internal static int RunCount { get; private set; }
+
+		public IEnumerable<(string Id, string Question,
+			Func<FuturemudDatabaseContext, IReadOnlyDictionary<string, string>, bool> Filter,
+			Func<string, FuturemudDatabaseContext, (bool Success, string error)> Validator)> SeederQuestions => [];
+
+		public int SortOrder => 1;
+		public string Name => "Failing Replay Seeder";
+		public string Tagline => "Test";
+		public string FullDescription => "Test";
+
+		public string SeedData(FuturemudDatabaseContext context, IReadOnlyDictionary<string, string> questionAnswers)
+		{
+			RunCount++;
+			throw new InvalidOperationException("Intentional replay failure.");
+		}
+
+		public ShouldSeedResult ShouldSeedData(FuturemudDatabaseContext context)
+		{
+			return ShouldSeedResult.ReadyToInstall;
+		}
+
+		internal static void Reset()
+		{
+			RunCount = 0;
+		}
+	}
+
+	private sealed class ConditionalReplaySeeder : IDatabaseSeeder
+	{
+		internal static int RunCount { get; private set; }
+
+		public IEnumerable<(string Id, string Question,
+			Func<FuturemudDatabaseContext, IReadOnlyDictionary<string, string>, bool> Filter,
+			Func<string, FuturemudDatabaseContext, (bool Success, string error)> Validator)> SeederQuestions =>
+		[
+			("active", "Active", (_, _) => true,
+				(answer, _) => answer == "ok" ? (true, string.Empty) : (false, "Expected ok.")),
+			("inactive", "Inactive", (_, _) => false,
+				(_, _) => (false, "This should not be validated."))
+		];
+
+		public int SortOrder => 0;
+		public string Name => "Conditional Replay Seeder";
+		public string Tagline => "Test";
+		public string FullDescription => "Test";
+
+		public string SeedData(FuturemudDatabaseContext context, IReadOnlyDictionary<string, string> questionAnswers)
+		{
+			RunCount++;
+			Assert.IsTrue(questionAnswers.ContainsKey("active"));
+			Assert.IsFalse(questionAnswers.ContainsKey("inactive"));
+			return "Completed";
+		}
+
+		public ShouldSeedResult ShouldSeedData(FuturemudDatabaseContext context)
+		{
+			return ShouldSeedResult.ReadyToInstall;
+		}
+
+		internal static void Reset()
+		{
+			RunCount = 0;
+		}
+	}
+
+	private sealed class BlockedReplaySeeder : IDatabaseSeeder
+	{
+		public IEnumerable<(string Id, string Question,
+			Func<FuturemudDatabaseContext, IReadOnlyDictionary<string, string>, bool> Filter,
+			Func<string, FuturemudDatabaseContext, (bool Success, string error)> Validator)> SeederQuestions => [];
+
+		public int SortOrder => 1;
+		public string Name => "Blocked Replay Seeder";
+		public string Tagline => "Test";
+		public string FullDescription => "Test";
+
+		public string SeedData(FuturemudDatabaseContext context, IReadOnlyDictionary<string, string> questionAnswers)
+		{
+			throw new AssertFailedException("A blocked replay seeder must not run.");
+		}
+
+		public ShouldSeedResult ShouldSeedData(FuturemudDatabaseContext context)
+		{
+			return ShouldSeedResult.PrerequisitesNotMet;
+		}
+
+		public SeederAssessment AssessSeedData(FuturemudDatabaseContext context)
+		{
+			return new SeederAssessment(
+				SeederAssessmentStatus.Blocked,
+				"Intentional test prerequisite block.",
+				["Test prerequisite"],
+				[],
+				[]);
+		}
+	}
+
+	private sealed class LaterReplaySeeder : IDatabaseSeeder
+	{
+		internal static int RunCount { get; private set; }
+
+		public IEnumerable<(string Id, string Question,
+			Func<FuturemudDatabaseContext, IReadOnlyDictionary<string, string>, bool> Filter,
+			Func<string, FuturemudDatabaseContext, (bool Success, string error)> Validator)> SeederQuestions => [];
+
+		public int SortOrder => 2;
+		public string Name => "Later Replay Seeder";
+		public string Tagline => "Test";
+		public string FullDescription => "Test";
+
+		public string SeedData(FuturemudDatabaseContext context, IReadOnlyDictionary<string, string> questionAnswers)
+		{
+			RunCount++;
+			return "Completed";
+		}
+
+		public ShouldSeedResult ShouldSeedData(FuturemudDatabaseContext context)
+		{
+			return ShouldSeedResult.ReadyToInstall;
+		}
+
+		internal static void Reset()
+		{
+			RunCount = 0;
+		}
+	}
+
+	private sealed class AddedReplaySeeder : IDatabaseSeeder
+	{
+		public IEnumerable<(string Id, string Question,
+			Func<FuturemudDatabaseContext, IReadOnlyDictionary<string, string>, bool> Filter,
+			Func<string, FuturemudDatabaseContext, (bool Success, string error)> Validator)> SeederQuestions => [];
+
+		public int SortOrder => int.MaxValue;
+		public string Name => "Added Replay Seeder";
+		public string Tagline => "Test";
+		public string FullDescription => "Test";
+
+		public string SeedData(FuturemudDatabaseContext context, IReadOnlyDictionary<string, string> questionAnswers)
+		{
+			return "Completed";
+		}
+
+		public ShouldSeedResult ShouldSeedData(FuturemudDatabaseContext context)
+		{
+			return ShouldSeedResult.ReadyToInstall;
+		}
+	}
+
+	private sealed class DisabledReplaySeeder : IDatabaseSeeder
+	{
+		public IEnumerable<(string Id, string Question,
+			Func<FuturemudDatabaseContext, IReadOnlyDictionary<string, string>, bool> Filter,
+			Func<string, FuturemudDatabaseContext, (bool Success, string error)> Validator)> SeederQuestions => [];
+
+		public int SortOrder => int.MaxValue;
+		public string Name => "Disabled Replay Seeder";
+		public string Tagline => "Test";
+		public string FullDescription => "Test";
+		public bool Enabled => false;
+
+		public string SeedData(FuturemudDatabaseContext context, IReadOnlyDictionary<string, string> questionAnswers)
+		{
+			return "Completed";
+		}
+
+		public ShouldSeedResult ShouldSeedData(FuturemudDatabaseContext context)
+		{
+			return ShouldSeedResult.ReadyToInstall;
+		}
+	}
+
+	private sealed class ChangedQuestionIdReplaySeeder : IDatabaseSeeder
+	{
+		public IEnumerable<(string Id, string Question,
+			Func<FuturemudDatabaseContext, IReadOnlyDictionary<string, string>, bool> Filter,
+			Func<string, FuturemudDatabaseContext, (bool Success, string error)> Validator)> SeederQuestions =>
+		[
+			("new-question", "Changed question", (_, _) => true, (_, _) => (true, string.Empty))
+		];
+
+		public int SortOrder => 0;
+		public string Name => "Changed Question Replay Seeder";
+		public string Tagline => "Test";
+		public string FullDescription => "Test";
+
+		public string SeedData(FuturemudDatabaseContext context, IReadOnlyDictionary<string, string> questionAnswers)
+		{
+			return "Completed";
+		}
+
+		public ShouldSeedResult ShouldSeedData(FuturemudDatabaseContext context)
+		{
+			return ShouldSeedResult.ReadyToInstall;
+		}
+	}
+}
+#endif

--- a/DatabaseSeeder Unit Tests/SkillPackageSeederTests.cs
+++ b/DatabaseSeeder Unit Tests/SkillPackageSeederTests.cs
@@ -3,7 +3,9 @@
 using DatabaseSeeder.Seeders;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MudSharp.Models;
+using MudSharp.RPG.Checks;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace MudSharp_Unit_Tests;
 
@@ -77,5 +79,36 @@ public class SkillPackageSeederTests
 
 		StringAssert.Contains(source, "case CheckType.AvoidMountFallCheck:");
 		StringAssert.Contains(source, "(0.7*ride:{ridingTrait.Id})+(0.3*balance:{balancingTrait.Id})");
+	}
+
+	[TestMethod]
+	public void SkillPackageChecks_DefersOnlyTrapCheckTypesToTrapSeeder()
+	{
+		string source = SeederSourceTestHelper.ReadSeederSource("SkillPackageSeeder.cs");
+		var handledCheckTypes = Regex.Matches(source, @"case\s+CheckType\.(?<name>\w+)")
+			.Select(x => x.Groups["name"].Value)
+			.ToHashSet(System.StringComparer.Ordinal);
+		var deferredTrapCheckTypes = new[]
+		{
+			CheckType.SetTrapCheck,
+			CheckType.SpotTrapCheck,
+			CheckType.SearchForTrapCheck,
+			CheckType.AvoidTrapCheck,
+			CheckType.DisarmTrapCheck,
+			CheckType.DispelTrapCheck,
+			CheckType.EscapeTrapCheck
+		};
+
+		foreach (CheckType checkType in System.Enum.GetValues<CheckType>())
+		{
+			Assert.IsTrue(handledCheckTypes.Contains(checkType.ToString()),
+				$"SkillPackageSeeder must explicitly account for {checkType}.");
+		}
+
+		foreach (CheckType checkType in deferredTrapCheckTypes)
+		{
+			StringAssert.Contains(source, "TrapSeeder owns the optional trap skill and its check formulas.");
+			Assert.IsTrue(handledCheckTypes.Contains(checkType.ToString()));
+		}
 	}
 }

--- a/DatabaseSeeder/AssemblyInfo.cs
+++ b/DatabaseSeeder/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("MudSharpCore Unit Tests")]
+[assembly: InternalsVisibleTo("DatabaseSeeder Unit Tests")]

--- a/DatabaseSeeder/DebugSeederReplay.cs
+++ b/DatabaseSeeder/DebugSeederReplay.cs
@@ -1,0 +1,487 @@
+#if DEBUG
+#nullable enable
+
+using DatabaseSeeder.Seeders;
+using Microsoft.EntityFrameworkCore;
+using MudSharp.Database;
+using MudSharp.Framework;
+using MySql.Data.MySqlClient;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DatabaseSeeder;
+
+internal sealed record SeederReplayAnswer(string Id, string Answer);
+
+internal sealed record SeederReplayStep(Type SeederType, IReadOnlyList<SeederReplayAnswer> Answers);
+
+internal sealed record SeederReplayProfile(
+	string Id,
+	string Name,
+	string Description,
+	IReadOnlyList<SeederReplayStep> Steps);
+
+internal sealed record SeederReplayValidationResult(IReadOnlyList<string> Errors)
+{
+	internal bool IsValid => Errors.Count == 0;
+}
+
+internal sealed record SeederReplayRunResult(
+	SeederReplayProfile Profile,
+	IReadOnlyList<string> CompletedSeeders,
+	string? FailedSeeder,
+	IReadOnlyList<string> UnstartedSeeders,
+	string? Failure,
+	Exception? Exception,
+	SeederReplayValidationResult Validation)
+{
+	internal bool Success => Validation.IsValid && string.IsNullOrWhiteSpace(Failure) && Exception is null;
+}
+
+internal static class DebugSeederConnection
+{
+	internal const string DefaultConnectionString =
+		"server=localhost;port=3307;database=demo_dbo;uid=futuremud;password=rpiengine2020;SslMode=None;AllowPublicKeyRetrieval=True;Default Command Timeout=300000;";
+
+	internal static bool TryCreateConnectionString(string? databaseName, out string connectionString,
+		out string error)
+	{
+		connectionString = string.Empty;
+		error = string.Empty;
+		if (string.IsNullOrWhiteSpace(databaseName))
+		{
+			error = "You must enter a database name.";
+			return false;
+		}
+
+		try
+		{
+			var builder = new MySqlConnectionStringBuilder(DefaultConnectionString)
+			{
+				Database = databaseName.Trim()
+			};
+			connectionString = builder.ConnectionString;
+			return true;
+		}
+		catch (Exception exception)
+		{
+			error = $"The database name could not be used: {exception.Message}";
+			return false;
+		}
+	}
+
+	internal static string GetDatabaseName(string connectionString)
+	{
+		return new MySqlConnectionStringBuilder(connectionString).Database;
+	}
+}
+
+internal static class SeederReplayRunner
+{
+	private static readonly Type[] ExcludedSeederTypes = [typeof(SkillSeeder)];
+
+	internal static SeederReplayValidationResult Validate(SeederReplayProfile profile,
+		IEnumerable<IDatabaseSeeder> seeders)
+	{
+		var errors = new List<string>();
+		var seederList = seeders
+			.Where(x => x.Enabled)
+			.ToList();
+		var seedersByType = seederList
+			.GroupBy(x => x.GetType())
+			.ToDictionary(x => x.Key, x => x.First());
+		var dependencyPlan = SeederCatalogue.GetDependencyPlan(seederList);
+		if (dependencyPlan.Errors.Any())
+		{
+			errors.AddRange(dependencyPlan.Errors.Select(x => $"Seeder dependency registry: {x}"));
+			return new SeederReplayValidationResult(errors);
+		}
+
+		var expectedSeeders = dependencyPlan.OrderedSeeders
+			.Where(x => !ExcludedSeederTypes.Contains(x.GetType()))
+			.ToList();
+		var stepTypes = profile.Steps.Select(x => x.SeederType).ToList();
+		var duplicateStepTypes = stepTypes
+			.GroupBy(x => x)
+			.Where(x => x.Count() > 1)
+			.Select(x => x.Key.Name)
+			.ToList();
+		if (duplicateStepTypes.Any())
+		{
+			errors.Add($"The replay profile contains duplicate seeder steps: {string.Join(", ", duplicateStepTypes)}.");
+		}
+
+		foreach (Type type in stepTypes.Where(x => !seedersByType.ContainsKey(x)).Distinct())
+		{
+			errors.Add($"The replay profile references unavailable or disabled seeder {type.Name}.");
+		}
+
+		var expectedTypes = expectedSeeders.Select(x => x.GetType()).ToList();
+		if (!stepTypes.SequenceEqual(expectedTypes))
+		{
+			var missing = expectedTypes.Except(stepTypes).Select(x => x.Name).ToList();
+			var unexpected = stepTypes.Except(expectedTypes).Select(x => x.Name).ToList();
+			if (missing.Any())
+			{
+				errors.Add($"The replay profile is missing enabled seeders: {string.Join(", ", missing)}.");
+			}
+
+			if (unexpected.Any())
+			{
+				errors.Add($"The replay profile has unexpected seeders: {string.Join(", ", unexpected)}.");
+			}
+
+			if (!missing.Any() && !unexpected.Any())
+			{
+				errors.Add(
+					$"The replay profile seeder order no longer matches the dependency plan. Expected: {string.Join(", ", expectedTypes.Select(x => x.Name))}.");
+			}
+		}
+
+		foreach (SeederReplayStep step in profile.Steps)
+		{
+			if (!seedersByType.TryGetValue(step.SeederType, out IDatabaseSeeder? seeder))
+			{
+				continue;
+			}
+
+			var duplicateAnswerIds = step.Answers
+				.GroupBy(x => x.Id, StringComparer.OrdinalIgnoreCase)
+				.Where(x => x.Count() > 1)
+				.Select(x => x.Key)
+				.ToList();
+			if (duplicateAnswerIds.Any())
+			{
+				errors.Add($"{seeder.Name} has duplicate replay answers: {string.Join(", ", duplicateAnswerIds)}.");
+				continue;
+			}
+
+			var expectedQuestionIds = seeder.Questions
+				.Select(x => x.Id)
+				.ToHashSet(StringComparer.OrdinalIgnoreCase);
+			var actualAnswerIds = step.Answers
+				.Select(x => x.Id)
+				.ToHashSet(StringComparer.OrdinalIgnoreCase);
+			var missingAnswers = expectedQuestionIds.Except(actualAnswerIds, StringComparer.OrdinalIgnoreCase).ToList();
+			var extraAnswers = actualAnswerIds.Except(expectedQuestionIds, StringComparer.OrdinalIgnoreCase).ToList();
+			if (missingAnswers.Any())
+			{
+				errors.Add($"{seeder.Name} is missing replay answers for: {string.Join(", ", missingAnswers)}.");
+			}
+
+			if (extraAnswers.Any())
+			{
+				errors.Add($"{seeder.Name} has answers for unknown questions: {string.Join(", ", extraAnswers)}.");
+			}
+		}
+
+		return new SeederReplayValidationResult(errors);
+	}
+
+	internal static SeederReplayRunResult Run(
+		SeederReplayProfile profile,
+		IEnumerable<IDatabaseSeeder> seeders,
+		Func<FuturemudDatabaseContext> contextFactory,
+		Version version,
+		Action<string>? progress = null)
+	{
+		var seederList = seeders
+			.Where(x => x.Enabled)
+			.ToList();
+		var validation = Validate(profile, seederList);
+		if (!validation.IsValid)
+		{
+			return FailureResult(profile, [], null, null, "The selected replay profile is no longer valid.", null,
+				validation);
+		}
+
+		try
+		{
+			using var preflightContext = contextFactory();
+			if (preflightContext.Accounts.Any() || preflightContext.SeederChoices.Any())
+			{
+				return FailureResult(profile, [], null, null,
+					"Replay profiles require a freshly migrated, unseeded database. This database already has bootstrap or seeder-answer data.",
+					null, validation);
+			}
+		}
+		catch (Exception exception)
+		{
+			return FailureResult(profile, [], null, null, "Could not inspect the target database before replay.", exception,
+				validation);
+		}
+
+		var seedersByType = seederList.ToDictionary(x => x.GetType());
+		var completedSeeders = new List<string>();
+		foreach (SeederReplayStep step in profile.Steps)
+		{
+			IDatabaseSeeder seeder = seedersByType[step.SeederType];
+			progress?.Invoke($"Running {seeder.Name}...");
+			try
+			{
+				using FuturemudDatabaseContext context = contextFactory();
+				SeederAssessment assessment = seeder.AssessSeedData(context);
+				if (assessment.Status == SeederAssessmentStatus.Blocked)
+				{
+					return FailureResult(profile, completedSeeders, seeder.Name, step,
+						$"{seeder.Name} is blocked: {assessment.Explanation}", null, validation);
+				}
+
+				var questions = seeder.Questions.ToList();
+				var suppliedAnswers = step.Answers.ToDictionary(x => x.Id, x => x.Answer,
+					StringComparer.OrdinalIgnoreCase);
+				DictionaryWithDefault<string, string> answers = new();
+				foreach (SeederQuestion question in questions)
+				{
+					if (!SeederQuestionWorkflow.IsActive(question, context, answers))
+					{
+						continue;
+					}
+
+					if (!suppliedAnswers.TryGetValue(question.Id, out string? answer))
+					{
+						return FailureResult(profile, completedSeeders, seeder.Name, step,
+							$"{seeder.Name} needs an answer for active question {question.Id}.", null, validation);
+					}
+
+					SeederQuestionValidationResult answerValidation =
+						SeederQuestionWorkflow.Validate(question, answer, context);
+					if (!answerValidation.Success)
+					{
+						return FailureResult(profile, completedSeeders, seeder.Name, step,
+							$"{seeder.Name} answer for {question.Id} is no longer valid: {answerValidation.Error}", null,
+							validation);
+					}
+
+					answers[question.Id] = answer;
+				}
+
+				SeederExecutionResult execution = SeederExecutionService.Execute(context, seeder, questions, answers, version);
+				if (!execution.Success)
+				{
+					return FailureResult(profile, completedSeeders, seeder.Name, step,
+						$"{seeder.Name} failed during replay.", execution.Exception, validation);
+				}
+
+				completedSeeders.Add(seeder.Name);
+			}
+			catch (Exception exception)
+			{
+				return FailureResult(profile, completedSeeders, seeder.Name, step,
+					$"{seeder.Name} could not be prepared for replay.", exception, validation);
+			}
+		}
+
+		return new SeederReplayRunResult(profile, completedSeeders, null, [], null, null, validation);
+	}
+
+	private static SeederReplayRunResult FailureResult(
+		SeederReplayProfile profile,
+		IReadOnlyList<string> completedSeeders,
+		string? failedSeeder,
+		SeederReplayStep? failedStep,
+		string failure,
+		Exception? exception,
+		SeederReplayValidationResult validation)
+	{
+		IEnumerable<SeederReplayStep> unstartedSteps = failedStep is null
+			? profile.Steps
+			: profile.Steps
+				.SkipWhile(x => !ReferenceEquals(x, failedStep))
+				.Skip(1);
+		return new SeederReplayRunResult(
+			profile,
+			completedSeeders,
+			failedSeeder,
+			unstartedSteps.Select(x => x.SeederType.Name).ToList(),
+			failure,
+			exception,
+			validation);
+	}
+}
+
+internal static class DebugSeederReplayProfiles
+{
+	private const string DebugPassword = "DebugReplayOnly!2026";
+
+	internal static IReadOnlyList<SeederReplayProfile> All { get; } =
+	[
+		CreateProfile(
+			"medieval-standard",
+			"Medieval Standard",
+			"Full Debug replay with medieval time, health, culture and item content.",
+			"Debug Medieval",
+			"1300",
+			"Medieval Age",
+			"medieval",
+			"medieval",
+			"earthdarkagesandmedieval"),
+		CreateProfile(
+			"renaissance-standard",
+			"Renaissance Standard",
+			"Full Debug replay with cumulative medieval and Renaissance item content.",
+			"Debug Renaissance",
+			"1500",
+			"Medieval Age",
+			"renaissance",
+			"medieval renaissance",
+			"earthrenaissanceeurope"),
+		CreateProfile(
+			"early-modern-standard",
+			"Early Modern Standard",
+			"Full Debug replay based on the Europe/1703 DemoMUD-style configuration.",
+			"Debug Early Modern",
+			"1703",
+			"Early Modern Age",
+			"earlymodern",
+			"medieval renaissance earlymodern",
+			"earthrenaissanceeurope")
+	];
+
+	private static SeederReplayProfile CreateProfile(
+		string id,
+		string name,
+		string description,
+		string gameName,
+		string year,
+		string economyEra,
+		string healthTechLevel,
+		string itemEras,
+		string culturePack)
+	{
+		var epoch = $"1 January {year}";
+		var moonEpoch = $"21 January {year}";
+		return new SeederReplayProfile(id, name, description,
+		[
+			Step<CoreDataSeeder>(
+				("gamename", gameName),
+				("account", "admin"),
+				("password", DebugPassword),
+				("email", "debug-replay@futuremud.com")),
+			Step<TimeSeeder>(
+				("secondsmultiplier", "2"),
+				("mode", "gregorian-uk"),
+				("startyear", year),
+				("ardaage", "3")),
+			Step<CelestialSeeder>(
+				("installsun", "yes"),
+				("suncalendar", "1"),
+				("sunname", "The Sun"),
+				("sunepoch", epoch),
+				("installmoon", "yes"),
+				("mooncalendar", "1"),
+				("moonname", "The Moon"),
+				("moonepoch", moonEpoch),
+				("installgasgiantmoon", "yes"),
+				("gasgiantcalendar", "1"),
+				("gasgiantsunepoch", epoch),
+				("gasgiantmoonepoch", epoch)),
+			Step<AttributeSeeder>(
+				("choice", "labmud"),
+				("decorator", "labmud")),
+			Step<CurrencySeeder>(("currency", "pounds")),
+			Step<AIStorytellerSeeder>(("install", "yes")),
+			Step<SkillPackageSeeder>(
+				("branching", "yes"),
+				("skillcapmodel", "rpi"),
+				("skillgainmodel", "labmud"),
+				("complexity", "complex"),
+				("gerund", "no"),
+				("modern", "yes")),
+			Step<ClanSeeder>(),
+			Step<HumanSeeder>(
+				("balance", "combat-rebalance"),
+				("model", "full"),
+				("inventory", "hands"),
+				("sever", "yes"),
+				("bones", "full"),
+				("distinctive", "yes"),
+				("nonbinary", "yes"),
+				("includeextraperson", "yes")),
+			Step<WeatherSeeder>(("rain", "full")),
+			Step<LawSeeder>(
+				("name", "Debug Authority"),
+				("currency", "1"),
+				("createai", "yes"),
+				("separatepowers", "yes"),
+				("punishmentlevel", "western"),
+				("classes", "immune sovereign noble officer soldier enforcer citizen non-citizen slave pet felon criminal"),
+				("religiouslaws", "yes"),
+				("penaltyunits", "4")),
+			Step<ChargenSeeder>(
+				("rpp", "yes"),
+				("rppname", "Roleplay Point/RPP"),
+				("bp", "yes"),
+				("class", "no"),
+				("subclass", "no"),
+				("role-first", "race"),
+				("attributemode", "points"),
+				("skillmode", "boosts"),
+				("merits", "merit"),
+				("customdescs", "no")),
+			Step<UsefulSeeder>(
+				("ai", "yes"),
+				("covers", "yes"),
+				("items", "yes"),
+				("modernitems", "yes"),
+				("tags", "yes"),
+				("autobuilder", "yes"),
+				("hints", "yes"),
+				("dreams", "yes"),
+				("dream-eras", "old modern")),
+			Step<TrapSeeder>(),
+			Step<EconomySeeder>(
+				("era", economyEra),
+				("currency", "1"),
+				("zone", "1"),
+				("shopper-scale", "standard")),
+			Step<CombatSeeder>(
+				("installmuskets", "yes"),
+				("installguns", "yes"),
+				("random", "static"),
+				("parryoption", "yes"),
+				("skilloption", "weapons"),
+				("messagestyle", "sparse")),
+			Step<CultureSeeder>(
+				("culturepacks", culturePack),
+				("seednames", "yes"),
+				("seedlanguages", "yes"),
+				("seedheritage", "yes")),
+			Step<StockMeritsSeeder>(),
+			Step<AgricultureSeeder>(),
+			Step<HealthSeeder>(("techlevel", healthTechLevel)),
+			Step<CookingSeeder>(),
+			Step<ArenaSeeder>(
+				("arena-name", $"{gameName} Arena"),
+				("arena-zone", "1")),
+			Step<AnimalSeeder>(
+				("model", "full"),
+				("random", "static"),
+				("messagestyle", "sparse")),
+			Step<MythicalAnimalSeeder>(
+				("model", "full"),
+				("random", "static"),
+				("messagestyle", "sparse")),
+			Step<WildlifeCatalogueSeeder>(),
+			Step<RobotSeeder>(),
+			Step<ItemSeeder>(
+				("eras", itemEras),
+				("scope", "all")),
+			Step<AnimalButcherySeeder>(),
+			Step<SupernaturalSeeder>(
+				("model", "full"),
+				("random", "static"),
+				("messagestyle", "sparse"))
+		]);
+	}
+
+	private static SeederReplayStep Step<T>(params (string Id, string Answer)[] answers)
+		where T : IDatabaseSeeder
+	{
+		return new SeederReplayStep(typeof(T), answers
+			.Select(x => new SeederReplayAnswer(x.Id, x.Answer))
+			.ToList());
+	}
+}
+#endif

--- a/DatabaseSeeder/Program.cs
+++ b/DatabaseSeeder/Program.cs
@@ -101,8 +101,26 @@ Please press enter to begin.".WriteLineConsole();
         Console.ReadLine();
         SafeClear();
 #if DEBUG
-        ConnectionString =
-            "server=localhost;port=3307;database=demo_dbo;uid=futuremud;password=rpiengine2020;SslMode=None;AllowPublicKeyRetrieval=True;Default Command Timeout=300000;";
+		while (true)
+		{
+			Console.Write("Please enter the name of the local Debug database to seed: ");
+			string? databaseName = Console.ReadLine();
+			if (databaseName is null)
+			{
+				return;
+			}
+
+			if (DebugSeederConnection.TryCreateConnectionString(databaseName, out string connectionString,
+					out string error))
+			{
+				ConnectionString = connectionString;
+				break;
+			}
+
+			Console.ForegroundColor = ConsoleColor.Red;
+			ConsoleLayoutHelper.WriteWrapped(error);
+			Console.ForegroundColor = ConsoleColor.White;
+		}
 #else
 		Console.WriteLine("Please enter the connection string for your database: ");
 		Console.Write("This is very likely to be in the following format: ");
@@ -236,7 +254,7 @@ The exception details were as follows:
 				: Environment.GetEnvironmentVariable("FUTUREMUD_ITEM_MANIFEST_CONNECTION_STRING");
 #if DEBUG
 			ConnectionString ??=
-				"server=localhost;port=3307;database=demo_dbo;uid=futuremud;password=rpiengine2020;SslMode=None;AllowPublicKeyRetrieval=True;Default Command Timeout=300000;";
+				DebugSeederConnection.DefaultConnectionString;
 #endif
 			if (string.IsNullOrWhiteSpace(ConnectionString))
 			{
@@ -490,18 +508,8 @@ The exception details were as follows:
         {
             SafeClear();
             Console.WriteLine("Loading seeders...");
-            Type iType = typeof(IDatabaseSeeder);
-            List<IDatabaseSeeder> seeders = Assembly
-                    .GetExecutingAssembly()
-                    .GetTypes()
-                    .Where(x => x.GetInterfaces().Contains(iType))
-                    .Where(x => !x.IsAbstract)
-                    .Select(x => Activator.CreateInstance(x))
-                    .OfType<IDatabaseSeeder>()
-                    .Where(x => x.Enabled)
-                    .ToList()
-                ;
-            SeederDependencyPlan dependencyPlan = SeederMetadataRegistry.GetDependencyPlan(seeders);
+            List<IDatabaseSeeder> seeders = SeederCatalogue.GetEnabledSeeders().ToList();
+            SeederDependencyPlan dependencyPlan = SeederCatalogue.GetDependencyPlan(seeders);
             if (dependencyPlan.Errors.Any())
             {
                 throw new InvalidOperationException(
@@ -558,6 +566,12 @@ The exception details were as follows:
                     }
                     Console.ForegroundColor = ConsoleColor.White;
                 }
+#if DEBUG
+                Console.ForegroundColor = ConsoleColor.Cyan;
+                Console.WriteLine();
+                Console.WriteLine("REPLAY - run a complete standard Debug replay profile");
+                Console.ForegroundColor = ConsoleColor.White;
+#endif
             }
 
             string blockedSeederSummary = GetBlockedSeederSummary(blockedSeederCount, showBlockedSeeders);
@@ -581,6 +595,15 @@ The exception details were as follows:
             {
                 return;
             }
+
+#if DEBUG
+			if (choice.EqualToAny("replay", "profile", "replayprofile"))
+			{
+				ShowReplayProfiles(seeders);
+				errorMessage = string.Empty;
+				continue;
+			}
+#endif
 
             if (choice.EqualToAny("invalid", "blocked"))
             {
@@ -627,6 +650,112 @@ The exception details were as follows:
             errorMessage = string.Empty;
         }
     }
+
+#if DEBUG
+	private static void ShowReplayProfiles(IReadOnlyList<IDatabaseSeeder> seeders)
+	{
+		SafeClear();
+		Console.ForegroundColor = ConsoleColor.DarkYellow;
+		ConsoleLayoutHelper.WriteWrapped(
+			"Debug replay profiles run a complete known seeder sequence against a freshly migrated, unseeded local database. They use the fixed Debug implementor password DebugReplayOnly!2026. Never use this workflow or credential for a reachable or production database.");
+		Console.ForegroundColor = ConsoleColor.White;
+		Console.WriteLine();
+		Console.WriteLine($"Target database: {DebugSeederConnection.GetDatabaseName(ConnectionString!)}");
+		Console.WriteLine();
+
+		for (var i = 0; i < DebugSeederReplayProfiles.All.Count; i++)
+		{
+			SeederReplayProfile profile = DebugSeederReplayProfiles.All[i];
+			Console.ForegroundColor = ConsoleColor.Cyan;
+			Console.WriteLine($"{i + 1}. {profile.Name} ({profile.Id})");
+			Console.ForegroundColor = ConsoleColor.White;
+			ConsoleLayoutHelper.WriteWrapped(profile.Description, indent: "   ");
+		}
+
+		Console.WriteLine();
+		Console.Write("Choose a profile by number or ID, or type BACK: ");
+		string? choice = Console.ReadLine();
+		if (choice is null || choice.EqualToAny("back", "b", "quit", "q", "exit"))
+		{
+			return;
+		}
+
+		SeederReplayProfile? selectedProfile = uint.TryParse(choice, out uint profileNumber)
+			? DebugSeederReplayProfiles.All.ElementAtOrDefault((int)profileNumber - 1)
+			: DebugSeederReplayProfiles.All.FirstOrDefault(x => x.Id.EqualTo(choice));
+		if (selectedProfile is null)
+		{
+			Console.ForegroundColor = ConsoleColor.Red;
+			ConsoleLayoutHelper.WriteWrapped("That is not a valid replay profile.");
+			Console.ForegroundColor = ConsoleColor.White;
+			WaitForReturnToMenu();
+			return;
+		}
+
+		Console.WriteLine();
+		Console.ForegroundColor = ConsoleColor.DarkYellow;
+		ConsoleLayoutHelper.WriteWrapped(
+			$"Type REPLAY to run {selectedProfile.Name} against {DebugSeederConnection.GetDatabaseName(ConnectionString!)}. The run stops on the first failure and does not reset the database.");
+		Console.ForegroundColor = ConsoleColor.White;
+		Console.Write("> ");
+		string? confirmation = Console.ReadLine();
+		if (!string.Equals(confirmation, "replay", StringComparison.OrdinalIgnoreCase))
+		{
+			return;
+		}
+
+		SafeClear();
+		Console.WriteLine($"Starting {selectedProfile.Name} replay...");
+		SeederReplayRunResult result = SeederReplayRunner.Run(
+			selectedProfile,
+			seeders,
+			() => CreateContext(useLazyLoading: true),
+			Assembly.GetCallingAssembly().GetName().Version ?? new Version(1, 0, 0),
+			message => ConsoleLayoutHelper.WriteWrapped(message));
+		Console.WriteLine();
+		if (!result.Validation.IsValid)
+		{
+			Console.ForegroundColor = ConsoleColor.Red;
+			ConsoleLayoutHelper.WriteWrapped("The replay profile needs maintenance:");
+			foreach (string error in result.Validation.Errors)
+			{
+				ConsoleLayoutHelper.WriteWrapped($" - {error}", indent: "   ");
+			}
+		}
+		else if (result.Success)
+		{
+			Console.ForegroundColor = ConsoleColor.Green;
+			ConsoleLayoutHelper.WriteWrapped(
+				$"Replay completed successfully. Ran {result.CompletedSeeders.Count:N0} seeders: {string.Join(", ", result.CompletedSeeders)}.");
+		}
+		else
+		{
+			Console.ForegroundColor = ConsoleColor.Red;
+			ConsoleLayoutHelper.WriteWrapped(result.Failure ?? "Replay failed.");
+			if (result.Exception is not null)
+			{
+				ConsoleLayoutHelper.WriteWrapped(result.Exception.ToString());
+			}
+		}
+
+		Console.ForegroundColor = ConsoleColor.White;
+		ConsoleLayoutHelper.WriteWrapped(
+			$"Completed steps: {(result.CompletedSeeders.Any() ? string.Join(", ", result.CompletedSeeders) : "none")}.");
+		if (!string.IsNullOrWhiteSpace(result.FailedSeeder))
+		{
+			ConsoleLayoutHelper.WriteWrapped($"Failed step: {result.FailedSeeder}.");
+		}
+
+		if (result.UnstartedSeeders.Any())
+		{
+			ConsoleLayoutHelper.WriteWrapped($"Unstarted steps: {string.Join(", ", result.UnstartedSeeders)}.");
+		}
+
+		Console.WriteLine();
+		Console.WriteLine("Press any key to return to the main menu.");
+		WaitForReturnToMenu();
+	}
+#endif
 
     private static void ShowSeeder(IDatabaseSeeder seeder)
     {
@@ -728,7 +857,7 @@ The exception details were as follows:
             $"╔{new string('═', banner.Length + 2)}╗\n║ {banner} ║\n╚{new string('═', banner.Length + 2)}╝\n";
         foreach (SeederQuestion? question in questions)
         {
-            if (!question.Filter(context, answers))
+            if (!SeederQuestionWorkflow.IsActive(question, context, answers))
             {
                 continue;
             }
@@ -738,8 +867,9 @@ The exception details were as follows:
             string? resolvedDefaultAnswer = null;
             if (!string.IsNullOrWhiteSpace(rememberedAnswer))
             {
-                (bool success, string? error) = question.Validator(rememberedAnswer, context);
-                if (success)
+                SeederQuestionValidationResult rememberedValidation =
+                    SeederQuestionWorkflow.Validate(question, rememberedAnswer, context);
+                if (rememberedValidation.Success)
                 {
                     if (question.AutoReuseLastAnswer)
                     {
@@ -758,7 +888,7 @@ The exception details were as follows:
                 else
                 {
                     errorText =
-                        $"The previously remembered answer for {question.Id} is no longer valid and will be ignored.{(string.IsNullOrWhiteSpace(error) ? "" : $"\n{error}")}";
+                        $"The previously remembered answer for {question.Id} is no longer valid and will be ignored.{(string.IsNullOrWhiteSpace(rememberedValidation.Error) ? "" : $"\n{rememberedValidation.Error}")}";
                 }
             }
 
@@ -782,15 +912,16 @@ The exception details were as follows:
                 if (!string.IsNullOrWhiteSpace(display.DefaultAnswer) &&
                     string.IsNullOrWhiteSpace(resolvedDefaultAnswer))
                 {
-                    (bool defaultSuccess, string? defaultError) = question.Validator(display.DefaultAnswer, context);
-                    if (defaultSuccess)
+                    SeederQuestionValidationResult defaultValidation =
+                        SeederQuestionWorkflow.Validate(question, display.DefaultAnswer, context);
+                    if (defaultValidation.Success)
                     {
                         resolvedDefaultAnswer = display.DefaultAnswer;
                     }
                     else
                     {
                         errorText =
-                            $"The suggested default answer for {question.Id} is no longer valid and will be ignored.{(string.IsNullOrWhiteSpace(defaultError) ? "" : $"\n{defaultError}")}";
+                            $"The suggested default answer for {question.Id} is no longer valid and will be ignored.{(string.IsNullOrWhiteSpace(defaultValidation.Error) ? "" : $"\n{defaultValidation.Error}")}";
                     }
                 }
 
@@ -818,10 +949,11 @@ The exception details were as follows:
 
                 answer = ResolveQuestionAnswer(answer, resolvedDefaultAnswer);
 
-                (bool success, string? error) = question.Validator(answer, context);
-                if (!success)
+                SeederQuestionValidationResult answerValidation =
+                    SeederQuestionWorkflow.Validate(question, answer, context);
+                if (!answerValidation.Success)
                 {
-                    errorText = error;
+                    errorText = answerValidation.Error;
                     continue;
                 }
 
@@ -832,27 +964,25 @@ The exception details were as follows:
 
         SafeClear();
         $"Applying the data from the #2{seeder.Name}#F seeder...".WriteLineConsole();
-        try
+        SeederExecutionResult execution = SeederExecutionService.Execute(
+            context,
+            seeder,
+            questions,
+            answers,
+            Assembly.GetCallingAssembly().GetName().Version ?? new Version(1, 0, 0));
+        if (execution.Success)
         {
-            string result = seeder.SeedData(context, answers);
-            Console.WriteLine(result);
-            string version = (Assembly.GetCallingAssembly().GetName().Version ?? new Version(1, 0, 0)).ToString();
-            DateTime now = DateTime.UtcNow;
-            SeederAnswerMemory.PersistAnswers(context, seeder, questions, answers, version, now);
-            context.SaveChanges();
+            Console.WriteLine(execution.Message);
+            return;
         }
-        catch (Exception exception)
-        {
-            context.Database.CurrentTransaction?.Rollback();
-            context.ChangeTracker.Clear();
-            Console.ForegroundColor = ConsoleColor.Red;
+
+        Console.ForegroundColor = ConsoleColor.Red;
 #if DEBUG
-			ConsoleLayoutHelper.WriteWrapped($"The {seeder.Name} seeder failed: {exception}");
+		ConsoleLayoutHelper.WriteWrapped($"The {seeder.Name} seeder failed: {execution.Exception}");
 #else
-			ConsoleLayoutHelper.WriteWrapped($"The {seeder.Name} seeder failed: {exception.Message}");
+		ConsoleLayoutHelper.WriteWrapped($"The {seeder.Name} seeder failed: {execution.Exception?.Message}");
 #endif
-            Console.ForegroundColor = ConsoleColor.White;
-        }
+        Console.ForegroundColor = ConsoleColor.White;
     }
 
     internal static string ResolveQuestionAnswer(string answer, string? defaultAnswer)

--- a/DatabaseSeeder/SeederCatalogue.cs
+++ b/DatabaseSeeder/SeederCatalogue.cs
@@ -1,0 +1,27 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace DatabaseSeeder;
+
+internal static class SeederCatalogue
+{
+	internal static IReadOnlyList<IDatabaseSeeder> GetEnabledSeeders()
+	{
+		return Assembly.GetExecutingAssembly()
+			.GetTypes()
+			.Where(x => !x.IsAbstract && typeof(IDatabaseSeeder).IsAssignableFrom(x))
+			.Select(Activator.CreateInstance)
+			.OfType<IDatabaseSeeder>()
+			.Where(x => x.Enabled)
+			.ToList();
+	}
+
+	internal static SeederDependencyPlan GetDependencyPlan(IEnumerable<IDatabaseSeeder> seeders)
+	{
+		return SeederMetadataRegistry.GetDependencyPlan(seeders);
+	}
+}

--- a/DatabaseSeeder/SeederExecutionService.cs
+++ b/DatabaseSeeder/SeederExecutionService.cs
@@ -1,0 +1,45 @@
+#nullable enable
+
+using MudSharp.Database;
+using System;
+using System.Collections.Generic;
+
+namespace DatabaseSeeder;
+
+internal sealed record SeederExecutionResult(bool Success, string? Message, Exception? Exception)
+{
+	public static SeederExecutionResult Failed(Exception exception)
+	{
+		return new SeederExecutionResult(false, null, exception);
+	}
+
+	public static SeederExecutionResult Completed(string message)
+	{
+		return new SeederExecutionResult(true, message, null);
+	}
+}
+
+internal static class SeederExecutionService
+{
+	internal static SeederExecutionResult Execute(
+		FuturemudDatabaseContext context,
+		IDatabaseSeeder seeder,
+		IEnumerable<SeederQuestion> questions,
+		IReadOnlyDictionary<string, string> answers,
+		Version version)
+	{
+		try
+		{
+			var result = seeder.SeedData(context, answers);
+			SeederAnswerMemory.PersistAnswers(context, seeder, questions, answers, version.ToString(), DateTime.UtcNow);
+			context.SaveChanges();
+			return SeederExecutionResult.Completed(result);
+		}
+		catch (Exception exception)
+		{
+			context.Database.CurrentTransaction?.Rollback();
+			context.ChangeTracker.Clear();
+			return SeederExecutionResult.Failed(exception);
+		}
+	}
+}

--- a/DatabaseSeeder/SeederMetadataRegistry.cs
+++ b/DatabaseSeeder/SeederMetadataRegistry.cs
@@ -196,12 +196,17 @@ public static class SeederMetadataRegistry
                 SeederRepeatabilityMode.Idempotent,
                 SeederUpdateCapability.InstallMissing,
                 [
-                    Requirement("The Core seeder must have created at least one account.", context => context.Accounts.Any())
+                    Requirement("The Core seeder must have created at least one account.", context => context.Accounts.Any()),
+                    Requirement("The Human seeder must have installed the characteristic profiles required by stock item components.", context =>
+                        context.CharacteristicProfiles.Any(x => x.Name == "All Hair Colours") &&
+                        context.CharacteristicProfiles.Any(x => x.Name == "All Hair Styles") &&
+                        context.CharacteristicProfiles.Any(x => x.Name == "All Facial Hair Colours") &&
+                        context.CharacteristicProfiles.Any(x => x.Name == "All Facial Hair Styles"))
                 ],
                 RerunSummary: "This package can be rerun to install missing stock kickstart content without duplicating its tracked packages.",
                 UpdateSummary: "Reruns also refresh the stock wilderness autobuilder room template, area template, and supporting terrain-feature tags by stable names.",
                 OwnershipSummary: "Kickstart now owns stock items, AI, helper tags, the wilderness autobuilder room+area starter package, ranged covers, hints, and dream content; core terrain foundations are seeded separately.",
-                DependencySeederTypes: [typeof(CoreDataSeeder)]
+                DependencySeederTypes: [typeof(CoreDataSeeder), typeof(HumanSeeder)]
             ),
             nameof(AgricultureSeeder) => new SeederMetadata(
                 SeederRepeatabilityMode.Idempotent,
@@ -297,7 +302,7 @@ public static class SeederMetadataRegistry
                     Requirement("The Core seeder must have installed the Simple name culture.", context => context.NameCultures.Any(x => x.Name == "Simple"))
                 ],
                 RerunSummary: "Reruns retain the installed animal package choices and reconcile stock bodies, races, attacks and supporting content.",
-                DependencySeederTypes: [typeof(CoreDataSeeder), typeof(HumanSeeder)]
+                DependencySeederTypes: [typeof(CoreDataSeeder), typeof(HumanSeeder), typeof(CultureSeeder)]
             ),
             nameof(WildlifeCatalogueSeeder) => new SeederMetadata(
                 SeederRepeatabilityMode.Idempotent,
@@ -484,7 +489,7 @@ public static class SeederMetadataRegistry
                 RerunSummary: "Reruns reconcile the dedicated Traps skill, seven trap checks, and Stock Trap templates without overwriting builder-owned templates.",
                 UpdateSummary: "Stock trap definitions use the Stock Trap prefix; other templates are never modified.",
                 OwnershipSummary: "The package owns only the Traps skill/check mappings and Stock Trap prefixed templates.",
-                DependencySeederTypes: [typeof(CoreDataSeeder)]
+                DependencySeederTypes: [typeof(CoreDataSeeder), typeof(SkillPackageSeeder)]
             ),
             _ => SeederMetadata.Default
         };

--- a/DatabaseSeeder/SeederQuestionWorkflow.cs
+++ b/DatabaseSeeder/SeederQuestionWorkflow.cs
@@ -1,0 +1,28 @@
+#nullable enable
+
+using MudSharp.Database;
+using System.Collections.Generic;
+
+namespace DatabaseSeeder;
+
+internal readonly record struct SeederQuestionValidationResult(bool Success, string Error);
+
+internal static class SeederQuestionWorkflow
+{
+	internal static bool IsActive(
+		SeederQuestion question,
+		FuturemudDatabaseContext context,
+		IReadOnlyDictionary<string, string> answers)
+	{
+		return question.Filter(context, answers);
+	}
+
+	internal static SeederQuestionValidationResult Validate(
+		SeederQuestion question,
+		string answer,
+		FuturemudDatabaseContext context)
+	{
+		(bool success, string error) = question.Validator(answer, context);
+		return new SeederQuestionValidationResult(success, error);
+	}
+}

--- a/DatabaseSeeder/Seeders/CombatSeeder.ModernFirearms.cs
+++ b/DatabaseSeeder/Seeders/CombatSeeder.ModernFirearms.cs
@@ -924,6 +924,9 @@ public partial class CombatSeeder
 		}
 
 		var functionsTag = EnsureTag("Functions");
+		var toolsTag = EnsureTag("Tools", functionsTag);
+		var artilleryToolsTag = EnsureTag("Artillery Tools", toolsTag);
+		var materialFunctionsTag = EnsureTag("Material Functions", functionsTag);
 		var trapRootTag = EnsureTag("Trap Components", functionsTag);
 		var explosivePayloadTag = EnsureTag("Explosive Trap Payload", trapRootTag);
 		var tripwireTriggerTag = EnsureTag("Tripwire Trigger", trapRootTag);
@@ -1000,12 +1003,12 @@ public partial class CombatSeeder
 			return type;
 		}
 
-		var spongeTag = EnsureTag("Artillery Sponge", functionsTag);
-		var waddingTag = EnsureTag("Artillery Wadding", functionsTag);
-		var rammerTag = EnsureTag("Artillery Rammer", functionsTag);
-		var ventTag = EnsureTag("Artillery Vent Tool", functionsTag);
-		var linstockTag = EnsureTag("Artillery Linstock", functionsTag);
-		var fuseTag = EnsureTag("Artillery Fuse", functionsTag);
+		var spongeTag = EnsureTag("Artillery Sponge", artilleryToolsTag);
+		var waddingTag = EnsureTag("Artillery Wadding", materialFunctionsTag);
+		var rammerTag = EnsureTag("Artillery Rammer", artilleryToolsTag);
+		var ventTag = EnsureTag("Artillery Vent Tool", artilleryToolsTag);
+		var linstockTag = EnsureTag("Artillery Linstock", artilleryToolsTag);
+		var fuseTag = EnsureTag("Artillery Fuse", materialFunctionsTag);
 
 		void EnsureModernArtillery(string key, string name, string profile, int calibre, int range,
 			int minimumCrew, double weight, string damage, string blast, string fragments,

--- a/DatabaseSeeder/Seeders/CombatSeeder.cs
+++ b/DatabaseSeeder/Seeders/CombatSeeder.cs
@@ -179,6 +179,7 @@ You can choose #3Compact#f, #3Sentences#f or #3Sparse#f",
         SeedDataWeapons(context, effectiveAnswers, skills);
         EnsureExpandedStockCombatContent(context, effectiveAnswers, skills);
         SeedDataRanged(context, effectiveAnswers, skills);
+        SeedArmourTypes(context, effectiveAnswers);
 
         if (effectiveAnswers["installmuskets"].EqualToAny("yes", "y"))
         {
@@ -191,7 +192,6 @@ You can choose #3Compact#f, #3Sentences#f or #3Sparse#f",
             EnsureModernFirearmSamples(context);
         }
 
-        SeedArmourTypes(context, effectiveAnswers);
 		EnsureEraDependencyCombatContent(context, effectiveAnswers);
         CombatAuxiliarySeederHelper.EnsureStockAuxiliaryContent(context);
         ManualCombatCommandSeederHelper.EnsureStockManualCombatCommands(context);

--- a/DatabaseSeeder/Seeders/SkillPackageSeeder.cs
+++ b/DatabaseSeeder/Seeders/SkillPackageSeeder.cs
@@ -1304,6 +1304,15 @@ Please choose either #6simple#0 or #6complex#0: ", (context, answers) => true,
 						new TraitExpression { Expression = $"(0.7*ride:{ridingTrait.Id})+(0.3*balance:{balancingTrait.Id})" },
 						templates["Skill Check"].Id, Difficulty.Impossible);
 					continue;
+				// TrapSeeder owns the optional trap skill and its check formulas.
+				case CheckType.SetTrapCheck:
+				case CheckType.SpotTrapCheck:
+				case CheckType.SearchForTrapCheck:
+				case CheckType.AvoidTrapCheck:
+				case CheckType.DisarmTrapCheck:
+				case CheckType.DispelTrapCheck:
+				case CheckType.EscapeTrapCheck:
+					continue;
 				default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/Design Documents/Seeding/DatabaseSeeder_Repeatability_Strategy.md
+++ b/Design Documents/Seeding/DatabaseSeeder_Repeatability_Strategy.md
@@ -143,7 +143,30 @@ For source-only catalogue fixes, prefer invariant tests that scan the seed defin
 - Revolution, Modern, Atomic, and Computer are not selectable until executable modules contain real stock definitions.
 - `--check-item-manifest` validates the checked-in registry without a database. `--export-item-manifest [path]` exports the same canonical document without connecting to a database.
 
+## Debug Replay Profiles
+
+Debug builds expose a `REPLAY` option at the package menu for unattended developer setup. It is deliberately not part of a Release build or a consumer-facing installer path. Debug startup asks for a nonblank database name, inserts it into the fixed local development connection template with a MySQL connection-string builder, and then shows the ordinary interactive menu or the replay-profile menu. Manifest and blank-snapshot command modes remain noninteractive and retain their existing argument/environment-variable behavior.
+
+The maintained profiles are:
+
+- `medieval-standard` for a Medieval baseline.
+- `renaissance-standard` for cumulative Medieval and Renaissance content.
+- `early-modern-standard` for cumulative Medieval, Renaissance, and Early Modern content using the Europe/1703 DemoMUD-style baseline.
+
+Each profile is a typed inventory of concrete seeder types and question IDs; it is not a recording of menu positions, display names, or console keystrokes. The inventory includes every enabled seeder in the current dependency plan except the intentionally alternative `SkillSeeder`; it uses `SkillPackageSeeder` instead. It includes the Mythical, Supernatural, Robot, and AI Storyteller packages. Answers are stored for every declared question, including questions that may be inactive for one particular profile run. The runner re-evaluates filters and validators against the live database, ignores supplied answers for inactive questions, and rejects an active missing or invalid answer before the relevant seeder starts.
+
+Replay runs require a freshly migrated, unseeded database. The runner refuses a target with bootstrap accounts or remembered seeder choices and never resets, overwrites, or cross-seeder-rolls back a database. Each completed seeder commits through the same executor used by the interactive path. A blocked prerequisite or exception stops the run immediately; completed work is preserved, later steps are not run, and the result reports completed, failed, and unstarted steps.
+
+The profiles use the Debug-only bootstrap credential `DebugReplayOnly!2026`. The UI warns that this credential and workflow must never be used for a reachable or production database.
+
+### Replay-profile maintenance
+
+Treat a replay-profile failure as deliberate configuration drift, not a reason to silently fall back to defaults. Review and update all three profiles whenever any enabled seeder, dependency/order metadata, question ID, filter, validator, default, or recommended answer changes. In particular, a new enabled seeder must be placed in dependency order, a removed or disabled one must be removed from the inventory, and a changed conditional question must still have a complete inventoried answer even if it is inactive in a profile today.
+
+`SeederReplayTests` is the required fast gate for this contract. It verifies the full profile inventories, exact order, question coverage, the deliberate Skill Examples exclusion, connection construction, conditional answers, blocked prerequisites, persistence, and stop-on-failure behavior. Run the full `DatabaseSeeder Unit Tests` suite after any DatabaseSeeder workflow or profile change.
+
 ## System-Level Findings
+
 ### Menu and status flow
 - The old menu ordered only by `SortOrder`, so duplicate values produced unstable ordering.
 - The old package-detail view only warned for `PrerequisitesNotMet` and `MayAlreadyBeInstalled`. `ExtraPackagesAvailable` had no explanatory detail.


### PR DESCRIPTION
Adds Debug-only typed replay profiles for Medieval, Renaissance, and Early Modern. Extracts shared seeder discovery, dependency planning, question validation, execution, answer persistence, and error handling; prompts for a local Debug database name; refuses nonblank targets; and keeps replay paths behind #if DEBUG. Updates repeatability documentation and adds the futuremud-database-seeder maintenance skill. Validation: Debug and Release DatabaseSeeder builds; DatabaseSeeder Unit Tests 740 passed; git diff --check; Release replay symbols absent; skill quick_validate passed. Live acceptance: all three profiles completed 29 seeders on disposable local databases, and seeded-target refusal preserved Accounts=1 and SeederChoices=88.