### PR TITLE
Fix blank snapshot migration delta imports

### DIFF
--- a/Design Documents/Core/Database_Upgrade_Coordination.md
+++ b/Design Documents/Core/Database_Upgrade_Coordination.md
@@ -25,7 +25,7 @@ Disabled backups remain supported. Pending migration state is still written, but
 
 ## Snapshot and retention behavior
 
-Blank database snapshot import and export use unique temporary directories. The directories are removed in `finally` blocks after both success and exceptions. Export replaces the concrete database name with the maintained placeholder; import performs the reverse substitution before restore.
+Blank database snapshot import and export use unique temporary directories. The directories are removed in `finally` blocks after both success and exceptions. Export replaces the concrete database name with the maintained placeholder; import performs the reverse substitution before restore. Maintained snapshots may contain EF-generated idempotent migration deltas appended after the backup dump. Import restores the base dump first, then executes the appended delta section against the target database with support for MySQL `DELIMITER` directives before verifying the latest migration-history row.
 
 Backup pruning considers SQL files only, orders them newest first, and deletes entries beyond `RetainedBackupCount`.
 

--- a/MudsharpDatabaseLibrary Unit Tests/DatabaseUpgradeCoordinatorTests.cs
+++ b/MudsharpDatabaseLibrary Unit Tests/DatabaseUpgradeCoordinatorTests.cs
@@ -320,6 +320,31 @@ public class DatabaseUpgradeCoordinatorTests
 	}
 
 	[TestMethod]
+	public void ImportBlankDatabaseSnapshot_AppendedMigrationDeltasExecuteAfterBaseRestore()
+	{
+		using var harness = new TemporaryDirectoryHarness();
+		var backupService = new FakeBackupService(harness.DirectoryPath);
+		var coordinator = new DatabaseUpgradeCoordinator(new FakeMigrationService(), backupService);
+		var snapshotPath = Path.Combine(harness.DirectoryPath, "BlankDatabaseSnapshot.sql");
+		File.WriteAllText(snapshotPath,
+			"CREATE DATABASE `__FUTUREMUD_DATABASE__`;\r\n" +
+			"-- EF-generated idempotent delta for LatestMigration\r\n" +
+			"INSERT INTO `__efmigrationshistory` VALUES ('LatestMigration');\r\n");
+
+		coordinator.ImportBlankDatabaseSnapshot(CreateRequest(harness.DirectoryPath).ConnectionString,
+			snapshotPath, "__FUTUREMUD_DATABASE__");
+
+		Assert.AreEqual(1, backupService.RestoreBackupCalls);
+		Assert.AreEqual(1, backupService.ExecuteSqlScriptCalls);
+		Assert.IsNotNull(backupService.LastRestoreContents);
+		Assert.IsFalse(backupService.LastRestoreContents.Contains("EF-generated idempotent delta",
+			StringComparison.Ordinal));
+		Assert.IsNotNull(backupService.LastExecutedScript);
+		StringAssert.StartsWith(backupService.LastExecutedScript, "-- EF-generated idempotent delta");
+		StringAssert.Contains(backupService.LastExecutedScript, "LatestMigration");
+	}
+
+	[TestMethod]
 	public void ImportBlankDatabaseSnapshot_RestoreFailure_RemovesScratchDirectory()
 	{
 		using var harness = new TemporaryDirectoryHarness();
@@ -407,7 +432,9 @@ public class DatabaseUpgradeCoordinatorTests
 		public int CreateBackupCalls { get; private set; }
 		public int RestoreBackupCalls { get; private set; }
 		public int RecreateEmptyDatabaseCalls { get; private set; }
+		public int ExecuteSqlScriptCalls { get; private set; }
 		public string? LastRestoreContents { get; private set; }
+		public string? LastExecutedScript { get; private set; }
 		public string? LastRestorePath { get; private set; }
 		public string? LastBackupDirectory { get; private set; }
 		public bool ThrowOnRestore { get; init; }
@@ -453,6 +480,8 @@ public class DatabaseUpgradeCoordinatorTests
 
 		public void ExecuteSqlScript(string connectionString, string scriptContents)
 		{
+			ExecuteSqlScriptCalls++;
+			LastExecutedScript = scriptContents;
 		}
 	}
 

--- a/MudsharpDatabaseLibrary Unit Tests/MySqlScriptBatchParserTests.cs
+++ b/MudsharpDatabaseLibrary Unit Tests/MySqlScriptBatchParserTests.cs
@@ -1,0 +1,70 @@
+#nullable enable
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Database;
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class MySqlScriptBatchParserTests
+{
+	[TestMethod]
+	public void Parse_MysqlClientDelimiterDirectives_CreateExecutableBatches()
+	{
+		const string script = """
+		                      START TRANSACTION;
+		                      DROP PROCEDURE IF EXISTS MigrationsScript;
+		                      DELIMITER //
+		                      CREATE PROCEDURE MigrationsScript()
+		                      BEGIN
+		                          SELECT 1;
+		                      END //
+		                      DELIMITER ;
+		                      CALL MigrationsScript();
+		                      DROP PROCEDURE MigrationsScript;
+		                      COMMIT;
+		                      """;
+
+		var batches = MySqlScriptBatchParser.Parse(script).ToArray();
+
+		Assert.AreEqual(3, batches.Length);
+		Assert.AreEqual(";", batches[0].Delimiter);
+		StringAssert.Contains(batches[0].Script, "START TRANSACTION;");
+		Assert.AreEqual("//", batches[1].Delimiter);
+		StringAssert.Contains(batches[1].Script, "CREATE PROCEDURE MigrationsScript()");
+		StringAssert.Contains(batches[1].Script, "END //");
+		Assert.AreEqual(";", batches[2].Delimiter);
+		StringAssert.Contains(batches[2].Script, "CALL MigrationsScript();");
+		Assert.IsFalse(batches.Any(x => x.Script.Contains("DELIMITER", StringComparison.OrdinalIgnoreCase)));
+	}
+
+	[TestMethod]
+	public void Parse_CommittedBlankSnapshotDeltas_ConsumesEveryDelimiterDirective()
+	{
+		var snapshotPath = GetCommittedSnapshotPath();
+		var snapshot = File.ReadAllText(snapshotPath);
+		var markerIndex = snapshot.IndexOf("-- EF-generated idempotent delta", StringComparison.Ordinal);
+		Assert.IsTrue(markerIndex >= 0);
+
+		var batches = MySqlScriptBatchParser.Parse(snapshot[markerIndex..]).ToArray();
+
+		Assert.IsTrue(batches.Length > 1);
+		Assert.IsTrue(batches.All(x => !string.IsNullOrWhiteSpace(x.Script)));
+		Assert.IsTrue(batches.All(x => x.Delimiter is ";" or "//"));
+		Assert.IsFalse(batches.Any(x => x.Script.Contains("DELIMITER", StringComparison.OrdinalIgnoreCase)));
+		Assert.IsTrue(batches.Any(x =>
+			x.Script.Contains("20260829082253_AddOutfitTemplateItemSkin", StringComparison.Ordinal)));
+	}
+
+	private static string GetCommittedSnapshotPath([CallerFilePath] string sourceFilePath = "")
+	{
+		return Path.GetFullPath(Path.Combine(
+			Path.GetDirectoryName(sourceFilePath)!,
+			"..",
+			"DatabaseSeeder",
+			"BlankDatabaseSnapshot.sql"));
+	}
+}

--- a/MudsharpDatabaseLibrary/AssemblyInfo.cs
+++ b/MudsharpDatabaseLibrary/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("MudsharpDatabaseLibrary Unit Tests")]

--- a/MudsharpDatabaseLibrary/Database/DatabaseUpgradeCoordinator.cs
+++ b/MudsharpDatabaseLibrary/Database/DatabaseUpgradeCoordinator.cs
@@ -11,7 +11,8 @@ namespace MudSharp.Database;
 
 public sealed class DatabaseUpgradeCoordinator : IDatabaseUpgradeCoordinator
 {
-    private readonly IDatabaseMigrationService _migrationService;
+	private const string SnapshotDeltaMarker = "-- EF-generated idempotent delta";
+	private readonly IDatabaseMigrationService _migrationService;
     private readonly IDatabaseBackupService _backupService;
 
     public DatabaseUpgradeCoordinator()
@@ -165,14 +166,21 @@ public sealed class DatabaseUpgradeCoordinator : IDatabaseUpgradeCoordinator
         MySqlConnectionStringBuilder builder = new(connectionString);
         string tempDirectory = Path.Combine(Path.GetTempPath(), "FutureMUD-SnapshotImport", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDirectory);
-        try
-        {
-            string tempPath = Path.Combine(tempDirectory, Path.GetFileName(scriptPath));
-            string script = File.ReadAllText(scriptPath);
-            script = script.Replace(databaseNamePlaceholder, builder.Database, StringComparison.Ordinal);
-            File.WriteAllText(tempPath, script);
-            _backupService.RestoreBackup(connectionString, tempPath);
-        }
+		try
+		{
+			string tempPath = Path.Combine(tempDirectory, Path.GetFileName(scriptPath));
+			string script = File.ReadAllText(scriptPath);
+			script = script.Replace(databaseNamePlaceholder, builder.Database, StringComparison.Ordinal);
+			int deltaMarkerIndex = script.IndexOf(SnapshotDeltaMarker, StringComparison.Ordinal);
+			string backupScript = deltaMarkerIndex >= 0 ? script[..deltaMarkerIndex] : script;
+			string? deltaScript = deltaMarkerIndex >= 0 ? script[deltaMarkerIndex..] : null;
+			File.WriteAllText(tempPath, backupScript);
+			_backupService.RestoreBackup(connectionString, tempPath);
+			if (!string.IsNullOrWhiteSpace(deltaScript))
+			{
+				_backupService.ExecuteSqlScript(connectionString, deltaScript);
+			}
+		}
         finally
         {
             if (Directory.Exists(tempDirectory))

--- a/MudsharpDatabaseLibrary/Database/MySqlDatabaseBackupService.cs
+++ b/MudsharpDatabaseLibrary/Database/MySqlDatabaseBackupService.cs
@@ -114,13 +114,19 @@ public sealed class MySqlDatabaseBackupService : IDatabaseBackupService
         command.ExecuteNonQuery();
     }
 
-    public void ExecuteSqlScript(string connectionString, string scriptContents)
-    {
-        using MySqlConnection connection = new(GetServerConnectionString(connectionString));
-        connection.Open();
-        MySqlScript script = new(connection, scriptContents);
-        script.Execute();
-    }
+	public void ExecuteSqlScript(string connectionString, string scriptContents)
+	{
+		using MySqlConnection connection = new(connectionString);
+		connection.Open();
+		foreach (var batch in MySqlScriptBatchParser.Parse(scriptContents))
+		{
+			MySqlScript script = new(connection, batch.Script)
+			{
+				Delimiter = batch.Delimiter
+			};
+			script.Execute();
+		}
+	}
 
     private static string GetServerConnectionString(string connectionString)
     {

--- a/MudsharpDatabaseLibrary/Database/MySqlScriptBatchParser.cs
+++ b/MudsharpDatabaseLibrary/Database/MySqlScriptBatchParser.cs
@@ -1,0 +1,56 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace MudSharp.Database;
+
+internal readonly record struct MySqlScriptBatch(string Script, string Delimiter);
+
+internal static partial class MySqlScriptBatchParser
+{
+	public static IReadOnlyList<MySqlScriptBatch> Parse(string script)
+	{
+		ArgumentNullException.ThrowIfNull(script);
+		List<MySqlScriptBatch> batches = [];
+		StringBuilder currentBatch = new();
+		var delimiter = ";";
+		using StringReader reader = new(script);
+		while (reader.ReadLine() is { } line)
+		{
+			var match = DelimiterDirectiveRegex().Match(line);
+			if (!match.Success)
+			{
+				currentBatch.AppendLine(line);
+				continue;
+			}
+
+			AddBatchIfPresent(batches, currentBatch, delimiter);
+			delimiter = match.Groups["delimiter"].Value;
+		}
+
+		AddBatchIfPresent(batches, currentBatch, delimiter);
+		return batches;
+	}
+
+	private static void AddBatchIfPresent(List<MySqlScriptBatch> batches, StringBuilder currentBatch,
+		string delimiter)
+	{
+		if (currentBatch.Length == 0)
+		{
+			return;
+		}
+
+		var script = currentBatch.ToString();
+		currentBatch.Clear();
+		if (!string.IsNullOrWhiteSpace(script))
+		{
+			batches.Add(new MySqlScriptBatch(script, delimiter));
+		}
+	}
+
+	[GeneratedRegex(@"^\s*DELIMITER\s+(?<delimiter>\S+)\s*$", RegexOptions.IgnoreCase)]
+	private static partial Regex DelimiterDirectiveRegex();
+}


### PR DESCRIPTION
## Summary\n- restore the base blank-database dump before executing appended EF migration deltas\n- execute appended MySQL procedure batches with DELIMITER-aware Connector/NET scripts\n- document the maintained snapshot import contract and add regression coverage\n\n## Validation\n- 6/6 BlankDatabaseSnapshotTests\n- 38/38 MudsharpDatabaseLibrary Unit Tests\n- 25 focused coordinator/parser tests\n- git diff --check\n\nThe source-controlled snapshot and manifest were already current; this fixes the importer path that silently skipped appended deltas and caused verification to fall back to all migrations.