### PR TITLE
Create snapshot target database before restore

### DIFF
--- a/Design Documents/Core/Database_Upgrade_Coordination.md
+++ b/Design Documents/Core/Database_Upgrade_Coordination.md
@@ -25,7 +25,7 @@ Disabled backups remain supported. Pending migration state is still written, but
 
 ## Snapshot and retention behavior
 
-Blank database snapshot import and export use unique temporary directories. The directories are removed in `finally` blocks after both success and exceptions. Export replaces the concrete database name with the maintained placeholder; import performs the reverse substitution before restore. Maintained snapshots may contain EF-generated idempotent migration deltas appended after the backup dump. Import restores the base dump first, then executes the appended delta section against the target database with support for MySQL `DELIMITER` directives before verifying the latest migration-history row.
+Blank database snapshot import and export use unique temporary directories. The directories are removed in `finally` blocks after both success and exceptions. Export replaces the concrete database name with the maintained placeholder; import performs the reverse substitution before restore. Restore explicitly creates and selects the target database before invoking the backup importer. Maintained snapshots may contain EF-generated idempotent migration deltas appended after the backup dump. Import restores the base dump first, then executes the appended delta section against the target database with support for MySQL `DELIMITER` directives before verifying the latest migration-history row.
 
 Backup pruning considers SQL files only, orders them newest first, and deletes entries beyond `RetainedBackupCount`.
 

--- a/MudsharpDatabaseLibrary Unit Tests/DatabaseUpgradeCoordinatorTests.cs
+++ b/MudsharpDatabaseLibrary Unit Tests/DatabaseUpgradeCoordinatorTests.cs
@@ -345,6 +345,27 @@ public class DatabaseUpgradeCoordinatorTests
 	}
 
 	[TestMethod]
+	public void ImportBlankDatabaseSnapshot_AppendedDeltaFailureStillCleansTemporaryDirectory()
+	{
+		using var harness = new TemporaryDirectoryHarness();
+		var backupService = new FakeBackupService(harness.DirectoryPath) { ThrowOnExecuteSqlScript = true };
+		var coordinator = new DatabaseUpgradeCoordinator(new FakeMigrationService(), backupService);
+		var snapshotPath = Path.Combine(harness.DirectoryPath, "BlankDatabaseSnapshot.sql");
+		File.WriteAllText(snapshotPath,
+			"CREATE DATABASE `__FUTUREMUD_DATABASE__`;\r\n" +
+			"-- EF-generated idempotent delta for LatestMigration\r\n" +
+			"INSERT INTO `__efmigrationshistory` VALUES ('LatestMigration');\r\n");
+
+		Assert.ThrowsException<InvalidOperationException>(() => coordinator.ImportBlankDatabaseSnapshot(
+			CreateRequest(harness.DirectoryPath).ConnectionString,
+			snapshotPath,
+			"__FUTUREMUD_DATABASE__"));
+
+		Assert.IsNotNull(backupService.LastRestorePath);
+		Assert.IsFalse(Directory.Exists(Path.GetDirectoryName(backupService.LastRestorePath)));
+	}
+
+	[TestMethod]
 	public void ImportBlankDatabaseSnapshot_RestoreFailure_RemovesScratchDirectory()
 	{
 		using var harness = new TemporaryDirectoryHarness();
@@ -438,6 +459,7 @@ public class DatabaseUpgradeCoordinatorTests
 		public string? LastRestorePath { get; private set; }
 		public string? LastBackupDirectory { get; private set; }
 		public bool ThrowOnRestore { get; init; }
+		public bool ThrowOnExecuteSqlScript { get; init; }
 		public bool ThrowOnCreateBackup { get; init; }
 		public string BackupContents { get; init; } = "CREATE DATABASE `futuremud_tests`;";
 
@@ -482,6 +504,10 @@ public class DatabaseUpgradeCoordinatorTests
 		{
 			ExecuteSqlScriptCalls++;
 			LastExecutedScript = scriptContents;
+			if (ThrowOnExecuteSqlScript)
+			{
+				throw new InvalidOperationException("Delta execution failed.");
+			}
 		}
 	}
 

--- a/MudsharpDatabaseLibrary/Database/MySqlDatabaseBackupService.cs
+++ b/MudsharpDatabaseLibrary/Database/MySqlDatabaseBackupService.cs
@@ -29,18 +29,27 @@ public sealed class MySqlDatabaseBackupService : IDatabaseBackupService
         return destination;
     }
 
-    public void RestoreBackup(string connectionString, string backupFilePath)
-    {
-        string serverConnectionString = GetServerConnectionString(connectionString);
-        using MySqlConnection connection = new(serverConnectionString);
-        using MySqlCommand command = new()
+	public void RestoreBackup(string connectionString, string backupFilePath)
+	{
+		MySqlConnectionStringBuilder builder = new(connectionString);
+		if (string.IsNullOrWhiteSpace(builder.Database))
+		{
+			throw new InvalidOperationException("Cannot restore a database backup when the connection string has no database name.");
+		}
+
+		string escapedDatabaseName = builder.Database.Replace("`", "``", StringComparison.Ordinal);
+		string serverConnectionString = GetServerConnectionString(connectionString);
+		using MySqlConnection connection = new(serverConnectionString);
+		using MySqlCommand command = new()
         {
-            Connection = connection
-        };
-        using MySqlBackup backup = new(command);
-        connection.Open();
-        backup.ImportFromFile(backupFilePath);
-    }
+			Connection = connection
+		};
+		connection.Open();
+		command.CommandText = $"CREATE DATABASE IF NOT EXISTS `{escapedDatabaseName}`; USE `{escapedDatabaseName}`;";
+		command.ExecuteNonQuery();
+		using MySqlBackup backup = new(command);
+		backup.ImportFromFile(backupFilePath);
+	}
 
     public bool DatabaseLooksBlank(string connectionString)
     {


### PR DESCRIPTION
## Summary\n- explicitly create and select the requested database before MySqlBackup.NET restores a blank snapshot\n- keep appended migration-delta execution and post-import verification working for fresh databases\n- add regression coverage for delta failure cleanup and document the restore precondition\n\n## Validation\n- 26/26 focused database coordinator/parser tests\n- 38/38 MudsharpDatabaseLibrary Unit Tests\n- git diff --check\n\nThe failure log showed the delta executor opening demo_dbo before the importer had created it, producing Unknown database 'demo_dbo'.