### PR TITLE
Complete signed language follow-up integration

### DIFF
--- a/Design Documents/Communication/Sign_Language_System.md
+++ b/Design Documents/Communication/Sign_Language_System.md
@@ -8,11 +8,11 @@ The runtime is implemented by `ISignedLanguage`, `SignedLanguage`, `SignedLangua
 
 ## Player Workflow
 
-- `signedlanguages` lists understood signed languages and known varieties.
+- `signedlanguages` lists understood signed languages and known varieties; `signedlanguages list [<name filter>]` browses the complete game catalogue.
 - `signlanguage [<language> [<variety>]]` views or selects the current signed language.
 - `sign [(<emote>)] <message>` signs to the current location.
 - `signto <target> [(<emote>)] <message>` directs signing toward a visible target without making it private.
-- In a player emote, matching backticks delimit signed content: ``emote @ smiles and signs, `Welcome home.` ``
+- In a player emote, matching backticks delimit signed input: ``emote @ smiles and signs, `Welcome home.` ``. Backticks are an input convention chosen for ordinary keyboards; rendered signed content uses guillemets, for example `«Welcome home.»`, so it remains visually distinct from speech.
 
 Signing is purely visual. A recipient must be able to see the signer; hearing and vocal anatomy are irrelevant. The normal comprehend-language effect is considered only after that visual gate.
 
@@ -30,9 +30,17 @@ The stock humanoid profiles require at least one functional hand and prefer two.
 
 ## Builder Workflow
 
-Administrators use `signedlanguage edit`, `show`, `set`, and `close`. Settings cover the linked trait and difficulty model, unknown-language text, obfuscation, directional mutual intelligibility, regional varieties, and articulation profiles. Profiles are alternatives. `profile add` creates one with its first bodypart-shape requirement, and `profile requirement` adds or updates further minimum and preferred functional-part requirements.
+Administrators use `signedlanguage list`, `edit`, `show`, `set`, and `close`. `show signedlanguages [<name filter>]` provides the same full catalogue through the general builder browser. Settings cover the linked trait and difficulty model, unknown-language text, obfuscation, directional mutual intelligibility, regional varieties, and articulation profiles. Profiles are alternatives. `profile add` creates one with its first bodypart-shape requirement, and `profile requirement` adds or updates further minimum and preferred functional-part requirements.
 
 Regional familiarity is deliberately separate from language knowledge. Staff use `signedlanguage grantvariety <who> <language> <variety>` and `signedlanguage revokevariety <who> <language> <variety>` to assign it. Granting a variety also grants the parent signed language for comprehension when necessary; it does not bypass that language's anatomy requirements for production.
+
+NPC templates grant signed-language knowledge from the same linked skill relationship used at runtime: when a generated NPC receives a skill linked to a signed language, that language is added automatically and becomes its current signed language if it has no earlier selection. Simple and variable NPC-template displays show these inferred signed languages so builders can verify the result before spawning.
+
+## FutureProg and Events
+
+`SignedLanguage` and `SignedVariety` are first-class FutureProg types. `SignedLanguageVariety` remains accepted as a compatibility alias for existing progs. Signed languages expose identity, trait, unknown-description and variety properties; signed varieties expose identity, parent language, description, presentation suffixes and recognition difficulty.
+
+The five signing events pass the signed-language and optional signed-variety objects directly rather than their names. Their metadata uses the same first-class types, so event progs can inspect properties such as `language.name`, `language.trait`, `variety.language`, and `variety.difficulty`. The variety argument is null when no variety is selected.
 
 ## Description Markup
 

--- a/Design Documents/Markup/Emote_System.md
+++ b/Design Documents/Markup/Emote_System.md
@@ -30,7 +30,7 @@ Related variants exist for language handling:
 - `forceSourceInclusion` prepends the source token if the emote text never explicitly included a plain `@`.
 - The parser auto-closes an odd number of quote characters by appending a trailing `"`.
 - Quoted speech is tokenised before the normal emote tokens.
-- Matching backticks in player emotes delimit signed-language content. Unlike speech quotes, unmatched backticks are an error, and the signer must have a selected signed language and valid functional anatomy.
+- Matching backticks in player emotes delimit signed-language input. Unlike speech quotes, unmatched backticks are an error, and the signer must have a selected signed language and valid functional anatomy. Backticks are only the keyboard input boundary; rendered signed-language content is enclosed in guillemets (`«…»`).
 - Player emotes are sanitised before parsing.
 
 ### Signed Language in Player Emotes

--- a/FutureMUDLibrary Unit Tests/EventTypeMetadataTests.cs
+++ b/FutureMUDLibrary Unit Tests/EventTypeMetadataTests.cs
@@ -144,6 +144,43 @@ public class EventTypeMetadataTests
 				ProgVariableTypes.Text, ProgVariableTypes.Text]);
 	}
 
+	[TestMethod]
+	public void SignedCommunicationEventTypes_UseFirstClassLanguagePayloads()
+	{
+		Assert.AreEqual(147, (int)EventType.CharacterSigns);
+		Assert.AreEqual(148, (int)EventType.CharacterSignsWitness);
+		Assert.AreEqual(149, (int)EventType.CharacterSignsDirect);
+		Assert.AreEqual(150, (int)EventType.CharacterSignsDirectTarget);
+		Assert.AreEqual(151, (int)EventType.CharacterSignsDirectWitness);
+
+		AssertEventMetadata(EventType.CharacterSigns,
+			["character", "signedlanguage", "signedvariety", "text", "number"],
+			["signer", "language", "variety", "message", "outcome"],
+			[ProgVariableTypes.Character, ProgVariableTypes.SignedLanguage, ProgVariableTypes.SignedVariety,
+				ProgVariableTypes.Text, ProgVariableTypes.Number]);
+		AssertEventMetadata(EventType.CharacterSignsWitness,
+			["character", "perceivable", "signedlanguage", "signedvariety", "text", "number"],
+			["signer", "witness", "language", "variety", "message", "outcome"],
+			[ProgVariableTypes.Character, ProgVariableTypes.Perceivable, ProgVariableTypes.SignedLanguage,
+				ProgVariableTypes.SignedVariety, ProgVariableTypes.Text, ProgVariableTypes.Number]);
+		AssertEventMetadata(EventType.CharacterSignsDirect,
+			["character", "perceivable", "signedlanguage", "signedvariety", "text", "number"],
+			["signer", "target", "language", "variety", "message", "outcome"],
+			[ProgVariableTypes.Character, ProgVariableTypes.Perceivable, ProgVariableTypes.SignedLanguage,
+				ProgVariableTypes.SignedVariety, ProgVariableTypes.Text, ProgVariableTypes.Number]);
+		AssertEventMetadata(EventType.CharacterSignsDirectTarget,
+			["character", "perceivable", "signedlanguage", "signedvariety", "text", "number"],
+			["signer", "target", "language", "variety", "message", "outcome"],
+			[ProgVariableTypes.Character, ProgVariableTypes.Perceivable, ProgVariableTypes.SignedLanguage,
+				ProgVariableTypes.SignedVariety, ProgVariableTypes.Text, ProgVariableTypes.Number]);
+		AssertEventMetadata(EventType.CharacterSignsDirectWitness,
+			["character", "perceivable", "perceivable", "signedlanguage", "signedvariety", "text", "number"],
+			["signer", "target", "witness", "language", "variety", "message", "outcome"],
+			[ProgVariableTypes.Character, ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
+				ProgVariableTypes.SignedLanguage, ProgVariableTypes.SignedVariety, ProgVariableTypes.Text,
+				ProgVariableTypes.Number]);
+	}
+
     private static void AssertEventMetadata(EventType eventType, string[] parameterTypes, string[] parameterNames,
         ProgVariableTypes[] progTypes)
     {

--- a/FutureMUDLibrary Unit Tests/SignedLanguageProgTypeTests.cs
+++ b/FutureMUDLibrary Unit Tests/SignedLanguageProgTypeTests.cs
@@ -1,0 +1,36 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Communication.Language;
+using MudSharp.FutureProg;
+
+namespace FutureMUDLibrary_Unit_Tests.FutureProg;
+
+[TestClass]
+public class SignedLanguageProgTypeTests
+{
+	[TestMethod]
+	public void SignedTypes_ParseAndRoundTripStorage()
+	{
+		Assert.IsTrue(ProgVariableTypeRegistry.TryParse("signedlanguage", out var languageType));
+		Assert.AreEqual(ProgVariableTypes.SignedLanguage, languageType);
+		Assert.IsTrue(ProgVariableTypeRegistry.TryParse("signedvariety", out var varietyType));
+		Assert.AreEqual(ProgVariableTypes.SignedVariety, varietyType);
+		Assert.IsTrue(ProgVariableTypeRegistry.TryParse("signedlanguagevariety", out var compatibilityType));
+		Assert.AreEqual(ProgVariableTypes.SignedVariety, compatibilityType);
+		Assert.AreEqual(ProgVariableTypes.SignedVariety, ProgVariableTypes.SignedLanguageVariety);
+		Assert.IsTrue(ProgVariableTypeRegistry.TryParse(varietyType.ToStorageString(), out var roundTripped));
+		Assert.AreEqual(ProgVariableTypes.SignedVariety, roundTripped);
+	}
+
+	[TestMethod]
+	public void SignedTypes_AreFirstClassCollectionItems()
+	{
+		Assert.IsTrue(ProgVariableTypes.CollectionItem.HasFlag(ProgVariableTypes.SignedLanguage));
+		Assert.IsTrue(ProgVariableTypes.CollectionItem.HasFlag(ProgVariableTypes.SignedVariety));
+		Assert.AreEqual(ProgTypeKind.SignedLanguage, ProgVariableTypes.SignedLanguage.ExactKind);
+		Assert.AreEqual(ProgTypeKind.SignedVariety, ProgVariableTypes.SignedVariety.ExactKind);
+		Assert.IsTrue(typeof(IProgVariable).IsAssignableFrom(typeof(ISignedLanguage)));
+		Assert.IsTrue(typeof(IProgVariable).IsAssignableFrom(typeof(ISignedLanguageVariety)));
+	}
+}

--- a/FutureMUDLibrary/Communication/Language/ISignedLanguage.cs
+++ b/FutureMUDLibrary/Communication/Language/ISignedLanguage.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using MudSharp.Body;
 using MudSharp.Form.Shape;
+using MudSharp.FutureProg;
 using MudSharp.RPG.Checks;
 
 namespace MudSharp.Communication.Language;
@@ -15,7 +16,7 @@ public interface ISignedLanguage : ICommunicationLanguage
 	SignedLanguageArticulationResult EvaluateArticulation(IBody body);
 }
 
-public interface ISignedLanguageVariety : MudSharp.Framework.IFrameworkItem
+public interface ISignedLanguageVariety : MudSharp.Framework.IFrameworkItem, IProgVariable
 {
 	ISignedLanguage Language { get; }
 	string Description { get; }

--- a/FutureMUDLibrary/Communication/Language/LanguageInfo.cs
+++ b/FutureMUDLibrary/Communication/Language/LanguageInfo.cs
@@ -545,9 +545,9 @@ namespace MudSharp.Communication.Language
 				LanguagePerceptionResult.UnknownLanguage => $"*** something in {Language.UnknownLanguageDescription} ***".ColourBold(Telnet.Cyan),
 				LanguagePerceptionResult.HearFailure => "*** signing that you do not quite understand ***".ColourBold(Telnet.Cyan),
 				LanguagePerceptionResult.MutuallyIntelligableLanguage or LanguagePerceptionResult.PartialSuccess =>
-					$"«{perceiver.Gameworld.LanguageScrambler.Scramble(new ExplodedString(_rawText.ProperSentences()), result.Obfuscation).Fullstop()}»"
+					perceiver.Gameworld.LanguageScrambler.Scramble(new ExplodedString(_rawText.ProperSentences()), result.Obfuscation).Fullstop().DoubleGuillemets()
 						.FluentTagMXP("send", $"href='look' hint='{hint}'"),
-				LanguagePerceptionResult.Success => $"«{_rawText.ProperSentences()}»"
+				LanguagePerceptionResult.Success => _rawText.ProperSentences().DoubleGuillemets()
 					.FluentTagMXP("send", $"href='look' hint='{hint}'"),
 				_ => throw new ApplicationException("Unknown LanguagePerceptionResult in EmoteSignedLanguageInfo.ParseFor")
 			};

--- a/FutureMUDLibrary/Events/EventInfoAttribute.cs
+++ b/FutureMUDLibrary/Events/EventInfoAttribute.cs
@@ -18,5 +18,22 @@ namespace MudSharp.Events
             Parameters = parameterTypes.Zip(parameterNames, (type, name) => (type, name)).ToList();
             ProgTypes = progTypes.Select(x => ProgVariableTypes.FromLegacyLong((long)x)).ToList();
         }
+
+		public EventInfoAttribute(string description, string[] parameterTypes, string[] parameterNames)
+		{
+			Description = description;
+			Parameters = parameterTypes.Zip(parameterNames, (type, name) => (type, name)).ToList();
+			ProgTypes = parameterTypes.Select(ParseProgType).ToList();
+		}
+
+		private static ProgVariableTypes ParseProgType(string type)
+		{
+			if (ProgVariableTypes.TryParse(type, out var progType))
+			{
+				return progType;
+			}
+
+			throw new ArgumentException($"{type} is not a recognised FutureProg variable type.", nameof(type));
+		}
     }
 }

--- a/FutureMUDLibrary/Events/EventTypeEnum.cs
+++ b/FutureMUDLibrary/Events/EventTypeEnum.cs
@@ -755,19 +755,19 @@ namespace MudSharp.Events
         [EventInfo("Fires on a character when a bounded structured noise reaches that character's exact spatial location. Reception does not imply a successful hearing check.", ["character", "location", "perceivable", "number", "number", "text", "text", "text"], ["listener", "origin", "source", "volume", "proximity", "type", "direction", "echo"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Location, ProgVariableTypeCode.Perceivable, ProgVariableTypeCode.Number, ProgVariableTypeCode.Number, ProgVariableTypeCode.Text, ProgVariableTypeCode.Text, ProgVariableTypeCode.Text])]
 		CharacterNoiseReceived = 146,
 
-		[EventInfo("Fires on a character when they sign without a direct target.", ["character", "text", "text", "text", "number"], ["signer", "language", "variety", "message", "outcome"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Text, ProgVariableTypeCode.Text, ProgVariableTypeCode.Text, ProgVariableTypeCode.Number])]
+		[EventInfo("Fires on a character when they sign without a direct target.", ["character", "signedlanguage", "signedvariety", "text", "number"], ["signer", "language", "variety", "message", "outcome"])]
 		CharacterSigns = 147,
 
-		[EventInfo("Fires on a visible perceivable witnessing untargeted signing.", ["character", "perceivable", "text", "text", "text", "number"], ["signer", "witness", "language", "variety", "message", "outcome"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Perceivable, ProgVariableTypeCode.Text, ProgVariableTypeCode.Text, ProgVariableTypeCode.Text, ProgVariableTypeCode.Number])]
+		[EventInfo("Fires on a visible perceivable witnessing untargeted signing.", ["character", "perceivable", "signedlanguage", "signedvariety", "text", "number"], ["signer", "witness", "language", "variety", "message", "outcome"])]
 		CharacterSignsWitness = 148,
 
-		[EventInfo("Fires on a character when they sign directly to a target.", ["character", "perceivable", "text", "text", "text", "number"], ["signer", "target", "language", "variety", "message", "outcome"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Perceivable, ProgVariableTypeCode.Text, ProgVariableTypeCode.Text, ProgVariableTypeCode.Text, ProgVariableTypeCode.Number])]
+		[EventInfo("Fires on a character when they sign directly to a target.", ["character", "perceivable", "signedlanguage", "signedvariety", "text", "number"], ["signer", "target", "language", "variety", "message", "outcome"])]
 		CharacterSignsDirect = 149,
 
-		[EventInfo("Fires on the target of direct signing.", ["character", "perceivable", "text", "text", "text", "number"], ["signer", "target", "language", "variety", "message", "outcome"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Perceivable, ProgVariableTypeCode.Text, ProgVariableTypeCode.Text, ProgVariableTypeCode.Text, ProgVariableTypeCode.Number])]
+		[EventInfo("Fires on the target of direct signing.", ["character", "perceivable", "signedlanguage", "signedvariety", "text", "number"], ["signer", "target", "language", "variety", "message", "outcome"])]
 		CharacterSignsDirectTarget = 150,
 
-		[EventInfo("Fires on a visible perceivable witnessing directed signing.", ["character", "perceivable", "perceivable", "text", "text", "text", "number"], ["signer", "target", "witness", "language", "variety", "message", "outcome"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Perceivable, ProgVariableTypeCode.Perceivable, ProgVariableTypeCode.Text, ProgVariableTypeCode.Text, ProgVariableTypeCode.Text, ProgVariableTypeCode.Number])]
+		[EventInfo("Fires on a visible perceivable witnessing directed signing.", ["character", "perceivable", "perceivable", "signedlanguage", "signedvariety", "text", "number"], ["signer", "target", "witness", "language", "variety", "message", "outcome"])]
 		CharacterSignsDirectWitness = 151
     }
 }

--- a/FutureMUDLibrary/Framework/StringExtensions.cs
+++ b/FutureMUDLibrary/Framework/StringExtensions.cs
@@ -133,12 +133,13 @@ namespace MudSharp.Framework
 
 
 		/// <summary>
-		/// Fluent method to surround the input with guillements («/»)
+		/// Fluent method to surround the input with guillemets («/»)
 		/// </summary>
 		/// <param name="input">The text to surround</param>
 		/// <param name="truth">If true, perform the action. If not, return the input</param>
 		/// <returns></returns>
-		public static string DoubleGuillemets(this string input, bool truth = true) { 
+		public static string DoubleGuillemets(this string input, bool truth = true)
+		{
             if (!truth)
             {
                 return input;

--- a/FutureMUDLibrary/FutureProg/ProgTypeKind.cs
+++ b/FutureMUDLibrary/FutureProg/ProgTypeKind.cs
@@ -73,5 +73,6 @@ public enum ProgTypeKind
 	Trap,
 	NPCSkillPackage,
 	SignedLanguage,
-	SignedLanguageVariety
+	SignedVariety,
+	SignedLanguageVariety = SignedVariety
 }

--- a/FutureMUDLibrary/FutureProg/ProgVariableTypeRegistry.cs
+++ b/FutureMUDLibrary/FutureProg/ProgVariableTypeRegistry.cs
@@ -107,7 +107,8 @@ public static class ProgVariableTypeRegistry
 		RegisterExact(ProgTypeKind.Trap, ProgVariableTypes.Trap, "Trap", "trap");
 		RegisterExact(ProgTypeKind.NPCSkillPackage, ProgVariableTypes.NPCSkillPackage, "NPCSkillPackage", "npcskillpackage", "skillpackage");
 		RegisterExact(ProgTypeKind.SignedLanguage, ProgVariableTypes.SignedLanguage, "SignedLanguage", "signedlanguage", "signlanguage");
-		RegisterExact(ProgTypeKind.SignedLanguageVariety, ProgVariableTypes.SignedLanguageVariety, "SignedLanguageVariety", "signedlanguagevariety", "signvariety");
+		RegisterExact(ProgTypeKind.SignedVariety, ProgVariableTypes.SignedVariety, "SignedVariety",
+			"signedvariety", "signedlanguagevariety", "signvariety");
 
         RegisterNamed(ProgVariableTypes.CollectionItem, "CollectionItem", false, "collectionitem");
         RegisterNamed(ProgVariableTypes.Perceivable, "Perceivable", false, "perceivable");

--- a/FutureMUDLibrary/FutureProg/ProgVariableTypes.cs
+++ b/FutureMUDLibrary/FutureProg/ProgVariableTypes.cs
@@ -93,7 +93,8 @@ public readonly struct ProgVariableTypes : IEquatable<ProgVariableTypes>
 	public static readonly ProgVariableTypes Trap = FromLegacyBitIndex(68);
 	public static readonly ProgVariableTypes NPCSkillPackage = FromLegacyBitIndex(69);
 	public static readonly ProgVariableTypes SignedLanguage = FromLegacyBitIndex(70);
-	public static readonly ProgVariableTypes SignedLanguageVariety = FromLegacyBitIndex(71);
+	public static readonly ProgVariableTypes SignedVariety = FromLegacyBitIndex(71);
+	public static readonly ProgVariableTypes SignedLanguageVariety = SignedVariety;
 
     public static readonly ProgVariableTypes CollectionItem =
         Number | Boolean | Gender | Text | DateTime | TimeSpan | Character | Item | Chargen | Location | Zone |
@@ -103,7 +104,7 @@ public readonly struct ProgVariableTypes : IEquatable<ProgVariableTypes>
 		Liquid | Gas | MagicSchool | MagicCapability | MagicSpell | Bank | BankAccount | BankAccountType |
 		LegalAuthority | Law | Crime | Market | MarketCategory | LiquidMixture | Script | Writing | Area |
 		LegalClass | AgricultureField | VehicleRoute | VehicleService | VehicleJourney | Trap | NPCSkillPackage |
-		SignedLanguage | SignedLanguageVariety;
+		SignedLanguage | SignedVariety;
 
     public static readonly ProgVariableTypes Perceivable = Item | Character | Location | Zone | Shard;
     public static readonly ProgVariableTypes Perceiver = Item | Character;

--- a/MudSharpCore Unit Tests/CharacterInstanceInitialisationTests.cs
+++ b/MudSharpCore Unit Tests/CharacterInstanceInitialisationTests.cs
@@ -3,6 +3,12 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using MudSharp.Body.Needs;
+using MudSharp.Body.Traits;
+using MudSharp.CharacterCreation;
+using MudSharp.Communication.Language;
+using MudSharp.Framework;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using CharacterClass = MudSharp.Character.Character;
 
@@ -31,6 +37,27 @@ public class CharacterInstanceInitialisationTests
 		var result = CharacterClass.ResolveSecondaryNeedsModel(identity);
 
 		Assert.IsInstanceOfType(result, typeof(NoNeedsModel));
+	}
+
+	[TestMethod]
+	public void ResolveSignedLanguagesForTemplate_LinkedNpcSkillGrantsSignedLanguageOnce()
+	{
+		var linkedTrait = new Mock<ITraitDefinition>();
+		var unrelatedTrait = new Mock<ITraitDefinition>();
+		var auslan = new Mock<ISignedLanguage>();
+		auslan.SetupGet(x => x.LinkedTrait).Returns(linkedTrait.Object);
+		var repository = new Mock<IUneditableAll<ISignedLanguage>>();
+		repository.Setup(x => x.GetEnumerator()).Returns(() => new List<ISignedLanguage> { auslan.Object }.GetEnumerator());
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.SignedLanguages).Returns(repository.Object);
+		var template = new Mock<ICharacterTemplate>();
+		template.SetupGet(x => x.SkillValues).Returns(
+			[(linkedTrait.Object, 40.0), (linkedTrait.Object, 50.0), (unrelatedTrait.Object, 60.0)]);
+
+		var result = CharacterClass.ResolveSignedLanguagesForTemplate(gameworld.Object, template.Object);
+
+		Assert.AreEqual(1, result.Count);
+		Assert.AreSame(auslan.Object, result.Single());
 	}
 
 	private static void SetNeedsModel(CharacterClass character, INeedsModel needsModel)

--- a/MudSharpCore Unit Tests/SignedCommunicationEventTests.cs
+++ b/MudSharpCore Unit Tests/SignedCommunicationEventTests.cs
@@ -1,0 +1,47 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Body;
+using MudSharp.Character;
+using MudSharp.Communication.Language;
+using MudSharp.Construction;
+using MudSharp.Events;
+using MudSharp.Framework;
+using MudSharp.RPG.Checks;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class SignedCommunicationEventTests
+{
+	[TestMethod]
+	public void HandleEvents_DirectSigningPassesLanguageAndVarietyObjects()
+	{
+		var actor = new Mock<ICharacter>();
+		var target = new Mock<IPerceivable>();
+		var body = new Mock<IBody>();
+		var location = new Mock<ICell>();
+		var language = new Mock<ISignedLanguage>();
+		var variety = new Mock<ISignedLanguageVariety>();
+		location.SetupGet(x => x.EventHandlers).Returns([]);
+		body.SetupGet(x => x.Actor).Returns(actor.Object);
+		body.SetupGet(x => x.Location).Returns(location.Object);
+		object[]? actorPayload = null;
+		object[]? targetPayload = null;
+		actor.Setup(x => x.HandleEvent(EventType.CharacterSignsDirect, It.IsAny<object[]>()))
+			.Callback<EventType, object[]>((_, arguments) => actorPayload = arguments);
+		target.Setup(x => x.HandleEvent(EventType.CharacterSignsDirectTarget, It.IsAny<object[]>()))
+			.Callback<EventType, object[]>((_, arguments) => targetPayload = arguments);
+
+		SignedCommunicationService.HandleEvents(body.Object, target.Object, "hello", language.Object,
+			variety.Object, Outcome.Pass);
+
+		Assert.IsNotNull(actorPayload);
+		Assert.AreSame(language.Object, actorPayload[2]);
+		Assert.AreSame(variety.Object, actorPayload[3]);
+		Assert.IsNotNull(targetPayload);
+		Assert.AreSame(language.Object, targetPayload[2]);
+		Assert.AreSame(variety.Object, targetPayload[3]);
+	}
+}

--- a/MudSharpCore Unit Tests/SignedLanguageFutureProgTests.cs
+++ b/MudSharpCore Unit Tests/SignedLanguageFutureProgTests.cs
@@ -1,0 +1,33 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Communication.Language;
+using MudSharp.FutureProg;
+using MudSharp.RPG.Checks;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class SignedLanguageFutureProgTests
+{
+	[TestMethod]
+	public void SignedVariety_ReturnsFirstClassDotProperties()
+	{
+		var language = new Mock<ISignedLanguage>();
+		var variety = new SignedLanguageVariety(new MudSharp.Models.SignedLanguageVariety
+		{
+			Id = 42,
+			Name = "Sydney",
+			Description = "A Sydney variety.",
+			Suffix = "with Sydney signs",
+			VagueSuffix = "with an unfamiliar regional style",
+			RecognitionDifficulty = (int)Difficulty.Normal
+		}, language.Object);
+
+		Assert.AreEqual(ProgVariableTypes.SignedVariety, variety.Type);
+		Assert.AreSame(language.Object, variety.GetProperty("language"));
+		Assert.AreEqual("with Sydney signs", variety.GetProperty("suffix").GetObject);
+		Assert.AreEqual((decimal)(int)Difficulty.Normal, variety.GetProperty("difficulty").GetObject);
+	}
+}

--- a/MudSharpCore/Character/Character.cs
+++ b/MudSharpCore/Character/Character.cs
@@ -271,12 +271,18 @@ public partial class Character : PerceiverItem, ICharacter, ICharacterIdentity, 
         //Body.BaseLiverAlcoholRemovalKilogramsPerHour = LiverFunction(this);
         InitialiseStamina();
         foreach (ILanguage language in template.SkillValues.SelectMany(skill =>
-                     Gameworld.Languages.Where(x => x.LinkedTrait == skill.Item1)))
+                     Gameworld.Languages.Where(x => x.LinkedTrait == skill.Item1)).Distinct())
         {
             _languages.Add(language);
         }
 
         _currentLanguage = _languages.FirstOrDefault();
+		foreach (var language in ResolveSignedLanguagesForTemplate(Gameworld, template))
+		{
+			_signedLanguages.Add(language);
+		}
+
+		_currentSignedLanguage = _signedLanguages.FirstOrDefault();
         foreach (IAccent accent in template.SelectedAccents)
         {
             _accents[accent] = Difficulty.Trivial;
@@ -313,6 +319,15 @@ public partial class Character : PerceiverItem, ICharacter, ICharacterIdentity, 
         CurrentStamina = MaximumStamina;
         Gameworld.SaveManager.AddInitialisation(this);
     }
+
+	internal static IReadOnlyCollection<ISignedLanguage> ResolveSignedLanguagesForTemplate(IFuturemud gameworld,
+		ICharacterTemplate template)
+	{
+		return template.SkillValues
+			.SelectMany(skill => gameworld.SignedLanguages.Where(x => x.LinkedTrait == skill.Item1))
+			.Distinct()
+			.ToList();
+	}
 
     public override InitialisationPhase InitialisationPhase => InitialisationPhase.First;
 

--- a/MudSharpCore/Character/CharacterFutureprogs.cs
+++ b/MudSharpCore/Character/CharacterFutureprogs.cs
@@ -147,8 +147,9 @@ public partial class Character
 			case "signedlanguage":
 				returnVar = CurrentSignedLanguage;
 				break;
+			case "signedvariety":
 			case "signedlanguagevariety":
-				returnVar = CurrentSignedLanguageVariety as IProgVariable;
+				returnVar = CurrentSignedLanguageVariety;
 				break;
             case "class":
                 returnVar =
@@ -336,7 +337,8 @@ public partial class Character
             { "languages", ProgVariableTypes.Language | ProgVariableTypes.Collection },
 			{ "signedlanguages", ProgVariableTypes.SignedLanguage | ProgVariableTypes.Collection },
 			{ "signedlanguage", ProgVariableTypes.SignedLanguage },
-			{ "signedlanguagevariety", ProgVariableTypes.SignedLanguageVariety },
+			{ "signedvariety", ProgVariableTypes.SignedVariety },
+			{ "signedlanguagevariety", ProgVariableTypes.SignedVariety },
             { "guest", ProgVariableTypes.Boolean },
             { "linewidth", ProgVariableTypes.Number },
             { "innerlinewidth", ProgVariableTypes.Number },

--- a/MudSharpCore/Commands/Modules/CommunicationsModule.cs
+++ b/MudSharpCore/Commands/Modules/CommunicationsModule.cs
@@ -175,11 +175,35 @@ The syntax is:
     }
 
 	[PlayerCommand("SignedLanguages", "signedlanguages")]
-	[HelpInfo("signedlanguages", @"The #3signedlanguages#0 command lists the signed languages your character understands. Signed languages are learned independently from spoken and written languages, so knowing one does not imply knowing another.
+	[HelpInfo("signedlanguages", @"The #3signedlanguages#0 command lists the signed languages your character understands. Signed languages are learned independently from spoken and written languages, so knowing one does not imply knowing another. Use #3signedlanguages list#0 to browse every signed language configured in the game; an optional name filter narrows the catalogue.
 
-	#3signedlanguages#0", AutoHelp.HelpArg)]
+	#3signedlanguages#0
+	#3signedlanguages list [<name filter>]#0", AutoHelp.HelpArg)]
 	protected static void SignedLanguages(ICharacter actor, string input)
 	{
+		var ss = new StringStack(input.RemoveFirstWord());
+		if (ss.PopForSwitch().EqualTo("list"))
+		{
+			var filter = ss.SafeRemainingArgument;
+			var languages = actor.Gameworld.SignedLanguages
+				.Where(x => filter.Length == 0 || x.Name.Contains(filter, StringComparison.InvariantCultureIgnoreCase))
+				.OrderBy(x => x.Name)
+				.ToList();
+			actor.OutputHandler.Send(StringUtilities.GetTextTable(
+				languages.Select(language => new[]
+				{
+					language.Name.TitleCase(),
+					actor.SignedLanguages.Contains(language).ToColouredString(),
+					actor.CurrentSignedLanguage == language ? "Current".ColourValue() : string.Empty,
+					language.Varieties.Select(x => x.Name.TitleCase()).ListToString()
+				}),
+				new[] { "Signed Language", "Known?", "In Use", "Varieties" },
+				actor.Account.LineFormatLength,
+				colour: Telnet.Green,
+				unicodeTable: actor.Account.UseUnicode));
+			return;
+		}
+
 		var sb = new StringBuilder();
 		sb.AppendLine("You know the following signed languages:");
 		sb.AppendLine();

--- a/MudSharpCore/Commands/Modules/HeritageBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/HeritageBuilderModule.cs
@@ -250,6 +250,7 @@ internal class HeritageBuilderModule : BaseBuilderModule
 	private const string SignedLanguageCommandHelp = @"The #3signedlanguage#0 builder command manages signed languages independently from spoken and written languages. A signed language needs a linked skill and at least one articulation profile before characters can produce it.
 
 	#3signedlanguage show <which>#0
+	#3signedlanguage list [<name filter>]#0
 	#3signedlanguage edit new <name> <trait>#0
 	#3signedlanguage edit <which>#0
 	#3signedlanguage close#0
@@ -265,6 +266,9 @@ internal class HeritageBuilderModule : BaseBuilderModule
 		var ss = new StringStack(command.RemoveFirstWord());
 		switch (ss.PopSpeech().ToLowerInvariant())
 		{
+			case "list":
+				ShowModule.Show_SignedLanguages(actor, ss);
+				return;
 			case "edit":
 				if (ss.PeekSpeech().EqualTo("new"))
 				{

--- a/MudSharpCore/Commands/Modules/ShowModule.cs
+++ b/MudSharpCore/Commands/Modules/ShowModule.cs
@@ -148,6 +148,7 @@ public class ShowModule : Module<ICharacter>
 	#3itemquality#0 - shows all item qualities 
 	#3knowledges#0 - shows knowledges
 	#3languages#0 - shows all languages
+	#3signedlanguages [<name filter>]#0 - shows all signed languages
 	#3materials#0 - shows all materials
 	#3merits#0 - shows all merits
 	#3outcomes#0 - shows a list of the possible outcomes
@@ -406,6 +407,9 @@ Using #3show#0 on its own displays the topic list appropriate to your current pe
             case "languages":
                 Show_Languages(actor, ss);
                 break;
+			case "signedlanguages":
+				Show_SignedLanguages(actor, ss);
+				break;
             case "accents":
                 Show_Accents(actor, ss);
                 break;
@@ -3431,6 +3435,36 @@ Using #3show#0 on its own displays the topic list appropriate to your current pe
             )
         );
     }
+
+	internal static void Show_SignedLanguages(ICharacter actor, StringStack input)
+	{
+		if (!actor.IsAdministrator())
+		{
+			actor.Send("You are not authorised to use show in this way.");
+			return;
+		}
+
+		var filter = input.SafeRemainingArgument;
+		var languages = actor.Gameworld.SignedLanguages
+			.Where(x => filter.Length == 0 || x.Name.Contains(filter, StringComparison.InvariantCultureIgnoreCase))
+			.OrderBy(x => x.Name)
+			.ToList();
+		actor.OutputHandler.Send(StringUtilities.GetTextTable(
+			languages.Select(language => new[]
+			{
+				language.Id.ToString("N0", actor),
+				language.Name,
+				language.LinkedTrait.Name,
+				language.Model.Name,
+				language.Varieties.Count().ToString("N0", actor),
+				language.ArticulationProfiles.Count().ToString("N0", actor),
+				language.LanguageObfuscationFactor.ToString("N3", actor)
+			}),
+			new[] { "ID#", "Name", "Linked Trait", "Model", "Varieties", "Profiles", "Obfuscation" },
+			actor.Account.LineFormatLength,
+			colour: Telnet.Green,
+			unicodeTable: actor.Account.UseUnicode));
+	}
 
     private static void Show_Accents(ICharacter actor, StringStack input)
     {

--- a/MudSharpCore/Communication/Language/SignedCommunicationService.cs
+++ b/MudSharpCore/Communication/Language/SignedCommunicationService.cs
@@ -46,8 +46,6 @@ public static class SignedCommunicationService
 	public static void HandleEvents(IBody body, IPerceivable? target, string message, ISignedLanguage language,
 		ISignedLanguageVariety? variety, Outcome outcome)
 	{
-		var languageName = language.Name;
-		var varietyName = variety?.Name ?? string.Empty;
 		var witnesses = body.Location.EventHandlers
 			.OfType<IPerceiver>()
 			.Where(x => !x.IsSelf(body.Actor) && !x.IsSelf(target) && x.CanSee(body.Actor))
@@ -56,24 +54,24 @@ public static class SignedCommunicationService
 			.ToList();
 		if (target is null)
 		{
-			body.Actor.HandleEvent(EventType.CharacterSigns, body.Actor, languageName, varietyName, message,
+			body.Actor.HandleEvent(EventType.CharacterSigns, body.Actor, language, variety, message,
 				(int)outcome);
 			foreach (var witness in witnesses)
 			{
-				witness.HandleEvent(EventType.CharacterSignsWitness, body.Actor, witness, languageName, varietyName,
+				witness.HandleEvent(EventType.CharacterSignsWitness, body.Actor, witness, language, variety,
 					message, (int)outcome);
 			}
 			return;
 		}
 
-		body.Actor.HandleEvent(EventType.CharacterSignsDirect, body.Actor, target, languageName, varietyName, message,
+		body.Actor.HandleEvent(EventType.CharacterSignsDirect, body.Actor, target, language, variety, message,
 			(int)outcome);
-		target.HandleEvent(EventType.CharacterSignsDirectTarget, body.Actor, target, languageName, varietyName, message,
+		target.HandleEvent(EventType.CharacterSignsDirectTarget, body.Actor, target, language, variety, message,
 			(int)outcome);
 		foreach (var witness in witnesses)
 		{
-			witness.HandleEvent(EventType.CharacterSignsDirectWitness, body.Actor, target, witness, languageName,
-				varietyName, message, (int)outcome);
+			witness.HandleEvent(EventType.CharacterSignsDirectWitness, body.Actor, target, witness, language,
+				variety, message, (int)outcome);
 		}
 	}
 }

--- a/MudSharpCore/Communication/Language/SignedLanguage.cs
+++ b/MudSharpCore/Communication/Language/SignedLanguage.cs
@@ -378,7 +378,7 @@ public class SignedLanguage : SaveableItem, ISignedLanguage
 			"name" => new TextVariable(Name),
 			"trait" => LinkedTrait,
 			"unknown" => new TextVariable(UnknownLanguageDescription),
-			"varieties" => new CollectionVariable(_varieties.ToList(), ProgVariableTypes.SignedLanguageVariety),
+			"varieties" => new CollectionVariable(_varieties.ToList(), ProgVariableTypes.SignedVariety),
 			_ => throw new NotSupportedException()
 		};
 	}
@@ -395,7 +395,7 @@ public class SignedLanguage : SaveableItem, ISignedLanguage
 				["name"] = ProgVariableTypes.Text,
 				["trait"] = ProgVariableTypes.Trait,
 				["unknown"] = ProgVariableTypes.Text,
-				["varieties"] = ProgVariableTypes.SignedLanguageVariety | ProgVariableTypes.Collection
+				["varieties"] = ProgVariableTypes.SignedVariety | ProgVariableTypes.Collection
 			},
 			new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase)
 			{
@@ -434,7 +434,7 @@ public class SignedLanguage : SaveableItem, ISignedLanguage
 	}
 }
 
-public class SignedLanguageVariety : FrameworkItem, ISignedLanguageVariety, IProgVariable
+public class SignedLanguageVariety : FrameworkItem, ISignedLanguageVariety
 {
 	public SignedLanguageVariety(MudSharp.Models.SignedLanguageVariety variety, ISignedLanguage language)
 	{
@@ -453,7 +453,7 @@ public class SignedLanguageVariety : FrameworkItem, ISignedLanguageVariety, IPro
 	public string Suffix { get; }
 	public string VagueSuffix { get; }
 	public Difficulty RecognitionDifficulty { get; }
-	public ProgVariableTypes Type => ProgVariableTypes.SignedLanguageVariety;
+	public ProgVariableTypes Type => ProgVariableTypes.SignedVariety;
 	public object GetObject => this;
 	public IProgVariable GetProperty(string property) => property.ToLowerInvariant() switch
 	{
@@ -461,8 +461,38 @@ public class SignedLanguageVariety : FrameworkItem, ISignedLanguageVariety, IPro
 		"name" => new TextVariable(Name),
 		"language" => Language,
 		"description" => new TextVariable(Description),
+		"suffix" => new TextVariable(Suffix),
+		"vague" or "vaguesuffix" => new TextVariable(VagueSuffix),
+		"difficulty" => new NumberVariable((int)RecognitionDifficulty),
 		_ => throw new NotSupportedException()
 	};
+
+	public static void RegisterFutureProgCompiler()
+	{
+		ProgVariable.RegisterDotReferenceCompileInfo(ProgVariableTypes.SignedVariety,
+			new Dictionary<string, ProgVariableTypes>(StringComparer.InvariantCultureIgnoreCase)
+			{
+				["id"] = ProgVariableTypes.Number,
+				["name"] = ProgVariableTypes.Text,
+				["language"] = ProgVariableTypes.SignedLanguage,
+				["description"] = ProgVariableTypes.Text,
+				["suffix"] = ProgVariableTypes.Text,
+				["vague"] = ProgVariableTypes.Text,
+				["vaguesuffix"] = ProgVariableTypes.Text,
+				["difficulty"] = ProgVariableTypes.Number
+			},
+			new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase)
+			{
+				["id"] = "The ID of the signed-language variety",
+				["name"] = "The name of the signed-language variety",
+				["language"] = "The signed language to which this variety belongs",
+				["description"] = "The builder description of the variety",
+				["suffix"] = "The suffix shown when the variety is recognised",
+				["vague"] = "The suffix shown when the variety is not recognised",
+				["vaguesuffix"] = "The suffix shown when the variety is not recognised",
+				["difficulty"] = "The numeric difficulty for recognising the variety"
+			});
+	}
 }
 
 public class SignedLanguageArticulationProfile : FrameworkItem, ISignedLanguageArticulationProfile

--- a/MudSharpCore/NPC/Templates/SimpleNPCTemplate.cs
+++ b/MudSharpCore/NPC/Templates/SimpleNPCTemplate.cs
@@ -365,6 +365,10 @@ public class SimpleNPCTemplate : NPCTemplateBase
                                             x =>
                                                 $"{x.Name.Proper().ColourName()} ({SelectedAccents.Where(y => y.Language == x).Select(y => y.Name.Proper().ColourValue()).ListToString()})")
                                         .ListToString());
+			sb.AppendLine("Signed Languages: " +
+			              (SelectedSignedLanguages.Any()
+				              ? SelectedSignedLanguages.Select(x => x.Name.Proper().ColourName()).ListToString()
+				              : "None".Colour(Telnet.Red)));
 
             sb.AppendLine();
             sb.AppendLine("Characteristics:");
@@ -1903,6 +1907,10 @@ public class SimpleNPCTemplate : NPCTemplateBase
 
     public IEnumerable<ILanguage> SelectedLanguages => SelectedSkills
         .SelectNotNull(x => Gameworld.Languages.FirstOrDefault(y => y.LinkedTrait == x));
+
+	public IEnumerable<ISignedLanguage> SelectedSignedLanguages => SelectedSkills
+		.SelectMany(x => Gameworld.SignedLanguages.Where(y => y.LinkedTrait == x))
+		.Distinct();
 
     public double SelectedWeight { get; set; }
 

--- a/MudSharpCore/NPC/Templates/VariableNPCTemplate.cs
+++ b/MudSharpCore/NPC/Templates/VariableNPCTemplate.cs
@@ -675,6 +675,22 @@ public class VariableNPCTemplate : NPCTemplateBase
             sb.AppendLine($"\t{language.Name.TitleCase().ColourName()} ({skill.Chance.ToStringP2Colour(actor)}) - {accents.Select(x => x.Name.TitleCase()).ListToColouredString()}");
         }
         sb.AppendLine();
+		sb.AppendLine("Signed Languages:");
+		sb.AppendLine();
+		var signedLanguages = _skillTemplates
+			.SelectMany(skill => Gameworld.SignedLanguages
+				.Where(x => x.LinkedTrait == skill.Trait)
+				.Select(language => (Language: language, skill.Chance)))
+			.ToList();
+		foreach (var (language, chance) in signedLanguages)
+		{
+			sb.AppendLine($"\t{language.Name.TitleCase().ColourName()} ({chance.ToStringP2Colour(actor)})");
+		}
+		if (signedLanguages.Count == 0)
+		{
+			sb.AppendLine($"\t{"None".Colour(Telnet.Red)}");
+		}
+		sb.AppendLine();
 
         sb.AppendLine();
         if (_roles.Any(x => x.RoleType != ChargenRoleType.Class && x.RoleType != ChargenRoleType.Subclass))


### PR DESCRIPTION
## Summary
- add complete signed-language catalogue discovery via player, show, and builder commands
- initialize NPC signed-language knowledge from linked generated skills and expose it in template previews
- document guillemet rendering versus backtick input boundaries
- promote SignedLanguage and SignedVariety to first-class FutureProg types and pass typed objects through signing events

## Validation
- Release MudSharpCore build passed
- FutureMUDLibrary Unit Tests: 443/443 passed
- MudSharpCore Unit Tests: 2,540/2,540 passed
- git diff --check passed

The Debug output directory was locked by an existing live MudSharp process; Release validation completed without interrupting it.